### PR TITLE
docs: use Arkade terminology, remove stray "Ark" protocol references

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,4 +445,4 @@ Contract instantiation expressions in ASM use the format:
 <VTXO:ContractName(<arg1>,<arg2>)>
 ```
 
-The Ark runtime resolves this placeholder to the Taproot scriptPubKey of the named contract instantiated with the given arguments. Options (`server`, `exit`, `renew`) are inherited from the enclosing contract.
+The Arkade runtime resolves this placeholder to the Taproot scriptPubKey of the named contract instantiated with the given arguments. Options (`server`, `exit`, `renew`) are inherited from the enclosing contract.

--- a/arkade-bindgen/src/ir.rs
+++ b/arkade-bindgen/src/ir.rs
@@ -81,7 +81,7 @@ pub struct Field {
     pub ark_type: String,
     /// Wire encoding descriptor.
     pub encoding: Encoding,
-    /// True if this field is injected by the Ark server (e.g., "serverSig").
+    /// True if this field is injected by the Arkade server (e.g., "serverSig").
     pub is_server_injected: bool,
 }
 

--- a/arkade-bindgen/src/targets/go.rs
+++ b/arkade-bindgen/src/targets/go.rs
@@ -138,7 +138,10 @@ fn generate_go(ir: &ContractIR, options: &CodegenOptions) -> String {
     }
 
     // Contract struct
-    out.push_str(&format!("// {} wraps an Ark contract instance.\n", ir.name));
+    out.push_str(&format!(
+        "// {} wraps an Arkade contract instance.\n",
+        ir.name
+    ));
     out.push_str(&format!(
         "type {} struct {{\n\t*ark.Contract\n}}\n\n",
         ir.name
@@ -242,7 +245,7 @@ fn emit_witness_struct(
     }
 
     if variant_label == "Cooperative" {
-        out.push_str("\t// ServerSig injected by Ark server\n");
+        out.push_str("\t// ServerSig injected by Arkade server\n");
     } else if variant.is_nofn_fallback {
         out.push_str("\t// N-of-N multisig exit fallback\n");
     } else {

--- a/arkade-bindgen/src/targets/typescript.rs
+++ b/arkade-bindgen/src/targets/typescript.rs
@@ -207,7 +207,7 @@ fn emit_witness_interface(
 
     // Comments for server-injected or timelock fields
     if variant_label == "Cooperative" {
-        out.push_str("  // serverSig injected by Ark server\n");
+        out.push_str("  // serverSig injected by Arkade server\n");
     } else if variant.is_nofn_fallback {
         out.push_str("  // N-of-N multisig exit fallback\n");
     } else {

--- a/arkade-bindgen/tests/go_test.rs
+++ b/arkade-bindgen/tests/go_test.rs
@@ -40,7 +40,7 @@ fn test_htlc_go_generates() {
     assert!(code.contains("type HTLCClaimCooperativeWitness struct {"));
     assert!(code.contains("ReceiverSig [64]byte"));
     assert!(code.contains("Preimage []byte"));
-    assert!(code.contains("// ServerSig injected by Ark server"));
+    assert!(code.contains("// ServerSig injected by Arkade server"));
 
     assert!(code.contains("type HTLCClaimExitWitness struct {"));
     assert!(code.contains("// Exit timelock enforced by script"));

--- a/arkade-bindgen/tests/typescript_test.rs
+++ b/arkade-bindgen/tests/typescript_test.rs
@@ -42,7 +42,7 @@ fn test_htlc_typescript_generates() {
     assert!(code.contains("export interface HTLCClaimCooperativeWitness {"));
     assert!(code.contains("receiverSig: Signature;"));
     assert!(code.contains("preimage: Bytes;"));
-    assert!(code.contains("// serverSig injected by Ark server"));
+    assert!(code.contains("// serverSig injected by Arkade server"));
 
     assert!(code.contains("export interface HTLCClaimExitWitness {"));
     assert!(code.contains("// exit timelock enforced by script"));

--- a/docs/ArkadeKitties.md
+++ b/docs/ArkadeKitties.md
@@ -1,12 +1,12 @@
-# ArkadeKitties: A Trustless Collectible Game on Ark
+# ArkadeKitties: A Trustless Collectible Game on Arkade
 
-This document outlines the design for ArkadeKitties, a decentralized game for collecting and breeding unique digital cats, built entirely on the Ark protocol using Arkade Assets and Arkade Script.
+This document outlines the design for ArkadeKitties, a decentralized game for collecting and breeding unique digital cats, built entirely on Arkade using Arkade Assets and Arkade Script.
 
 ## 1. Core Concept
 
 ArkadeKitties are unique, collectible digital assets. Each Kitty is a non-fungible Arkade Asset with an amount of 1 and has a distinct set of traits determined by its genetic code (genome), which is stored immutably on-chain as asset metadata. Players can buy, sell, and breed their Kitties to create new, rare offspring.
 
-The entire system is trustless. Ownership is enforced by the Ark protocol, and all game logic, including breeding, is executed by on-chain Arkade Script contracts, eliminating the need for a central server.
+The entire system is trustless. Ownership is enforced by Arkade, and all game logic, including breeding, is executed by on-chain Arkade Script contracts, eliminating the need for a central server.
 
 ## 2. Kitty Asset Representation
 

--- a/docs/arkade-primitives-spec.md
+++ b/docs/arkade-primitives-spec.md
@@ -369,7 +369,7 @@ OP_VERIFY                               ; [srcId, burnTx, recip, sig0, sig1, sig
 ; The runtime computes the full child Taproot scriptPubKey for SingleSig(<recipientPk>)
 ; by inheriting the enclosing contract's options: the server key (serverPk) and the
 ; exit timelock (288 blocks). The inlined script is NOT a generic SingleSig output —
-; it is the specific Ark VTXO taproot that includes those inherited parameters.
+; it is the specific Arkade VTXO taproot that includes those inherited parameters.
 ; We compare output 1's scriptPubKey against that resolved script.
 OP_1
 OP_INSPECTOUTPUTSCRIPTPUBKEY            ; [.., ctrlIn, outScript(bytes)]

--- a/examples/htlc.ark
+++ b/examples/htlc.ark
@@ -4,7 +4,7 @@ options {
   server = server;
   
   // Renewal timelock: 7 days (1008 blocks)
-  // The contract must be renewed with the Ark server within this period
+  // The contract must be renewed with the Arkade server within this period
   renew = 1008;
   
   // Exit timelock: 24 hours (144 blocks)

--- a/examples/single_sig.ark
+++ b/examples/single_sig.ark
@@ -4,7 +4,7 @@ options {
   server = server;
   
   // Renewal timelock: 7 days (1008 blocks)
-  // The contract must be renewed with the Ark server within this period
+  // The contract must be renewed with the Arkade server within this period
   renew = 1008;
   
   // Exit timelock: 24 hours (144 blocks)

--- a/examples/threshold_multisig_htlc.ark
+++ b/examples/threshold_multisig_htlc.ark
@@ -4,7 +4,7 @@ options {
   server = server;
   
   // Renewal timelock: 7 days (1008 blocks)
-  // The contract must be renewed with the Ark server within this period
+  // The contract must be renewed with the Arkade server within this period
   renew = 1008;
   
   // Exit timelock: 24 hours (144 blocks)

--- a/playground/codegen.js
+++ b/playground/codegen.js
@@ -163,7 +163,7 @@ function generateTypeScript(ir) {
             for (const f of variant.userFields) {
                 out += `  /** ${f.arkType} (${f.encoding}) */\n  ${toCamelCase(f.name)}: ${tsTypeForField(f)};\n`;
             }
-            if (label === 'Cooperative') out += `  // serverSig injected by Ark server\n`;
+            if (label === 'Cooperative') out += `  // serverSig injected by Arkade server\n`;
             else if (variant.isNofnFallback) out += `  // N-of-N multisig exit fallback\n`;
             else out += `  // exit timelock enforced by script\n`;
             out += `}\n\n`;
@@ -255,7 +255,7 @@ function generateGo(ir) {
             for (const f of variant.userFields) {
                 out += `\t${toPascalCase(f.name)} ${goTypeForField(f)} // ${f.arkType} (${f.encoding})\n`;
             }
-            if (label === 'Cooperative') out += `\t// ServerSig injected by Ark server\n`;
+            if (label === 'Cooperative') out += `\t// ServerSig injected by Arkade server\n`;
             else if (variant.isNofnFallback) out += `\t// N-of-N multisig exit fallback\n`;
             else out += `\t// Exit timelock enforced by script\n`;
             out += `}\n\n`;
@@ -263,7 +263,7 @@ function generateGo(ir) {
     }
 
     // Contract struct
-    out += `// ${ir.name} wraps an Ark contract instance.\n`;
+    out += `// ${ir.name} wraps an Arkade contract instance.\n`;
     out += `type ${ir.name} struct {\n\t*ark.Contract\n}\n\n`;
 
     // Constructor

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -415,7 +415,7 @@ pub fn validate_asm_structure(
 /// - A name in `witnessSchema` (caller-supplied witness element).
 /// - A name in `constructorInputs` (constructor-bound script parameter).
 /// - A well-known runtime placeholder: `SERVER_KEY` (operator key), or any token
-///   starting with `VTXO:` (contract instance reference resolved by the Ark node).
+///   starting with `VTXO:` (contract instance reference resolved by the Arkade node).
 ///
 /// Orphaned placeholders mean the transaction can never be constructed because
 /// there is no known binding for that name.
@@ -444,7 +444,7 @@ pub fn validate_placeholder_consistency(
             // Compound-expression placeholders like
             // <checkMultisig([a,b],[c,d])> or <sha256(preimage)>
             // are emitted verbatim when the compiler cannot fully inline an
-            // expression.  They are evaluated by the Ark node at spend time —
+            // expression.  They are evaluated by the Arkade node at spend time —
             // not looked up by name — so we skip the name-resolution check.
             if name.contains('(') || name.contains('[') || name.contains(',') {
                 continue;

--- a/tests/asm_structural_test.rs
+++ b/tests/asm_structural_test.rs
@@ -414,7 +414,7 @@ fn orphaned_placeholder_is_warned() {
 
 #[test]
 fn server_key_placeholder_is_always_resolved() {
-    // <SERVER_KEY> is injected at runtime by the Ark operator — it must not be
+    // <SERVER_KEY> is injected at runtime by the Arkade operator — it must not be
     // flagged as unresolvable even though it is not in the schema.
     let asm = vec![
         "<SERVER_KEY>".to_string(),


### PR DESCRIPTION
Replace standalone "Ark" with "Arkade" in comments, docs, and example
contract source where it referred to Arkade's own server/node/runtime/
operator. Keeps the established `VTXO` output-format token and the real
`github.com/arkade-os/contract-sdk-go/ark` Go package import untouched.

https://claude.ai/code/session_01Qh7PueuU2EciLbgmHzHvBx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated product terminology references throughout README, API specifications, example contracts, developer guides, and auto-generated documentation comments.
- Ensured consistent naming conventions across user-facing documentation and technical specifications.

## Tests
- Updated test fixtures and assertions for code generation tests (Go and TypeScript backends) to align with terminology changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/compiler/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->