### PR TITLE
feat: playground network selector with API prefill

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -14,6 +14,14 @@
             <span class="version" id="compiler-version"></span>
         </div>
         <div class="header-right">
+            <div class="network-selector">
+                <select id="network-select">
+                    <option value="bitcoin">Bitcoin</option>
+                    <option value="mutinynet">Mutinynet</option>
+                    <option value="signet">Signet</option>
+                </select>
+                <span class="network-status" id="network-status" title="Fetching..."></span>
+            </div>
             <button id="compile-btn" class="btn-primary">
                 <i class="fas fa-play"></i> Compile
             </button>

--- a/playground/style.css
+++ b/playground/style.css
@@ -82,6 +82,54 @@ select:hover {
     border-color: var(--accent);
 }
 
+/* Network Selector */
+.network-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.network-selector select {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    cursor: pointer;
+}
+
+.network-selector select:hover {
+    border-color: var(--accent);
+}
+
+.network-status {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    flex-shrink: 0;
+    transition: background 0.3s;
+}
+
+.network-status.loading {
+    background: var(--warning);
+    animation: status-pulse 1s ease infinite;
+}
+
+.network-status.connected {
+    background: var(--success);
+}
+
+.network-status.error {
+    background: var(--error);
+}
+
+@keyframes status-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
 .btn-primary {
     background: var(--accent);
     color: white;


### PR DESCRIPTION
## Summary
- Adds a network selector dropdown (Bitcoin / Mutinynet / Signet) in the playground header bar with a live status indicator (green = connected, red = unreachable, yellow = loading)
- Fetches `signerPubkey` and `unilateralExitDelay` from `{url}/v1/info` and uses them to prefill the `options` block when creating new `.ark` files
- Existing open files are never auto-modified; selection persists in localStorage across sessions
- Falls back to hardcoded defaults (`exit = 144`, `renew = 1008`) when the API is unreachable

## Test plan
- [ ] Build WASM and serve playground locally, verify dropdown appears in header
- [ ] Switch to Mutinynet, create a new file, confirm options block has Mutinynet `signerPubkey` and `unilateralExitDelay`
- [ ] Switch networks while a file is open, confirm existing file content is unchanged
- [ ] Verify status dot turns red when selecting Signet (currently returns 404)
- [ ] Reload page, confirm selected network persists from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network selection dropdown in the header with options for Bitcoin, Mutinynet, and Signet.
  * Added network status indicator showing connection state.
  * Network selection is automatically saved and restored on reload.
  * Contract templates now dynamically incorporate selected network information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->