### PR TITLE
fix(bonds): deployment guards + dust-mint defence

### DIFF
--- a/docs/bonds.md
+++ b/docs/bonds.md
@@ -261,8 +261,9 @@ collateral and the health-call trigger (`liqThresholdBps`, e.g. 11000 =
 the more capital-efficient the loan but the more frequent the margin calls
 on volatile collateral.
 
-**Enforced deployment invariants.** `issue` requires both
-`initRatioBps > liqThresholdBps` and `liqThresholdBps > 0`:
+**Enforced deployment invariants.** `issue` (and the alternate issuance
+entry `rollIn`) require FOUR checks on the pool's constructor params before
+any vault can be created:
 
 - `initRatioBps > liqThresholdBps` — without it a deployer could set
   `liqThresholdBps >= initRatioBps`, in which case a vault minted at the
@@ -274,9 +275,33 @@ on volatile collateral.
   `collateralValue < healthFloor` can never hold and the margin call could
   never fire, silently disabling the health invariant that backs credit
   fungibility.
+- `auctionWindow > 0` — a zero-length auction window collapses the
+  `tx.time >= maturity AND tx.time < maturity` gate to the empty set, so no
+  defaulted vault can ever be settled via `acceptAuction`. `mintedAmount`
+  stays in `totalDebitOutstanding` forever and credit holders absorb 100% of
+  every default. Same class of deployment invariant as the ratio checks.
+- `auctionDiscountBps ∈ [0, 10000)` — an out-of-range discount bricks every
+  `liquidate` and `acceptAuction` at the runtime check, leaving the pool
+  unsettleable. The settlement functions also revalidate the bound at
+  runtime (defence-in-depth), but pool issuance MUST fail closed up-front
+  rather than silently producing an unsettleable book.
 
-Both checks live in `issue` (one-time per issuance, not a hot path), so a
-misconfigured pool can never originate a vault at all.
+All four checks live in both `issue` AND `rollIn` (one-time per issuance,
+not a hot path). A misconfigured pool can never originate a vault at all,
+through either issuance entry. Regression tests:
+`test_issue_enforces_deployment_invariants` and
+`test_roll_pair_enforces_all_deployment_invariants`.
+
+**Ceiling division on the origination floor.** `issue` and `rollIn` use
+`required = (amount * initRatioBps + 9999) / 10000` (ceiling), not
+`amount * initRatioBps / 10000` (floor). Floor rounding lets dust-sized
+issuances bypass collateralisation entirely (`amount=1, initRatioBps=14999`
+floors to `required=1`, so 1 sat of collateral mints 1 credit + 1 debit).
+Ceiling rounds UP so `1 * 14999 / 10000` → 2, breaking the dust-mint shape.
+Regression test: `test_issue_uses_ceiling_division_on_required_collateral`.
+A configurable `minAmount` / `minCollateral` floor is follow-up R1 (the
+ceiling alone is not enough to make every very-small vault economically
+liquidatable, but it does close the unit-boundary hole).
 
 ---
 
@@ -442,8 +467,8 @@ exact lines where each one would land.
 
 | # | Item | Why | Sketch |
 |---|---|---|---|
-| **R1** | Add `minCollateral` + `minAmount` constructor params; reject dust-sized issuances. | `issue` today accepts `collateral=1, amount=1`. The `required = amount * initRatioBps / 10000` collateralisation check rounds DOWN, so for `amount=1, initRatioBps=9999` the required floor is silently zero. An attacker can mint 1 credit + 1 debit for 1 sat, polluting the auction window with unprofitable defaults. | Add two int constructor params; `require(amount >= minAmount && collateral >= minCollateral)` at top of `issue`. |
-| **R2** | Ceiling division on the origination collateral check. | Mitigates the rounding floor at the unit boundary even without R1's explicit minimums. | Replace `required = amount * initRatioBps / 10000` with `required = (amount * initRatioBps + 9999) / 10000`. |
+| **R1** | Add `minCollateral` + `minAmount` constructor params; reject dust-sized issuances. | Even with R2 ceiling division landed, very small but non-dust amounts can still produce vaults that are uneconomic to liquidate (auctioneer gas > spread). A configurable floor is the principled fix. | Add two int constructor params; `require(amount >= minAmount && collateral >= minCollateral)` at top of `issue`. |
+| **R2** | ~~Ceiling division on the origination collateral check~~ — **WIRED**. | `required = (amount * initRatioBps + 9999) / 10000` lands in both `issue` and `rollIn` (assert via `test_issue_uses_ceiling_division_on_required_collateral`). Closes the `amount=1, initRatioBps=14999` floor-rounding hole where 1 sat of collateral minted 1 credit + 1 debit. | — |
 | **R3** | Final-redemption residue path. | `redeem`'s `require(payout > 0)` rejects dust redemptions; the last few USDT are stranded forever once they round below the per-unit rate. | Add a `redeemAll(holderPk, holderSig)` branch gated on `amount == totalCreditOutstanding` that pays the full residual `usdtBalance` regardless of payout rounding. |
 | **R4** | ASM-level assertion of the strict time gate on `redeem`. | `test_redeem_is_pro_rata_post_window` currently relies on the constructor-param surface, not the gate's actual ASM placement. A refactor removing the gate would not be caught by the test. | Pattern-match the comparison sequence in `redeem`'s ASM that proves `tx.time >= maturity + auctionWindow` is enforced. |
 

--- a/examples/bonds/repayment_pool.ark
+++ b/examples/bonds/repayment_pool.ark
@@ -129,13 +129,27 @@ contract RepaymentPool(
   function issue(int amount, int collateral, pubkey borrowerPk, signature borrowerSig, int oraclePrice, int oracleTime, signature oracleSig) {
     require(amount > 0, "zero issuance");
     require(collateral > 0, "zero collateral");
-    // Deployment-safety invariant: the health-call threshold MUST sit below
-    // the origination ratio, otherwise a vault minted at the minimum
-    // collateral is immediately liquidatable in the same block — a
-    // guaranteed loss for the borrower. Checked here (one-time per issuance)
-    // so a misconfigured pool can never originate a vault.
+    // Deployment-safety invariants: collected here at issuance time so a
+    // misconfigured pool can never originate a vault.
+    //  - initRatioBps > liqThresholdBps: a vault minted at the minimum
+    //    collateral must NOT be immediately liquidatable in the same block.
+    //  - liqThresholdBps > 0: a non-positive health threshold would invert
+    //    the liquidate gate (every vault liquidatable, or none).
+    //  - auctionWindow > 0: a zero-length auction window collapses the
+    //    `tx.time >= maturity && tx.time < maturity` gate to an empty set,
+    //    so no defaulted vault can ever be settled via acceptAuction —
+    //    mintedAmount stays in totalDebitOutstanding forever and credit
+    //    holders absorb the full default. Same class of deployment invariant
+    //    as the ratio checks above.
+    //  - auctionDiscountBps ∈ [0, 10000): an out-of-range discount bricks
+    //    every liquidate + acceptAuction (settlement-side runtime check
+    //    fails closed). Validate at deployment so pool issuance fails
+    //    rather than silently producing an unsettleable book.
     require(initRatioBps > liqThresholdBps, "liq threshold must be below init ratio");
     require(liqThresholdBps > 0, "liq threshold must be positive");
+    require(auctionWindow > 0, "auction window must be positive");
+    require(auctionDiscountBps >= 0, "negative discount");
+    require(auctionDiscountBps < 10000, "discount >= 100%");
     require(tx.time < maturity, "pool matured");
     require(checkSig(borrowerSig, borrowerPk), "invalid borrower sig");
     require(oraclePrice > 0, "invalid oracle price");
@@ -150,7 +164,15 @@ contract RepaymentPool(
     // a $1M BTC price; OP_MUL64 fails closed. Chunk issuance or rescale the
     // price denominator (e.g. 1e4 vs 1e8) for very large vaults.
     int collateralValue = collateral * oraclePrice / 100000000;
-    int required = amount * initRatioBps / 10000;
+    // Ceiling division on the required collateral floor: floor division
+    // lets dust-sized issuances bypass collateralisation entirely
+    // (`amount=1, initRatioBps=14999` floors to `required=1`, so 1 sat of
+    // collateral mints 1 credit + 1 debit). An attacker could flood the
+    // auction window with thousands of dust defaults that are unprofitable
+    // for auctioneers to settle (gas > profit), leaving them as permanent
+    // deadweight in totalDebitOutstanding. Ceiling rounds UP, so
+    // `1 * 14999 / 10000` → 2, breaking the dust-mint shape.
+    int required = (amount * initRatioBps + 9999) / 10000;
     require(collateralValue >= required, "undercollateralized at issuance");
 
     let creditGroup = tx.assetGroups.find(creditAssetId);
@@ -326,8 +348,13 @@ contract RepaymentPool(
                   int outIdxPool, int outIdxVault, int outIdxCredit) {
     require(newMintedAmount > 0, "zero issuance");
     require(newCollateral > 0, "zero collateral");
+    // Same deployment-safety invariants as issue() — rollIn is an alternate
+    // issuance entry that must reject misconfigured pools identically.
     require(initRatioBps > liqThresholdBps, "liq threshold must be below init ratio");
     require(liqThresholdBps > 0, "liq threshold must be positive");
+    require(auctionWindow > 0, "auction window must be positive");
+    require(auctionDiscountBps >= 0, "negative discount");
+    require(auctionDiscountBps < 10000, "discount >= 100%");
     require(tx.time < maturity, "new pool matured");
     require(checkSig(borrowerSig, borrowerPk), "invalid borrower sig");
     require(oraclePrice > 0, "invalid oracle price");
@@ -339,7 +366,9 @@ contract RepaymentPool(
     require(checkSigFromStack(oracleSig, oraclePk, oracleMsg), "invalid oracle signature");
 
     int collateralValue = newCollateral * oraclePrice / 100000000;
-    int required = newMintedAmount * initRatioBps / 10000;
+    // Ceiling division — see explanation in issue(). Same dust-issuance
+    // defence on the alternate issuance entry.
+    int required = (newMintedAmount * initRatioBps + 9999) / 10000;
     require(collateralValue >= required, "undercollateralized at issuance");
 
     let creditGroup = tx.assetGroups.find(creditAssetId);

--- a/tests/repayment_pool_test.rs
+++ b/tests/repayment_pool_test.rs
@@ -237,28 +237,75 @@ fn test_issue_is_oracle_priced_and_dual_mints() {
 }
 
 #[test]
-fn test_issue_enforces_liq_threshold_invariants() {
-    // Deployment-safety invariants: issue must reject a pool where the
-    // margin-call threshold is not strictly below the origination ratio, or is
-    // non-positive — otherwise a freshly-minted vault at minimum collateral
-    // would be immediately liquidatable (guaranteed borrower loss), or the
-    // health gate would be inverted by a negative threshold.
+fn test_issue_enforces_deployment_invariants() {
+    // Deployment-safety invariants: issue must reject a misconfigured pool at
+    // origination, before any vault is created. Specifically:
+    //   - initRatioBps > liqThresholdBps: a vault minted at the minimum
+    //     collateral must not be immediately liquidatable.
+    //   - liqThresholdBps > 0: a non-positive threshold inverts the health
+    //     gate (every vault liquidatable, or none).
+    //   - auctionWindow > 0: a zero-length auction window means no defaulted
+    //     vault can ever be settled (`tx.time >= maturity && tx.time <
+    //     maturity` is empty), so totalDebitOutstanding accumulates forever.
+    //   - auctionDiscountBps ∈ [0, 10000): an out-of-range discount bricks
+    //     every liquidate + acceptAuction at the runtime check, leaving the
+    //     pool unsettleable.
     //
     // issue carries exactly five strict `>` comparisons that lower to
-    // OP_GREATERTHAN: amount > 0, collateral > 0, oraclePrice > 0, the invariant
-    // initRatioBps > liqThresholdBps, and liqThresholdBps > 0. The bare `> 0`
-    // guards account for 3; the two threshold invariants add 2. Asserting the
-    // exact count (5) means removing EITHER threshold invariant fails the test —
-    // a `>= 4` lower bound would let one be silently deleted.
+    // OP_GREATERTHAN sites: amount > 0, collateral > 0, oraclePrice > 0,
+    // initRatioBps > liqThresholdBps, liqThresholdBps > 0, auctionWindow > 0.
+    // Total: 3 `> 0` value guards + 3 deployment invariants = 6. Asserting
+    // the EXACT count means removing any single invariant fails the test —
+    // a `>= 5` lower bound would let one be silently deleted.
     // (OP_GREATERTHANOREQUAL / *_64 are distinct opcodes, not counted here.)
     let output = compile(CODE).expect("compilation failed");
     let gt = opcode_count(&output, "issue", "OP_GREATERTHAN");
     assert_eq!(
-        gt, 5,
-        "issue must carry BOTH initRatioBps > liqThresholdBps AND \
-         liqThresholdBps > 0 (expected exactly 5 OP_GREATERTHAN incl. the 3 \
+        gt, 6,
+        "issue must carry initRatioBps > liqThresholdBps + liqThresholdBps > 0 \
+         + auctionWindow > 0 (expected exactly 6 OP_GREATERTHAN incl. the 3 \
          `> 0` value guards, found {gt})"
     );
+
+    // OP_GREATERTHANOREQUAL64 for auctionDiscountBps >= 0 — exactly one
+    // site in the deployment-safety block. (asset-amount `>=` checks like
+    // `output.assets.lookup(...) >= N` use the same opcode, but those fire
+    // AFTER the deployment checks and aren't counted as deployment guards.
+    // Floor at 1 captures the deployment check without coupling to the
+    // exact count of asset-amount checks.)
+    let gte = opcode_count(&output, "issue", "OP_GREATERTHANOREQUAL64");
+    assert!(
+        gte >= 1,
+        "issue must carry auctionDiscountBps >= 0 (OP_GREATERTHANOREQUAL64, \
+         found {gte} total — at least one must be the discount-bound check)"
+    );
+}
+
+#[test]
+fn test_issue_uses_ceiling_division_on_required_collateral() {
+    // Dust-issuance defence: the required-collateral floor is computed via
+    // CEILING division — `(amount * initRatioBps + 9999) / 10000` — not the
+    // naive `amount * initRatioBps / 10000`. Without ceiling, an attacker
+    // can mint 1 credit + 1 debit for 1 sat of collateral (amount=1,
+    // initRatioBps=14999 → required floors to 1), then flood the auction
+    // window with thousands of dust defaults that are unprofitable for
+    // auctioneers to settle.
+    //
+    // The signature of the ceiling form in the emitted ASM is the literal
+    // 9999 pushed before the OP_ADD64 that precedes the OP_DIV64. Asserting
+    // on the presence of `9999` as a token in both issue + rollIn locks in
+    // the fix at the ASM level — a regression to floor division (or to
+    // a different bias like + 5000) trips this test.
+    let output = compile(CODE).expect("compilation failed");
+    for fn_name in ["issue", "rollIn"] {
+        let tokens = asm_tokens(&output, fn_name);
+        assert!(
+            tokens.iter().any(|t| t == "9999"),
+            "{fn_name} must use ceiling division on the required-collateral \
+             floor (expected literal `9999` token in ASM; absent means \
+             dust-issuance defence regressed). Tokens: {tokens:?}"
+        );
+    }
 }
 
 #[test]
@@ -628,19 +675,26 @@ fn test_roll_in_oracle_priced_dual_mints_at_witness_indices() {
 }
 
 #[test]
-fn test_roll_pair_enforces_both_threshold_invariants() {
-    // The deployment-safety invariants (initRatioBps > liqThresholdBps AND
-    // liqThresholdBps > 0) are re-checked in rollIn because rollIn is an
-    // independent issuance path. Without re-checking, a misconfigured pool
-    // that escaped issue could still mint vaults via rollIn.
+fn test_roll_pair_enforces_all_deployment_invariants() {
+    // rollIn is an alternate issuance entry and must enforce the SAME
+    // deployment-safety invariants as issue (initRatioBps > liqThresholdBps,
+    // liqThresholdBps > 0, auctionWindow > 0, auctionDiscountBps in
+    // [0, 10000)). Without these re-checks a misconfigured pool that
+    // somehow escaped issue could still mint fresh vaults via rollIn.
     let output = compile(CODE).expect("compilation failed");
     let gt = opcode_count(&output, "rollIn", "OP_GREATERTHAN");
     // 3 `> 0` value guards (newMintedAmount, newCollateral, oraclePrice) +
-    // 2 threshold invariants (initRatioBps > liqThresholdBps, liqThresholdBps > 0)
-    // = 5 OP_GREATERTHAN, same as issue.
+    // 3 deployment invariants (initRatioBps > liqThresholdBps,
+    // liqThresholdBps > 0, auctionWindow > 0) = 6 OP_GREATERTHAN, matching
+    // issue.
     assert_eq!(
-        gt, 5,
-        "rollIn must replicate issue's invariants (expected 5 OP_GREATERTHAN, found {gt})"
+        gt, 6,
+        "rollIn must replicate issue's invariants (expected 6 OP_GREATERTHAN, found {gt})"
+    );
+    let gte = opcode_count(&output, "rollIn", "OP_GREATERTHANOREQUAL64");
+    assert!(
+        gte >= 1,
+        "rollIn must carry auctionDiscountBps >= 0 (found {gte} OP_GREATERTHANOREQUAL64)"
     );
 }
 

--- a/tests/repayment_pool_test.rs
+++ b/tests/repayment_pool_test.rs
@@ -267,18 +267,65 @@ fn test_issue_enforces_deployment_invariants() {
          `> 0` value guards, found {gt})"
     );
 
-    // OP_GREATERTHANOREQUAL64 for auctionDiscountBps >= 0 — exactly one
-    // site in the deployment-safety block. (asset-amount `>=` checks like
-    // `output.assets.lookup(...) >= N` use the same opcode, but those fire
-    // AFTER the deployment checks and aren't counted as deployment guards.
-    // Floor at 1 captures the deployment check without coupling to the
-    // exact count of asset-amount checks.)
-    let gte = opcode_count(&output, "issue", "OP_GREATERTHANOREQUAL64");
+    // Targeted check for `auctionDiscountBps >= 0` — must anchor to the
+    // specific guard's tokens, not just count any `>=` opcode. arkanaai O1
+    // and CodeRabbit's review both flagged that a bare `gte >= 1` floor on
+    // OP_GREATERTHANOREQUAL64 would still pass if the discount guard were
+    // deleted, because issue() emits many asset-amount `>=` checks
+    // (`output.assets.lookup(...) >= N`) that satisfy that floor.
+    //
+    // The compiler emits the comparison block with `<auctionDiscountBps>`,
+    // `OP_GREATERTHANOREQUAL`, and `0` clustered within a 3-token window
+    // (display order is `<auctionDiscountBps> OP_GREATERTHANOREQUAL 0` in
+    // the current emitter — execution order may differ; we accept any
+    // permutation to stay robust to that).
     assert!(
-        gte >= 1,
-        "issue must carry auctionDiscountBps >= 0 (OP_GREATERTHANOREQUAL64, \
-         found {gte} total — at least one must be the discount-bound check)"
+        contains_window_3(
+            &output,
+            "issue",
+            "<auctionDiscountBps>",
+            "OP_GREATERTHANOREQUAL",
+            "0"
+        ),
+        "issue must carry the `auctionDiscountBps >= 0` deployment guard \
+         (expected window of <auctionDiscountBps>, OP_GREATERTHANOREQUAL, 0 \
+         within 3 consecutive ASM tokens of `issue`)"
     );
+    assert!(
+        contains_window_3(
+            &output,
+            "issue",
+            "<auctionDiscountBps>",
+            "OP_LESSTHAN",
+            "10000"
+        ),
+        "issue must carry the `auctionDiscountBps < 10000` deployment guard \
+         (expected window of <auctionDiscountBps>, OP_LESSTHAN, 10000 within \
+         3 consecutive ASM tokens of `issue`)"
+    );
+}
+
+/// True iff the function `name`'s server-variant ASM contains three given
+/// tokens in any order within a 3-token sliding window. Used for targeted
+/// regression checks where the compiler may emit a comparison's operands
+/// and opcode in a non-postfix display order — what matters is adjacency,
+/// not exact sequence.
+fn contains_window_3(
+    output: &arkade_compiler::models::ContractJson,
+    name: &str,
+    a: &str,
+    b: &str,
+    c: &str,
+) -> bool {
+    let tokens = asm_tokens(output, name);
+    if tokens.len() < 3 {
+        return false;
+    }
+    let target: std::collections::BTreeSet<&str> = [a, b, c].into_iter().collect();
+    tokens.windows(3).any(|w| {
+        let s: std::collections::BTreeSet<&str> = w.iter().map(|t| t.as_str()).collect();
+        s == target
+    })
 }
 
 #[test]
@@ -691,10 +738,32 @@ fn test_roll_pair_enforces_all_deployment_invariants() {
         gt, 6,
         "rollIn must replicate issue's invariants (expected 6 OP_GREATERTHAN, found {gt})"
     );
-    let gte = opcode_count(&output, "rollIn", "OP_GREATERTHANOREQUAL64");
+    // Targeted check for `auctionDiscountBps >= 0` AND `< 10000` — see
+    // the parallel test in `test_issue_enforces_deployment_invariants` for
+    // the rationale (arkanaai O1 / CodeRabbit review).
     assert!(
-        gte >= 1,
-        "rollIn must carry auctionDiscountBps >= 0 (found {gte} OP_GREATERTHANOREQUAL64)"
+        contains_window_3(
+            &output,
+            "rollIn",
+            "<auctionDiscountBps>",
+            "OP_GREATERTHANOREQUAL",
+            "0"
+        ),
+        "rollIn must carry the `auctionDiscountBps >= 0` deployment guard \
+         (expected window of <auctionDiscountBps>, OP_GREATERTHANOREQUAL, 0 \
+         within 3 consecutive ASM tokens of `rollIn`)"
+    );
+    assert!(
+        contains_window_3(
+            &output,
+            "rollIn",
+            "<auctionDiscountBps>",
+            "OP_LESSTHAN",
+            "10000"
+        ),
+        "rollIn must carry the `auctionDiscountBps < 10000` deployment guard \
+         (expected window of <auctionDiscountBps>, OP_LESSTHAN, 10000 within \
+         3 consecutive ASM tokens of `rollIn`)"
     );
 }
 


### PR DESCRIPTION
Follow-up to the merged #37. Addresses the three actionable items from arkanaai's automated review ([#pullrequestreview-4404098591](https://github.com/arkade-os/compiler/pull/37#pullrequestreview-4404098591)) — one P1 + two P2. No protocol-breaking changes; all new logic is at the deployment-safety layer.

## Changes

### P1 — `auctionWindow > 0` deployment guard (`issue` + `rollIn`)

Without it, `auctionWindow = 0` collapses the auction time gate `tx.time >= maturity AND tx.time < maturity` to the empty set, so no defaulted vault can EVER be settled via `acceptAuction`. `mintedAmount` stays in `totalDebitOutstanding` forever and credit holders absorb 100% of every default. Same class of deployment invariant as the existing `initRatioBps > liqThresholdBps` and `liqThresholdBps > 0` checks.

### P2 — `auctionDiscountBps` validation at deployment (`issue` + `rollIn`)

Previously checked only at runtime in `liquidate()` and `acceptAuction()`. An out-of-range discount bricks both settlement paths, leaving the pool unsettleable — yet a vault could still be issued. Moved `require(auctionDiscountBps >= 0 && < 10000)` into the issuance deployment-safety block; runtime checks retained as defense-in-depth.

### P2 — Dust-issuance ceiling division on origination floor (`issue` + `rollIn`)

`required = amount * initRatioBps / 10000` floors to 1 for `amount=1, initRatioBps=14999`, letting 1 sat of collateral mint 1 credit + 1 debit. An attacker could flood the auction window with thousands of dust defaults that are unprofitable for auctioneers to settle (gas > profit), leaving them as permanent deadweight in `totalDebitOutstanding`. Replaced with ceiling:

```
required = (amount * initRatioBps + 9999) / 10000
```

Ceiling rounds UP so `1 * 14999 / 10000` → 2, breaking the unit-boundary mint hole. A configurable `minAmount` / `minCollateral` floor remains follow-up R1 (the ceiling alone is necessary but not sufficient for very-small-but-non-dust amounts).

## Tests

| Test | Change |
|---|---|
| `test_issue_enforces_liq_threshold_invariants` | Renamed → `test_issue_enforces_deployment_invariants`; OP_GREATERTHAN count 5 → 6 (added `auctionWindow > 0`); new `OP_GREATERTHANOREQUAL64 >= 1` floor for the `auctionDiscountBps` deployment check |
| `test_roll_pair_enforces_both_threshold_invariants` | Renamed → `test_roll_pair_enforces_all_deployment_invariants`; same updates |
| `test_issue_uses_ceiling_division_on_required_collateral` | **NEW** — asserts the literal `9999` token appears in both `issue` and `rollIn` ASM. A regression to floor (or to a different bias) trips it |

255 → 256 tests, all green.

## Docs

- `docs/bonds.md` §Enforced deployment invariants expanded from 2 → 4 and now applies to `rollIn` as well as `issue`.
- New paragraph on the ceiling-division origination floor.
- Follow-up R2 marked **WIRED** with reference to the new regression test; R1 kept as a separate open item (configurable minimums).

## Out of scope here

- **arkanaai P2.4** — `examples/lending/loan_vault.ark` still uses `>=` burn checks. That's a different contract family with a different trust model (keeper-signed vs permissionless); deferring to a separate PR.
- **arkanaai P3 observations** — the four P3 items (#5-#8) are informational and require no action.

## Test plan

- [x] `cargo test` — 256/256 pass
- [x] `cargo fmt --check` — clean
- [x] ASM verification: `<auctionWindow>` placeholder + literal `9999` present in both `issue` and `rollIn` server variants
- [x] OP_GREATERTHAN count = 6 in both `issue` and `rollIn` (was 5)

https://claude.ai/code/session_013U1kfFDEPH91g5VnPTmKD4


---
_Generated by [Claude Code](https://claude.ai/code/session_013U1kfFDEPH91g5VnPTmKD4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bond pool documentation with expanded details on issuance requirements and collateral calculation rules.

* **Bug Fixes**
  * Improved collateral calculation accuracy to handle rounding edge cases.
  * Added parameter validation for bond pool operations.

* **Tests**
  * Enhanced coverage for bond pool safety invariant validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->