### PR TITLE
Reject identifier shadowing and ABI namespace collisions at validation time

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -480,7 +480,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
 }
 
 /// Collect all asset ID parameter names used in AssetLookup expressions
-fn collect_lookup_asset_ids(contract: &crate::models::Contract) -> Vec<String> {
+pub(crate) fn collect_lookup_asset_ids(contract: &crate::models::Contract) -> Vec<String> {
     let mut ids = Vec::new();
     for function in &contract.functions {
         for stmt in &function.statements {
@@ -551,7 +551,7 @@ fn collect_asset_ids_from_expression(expr: &Expression, ids: &mut Vec<String>) {
 
 /// Decompose constructor params: bytes32 params used in asset lookups become _txid + _gidx pairs
 /// Array types (e.g., pubkey[]) are flattened to name_0, name_1, name_2, etc.
-fn decompose_constructor_params(
+pub(crate) fn decompose_constructor_params(
     params: &[crate::models::Parameter],
     lookup_asset_ids: &[String],
 ) -> Vec<crate::models::Parameter> {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -179,6 +179,8 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
         }
     }
 
+    check_shadowing(contract, &mut issues);
+
     issues
 }
 
@@ -205,6 +207,146 @@ fn statement_has_require(stmt: &Statement) -> bool {
                     .map_or(false, |b| statements_have_require(b))
         }
         Statement::ForIn { body, .. } => statements_have_require(body),
+    }
+}
+
+/// Check 1: reject any binding that shadows a name still live in an enclosing
+/// scope, plus `for (x, x)`. Function parameters are compared against
+/// constructor parameters explicitly before seeding (a collapsed set would
+/// silently swallow the duplicate).
+fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
+    let ctor_names: HashSet<&str> =
+        contract.parameters.iter().map(|p| p.name.as_str()).collect();
+
+    for func in &contract.functions {
+        // Seed frame: constructor params + this function's params.
+        let mut seed: HashSet<String> = ctor_names.iter().map(|s| s.to_string()).collect();
+        for param in &func.parameters {
+            if ctor_names.contains(param.name.as_str()) {
+                issues.push(ValidationIssue::error(format!(
+                    "parameter '{}' in function '{}' shadows constructor parameter '{}'",
+                    param.name, func.name, param.name
+                )));
+            }
+            seed.insert(param.name.clone());
+        }
+
+        let mut stack: Vec<HashSet<String>> = vec![seed];
+        walk_scope(&func.statements, &func.name, &mut stack, issues);
+
+        check_ctor_assignment(&func.statements, &func.name, &ctor_names, issues);
+    }
+}
+
+/// Reject `name = expr;` where `name` is a constructor parameter; constructor
+/// parameters are immutable. Recurses into branch and loop bodies.
+fn check_ctor_assignment(
+    stmts: &[Statement],
+    fname: &str,
+    ctor_names: &HashSet<&str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Statement::VarAssign { name, .. } => {
+                if ctor_names.contains(name.as_str()) {
+                    issues.push(ValidationIssue::error(format!(
+                        "cannot assign to constructor parameter '{}' in function '{}'; \
+                         constructor parameters are immutable",
+                        name, fname
+                    )));
+                }
+            }
+            Statement::IfElse {
+                then_body,
+                else_body,
+                ..
+            } => {
+                check_ctor_assignment(then_body, fname, ctor_names, issues);
+                if let Some(eb) = else_body {
+                    check_ctor_assignment(eb, fname, ctor_names, issues);
+                }
+            }
+            Statement::ForIn { body, .. } => {
+                check_ctor_assignment(body, fname, ctor_names, issues);
+            }
+            Statement::LetBinding { .. } | Statement::Require(_) => {}
+        }
+    }
+}
+
+/// Returns true if `name` is bound in any frame currently on the stack.
+fn in_scope(stack: &[HashSet<String>], name: &str) -> bool {
+    stack.iter().any(|frame| frame.contains(name))
+}
+
+/// Walk statements maintaining a lexical scope stack. Each block (`for` body,
+/// `if`/`else` branch) is a pushed frame, so sibling blocks do not conflict.
+fn walk_scope(
+    stmts: &[Statement],
+    fname: &str,
+    stack: &mut Vec<HashSet<String>>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Statement::LetBinding { name, .. } => {
+                if in_scope(stack, name) {
+                    issues.push(ValidationIssue::error(format!(
+                        "binding '{}' in function '{}' shadows an in-scope binding",
+                        name, fname
+                    )));
+                } else {
+                    stack
+                        .last_mut()
+                        .expect("non-empty scope stack")
+                        .insert(name.clone());
+                }
+            }
+            Statement::ForIn {
+                index_var,
+                value_var,
+                body,
+                ..
+            } => {
+                if index_var == value_var {
+                    issues.push(ValidationIssue::error(format!(
+                        "loop variables in function '{}' must differ; both are named '{}'",
+                        fname, index_var
+                    )));
+                }
+                for v in [index_var, value_var] {
+                    if in_scope(stack, v) {
+                        issues.push(ValidationIssue::error(format!(
+                            "loop variable '{}' in function '{}' shadows an in-scope binding",
+                            v, fname
+                        )));
+                    }
+                }
+                let mut frame = HashSet::new();
+                frame.insert(index_var.clone());
+                frame.insert(value_var.clone());
+                stack.push(frame);
+                walk_scope(body, fname, stack, issues);
+                stack.pop();
+            }
+            Statement::IfElse {
+                then_body,
+                else_body,
+                ..
+            } => {
+                stack.push(HashSet::new());
+                walk_scope(then_body, fname, stack, issues);
+                stack.pop();
+                if let Some(eb) = else_body {
+                    stack.push(HashSet::new());
+                    walk_scope(eb, fname, stack, issues);
+                    stack.pop();
+                }
+            }
+            // Reassignment is handled separately; requires introduce no bindings.
+            Statement::VarAssign { .. } | Statement::Require(_) => {}
+        }
     }
 }
 

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -216,8 +216,11 @@ fn statement_has_require(stmt: &Statement) -> bool {
 /// constructor parameters explicitly before seeding (a collapsed set would
 /// silently swallow the duplicate).
 fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
-    let ctor_names: HashSet<&str> =
-        contract.parameters.iter().map(|p| p.name.as_str()).collect();
+    let ctor_names: HashSet<&str> = contract
+        .parameters
+        .iter()
+        .map(|p| p.name.as_str())
+        .collect();
 
     for func in &contract.functions {
         // Seed frame: constructor params + this function's params.
@@ -379,15 +382,15 @@ fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssu
             }
         }
 
-        // Reserved generated names (conservative superset; never variant-specific here).
+        // `serverSig` is appended unconditionally to the cooperative witness
+        // schema (no dedup), so a parameter of that name genuinely collides.
         if contract.has_server_key {
             record_name("serverSig".to_string(), &func.name, &mut seen, issues);
         }
-        for p in &contract.parameters {
-            if p.param_type == "pubkey" {
-                record_name(format!("{}Sig", p.name), &func.name, &mut seen, issues);
-            }
-        }
+        // N-of-N exit signatures (`{pubkey}Sig`) are intentionally NOT reserved:
+        // the emitter deduplicates them against existing signature parameters by
+        // name (src/compiler/mod.rs ~690), so a param like `senderSig` for a
+        // `sender` pubkey is reused rather than duplicated — no collision.
     }
 }
 

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -180,6 +180,7 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
     }
 
     check_shadowing(contract, &mut issues);
+    check_expanded_namespace(contract, &mut issues);
 
     issues
 }
@@ -347,6 +348,61 @@ fn walk_scope(
             // Reassignment is handled separately; requires introduce no bindings.
             Statement::VarAssign { .. } | Statement::Require(_) => {}
         }
+    }
+}
+
+/// Check 2: the names a function's parameters and the constructor's parameters
+/// contribute to the *emitted* placeholder namespace — after array flattening,
+/// asset decomposition, and reserved generated names — must be unique. Distinct
+/// source names can still collide here (e.g. `int[] xs` vs `int xs_0`).
+fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
+    let lookup_ids = crate::compiler::collect_lookup_asset_ids(contract);
+    // Constructor params expanded exactly as the emitter decomposes them.
+    let ctor_expanded =
+        crate::compiler::decompose_constructor_params(&contract.parameters, &lookup_ids);
+
+    for func in contract.functions.iter().filter(|f| !f.is_internal) {
+        let mut seen: HashSet<String> = HashSet::new();
+
+        for p in &ctor_expanded {
+            record_name(p.name.clone(), &func.name, &mut seen, issues);
+        }
+
+        // Function parameters: array flattening only (mirrors generate_witness_schema).
+        for p in &func.parameters {
+            if p.param_type.ends_with("[]") {
+                for i in 0..crate::models::DEFAULT_ARRAY_LENGTH {
+                    record_name(format!("{}_{}", p.name, i), &func.name, &mut seen, issues);
+                }
+            } else {
+                record_name(p.name.clone(), &func.name, &mut seen, issues);
+            }
+        }
+
+        // Reserved generated names (conservative superset; never variant-specific here).
+        if contract.has_server_key {
+            record_name("serverSig".to_string(), &func.name, &mut seen, issues);
+        }
+        for p in &contract.parameters {
+            if p.param_type == "pubkey" {
+                record_name(format!("{}Sig", p.name), &func.name, &mut seen, issues);
+            }
+        }
+    }
+}
+
+/// Insert an emitted name; on the first duplicate, record a collision error.
+fn record_name(
+    name: String,
+    fname: &str,
+    seen: &mut HashSet<String>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    if !seen.insert(name.clone()) {
+        issues.push(ValidationIssue::error(format!(
+            "parameters in function '{}' collide in the emitted namespace as '{}'",
+            fname, name
+        )));
     }
 }
 

--- a/tests/bare_vtxo_test.rs
+++ b/tests/bare_vtxo_test.rs
@@ -20,7 +20,9 @@ contract SingleSig(
   pubkey server
 ) {
   // Cooperative spend path (user + server)
-  function cooperative(signature userSig, signature serverSig) {
+  // The server cosignature (serverSig) is injected automatically by the
+  // compiler, so it must not be declared as an explicit parameter.
+  function cooperative(signature userSig) {
     require(checkMultisig([user, server]));
   }
   
@@ -57,16 +59,13 @@ contract SingleSig(
         .find(|f| f.name == "cooperative" && f.server_variant)
         .unwrap();
 
-    // Check function inputs
-    assert_eq!(cooperative_function.function_inputs.len(), 2);
+    // Check function inputs. Only userSig is an explicit parameter; the server
+    // cosignature (<serverSig>) is injected by the compiler and appears in the
+    // ASM/witness rather than as a declared function input.
+    assert_eq!(cooperative_function.function_inputs.len(), 1);
     assert_eq!(cooperative_function.function_inputs[0].name, "userSig");
     assert_eq!(
         cooperative_function.function_inputs[0].param_type,
-        "signature"
-    );
-    assert_eq!(cooperative_function.function_inputs[1].name, "serverSig");
-    assert_eq!(
-        cooperative_function.function_inputs[1].param_type,
         "signature"
     );
 

--- a/tests/no_shadowing_test.rs
+++ b/tests/no_shadowing_test.rs
@@ -28,11 +28,8 @@ contract Demo(int limit) {
   }
 }
 "#;
-    assert!(
-        compile(src).is_ok(),
-        "expected clean compile: {:?}",
-        compile(src).err()
-    );
+    let result = compile(src);
+    assert!(result.is_ok(), "expected clean compile: {:?}", result.err());
 }
 
 #[test]
@@ -70,11 +67,8 @@ contract Demo(pubkey[] ks) {
   }
 }
 "#;
-    assert!(
-        compile(src).is_ok(),
-        "expected clean compile: {:?}",
-        compile(src).err()
-    );
+    let result = compile(src);
+    assert!(result.is_ok(), "expected clean compile: {:?}", result.err());
 }
 
 #[test]
@@ -260,11 +254,8 @@ contract Demo(pubkey[] ks) {
   }
 }
 "#;
-    assert!(
-        compile(src).is_ok(),
-        "expected clean compile: {:?}",
-        compile(src).err()
-    );
+    let result = compile(src);
+    assert!(result.is_ok(), "expected clean compile: {:?}", result.err());
 }
 
 use std::fs;

--- a/tests/no_shadowing_test.rs
+++ b/tests/no_shadowing_test.rs
@@ -169,6 +169,66 @@ contract Demo(pubkey[] ks) {
 }
 
 #[test]
+fn rejects_array_element_colliding_with_scalar_param() {
+    // Constructor `int[] xs` -> xs_0, xs_1, xs_2 ; function `int xs_0` -> xs_0.
+    let src = r#"
+contract Demo(int[] xs) {
+  function f(int xs_0) {
+    require(xs_0 >= 1);
+  }
+}
+"#;
+    let err = compile(src)
+        .expect_err("expected a namespace collision error")
+        .to_string();
+    assert!(
+        err.contains("collide in the emitted namespace"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_asset_decomposition_collision() {
+    // `foo` is used in a lookup -> decomposes to foo_txid, foo_gidx; param foo_txid collides.
+    let src = r#"
+contract Demo(bytes32 foo) {
+  function f(bytes32 foo_txid) {
+    require(tx.inputs[0].assets.lookup(foo) > 0);
+  }
+}
+"#;
+    let err = compile(src)
+        .expect_err("expected a namespace collision error")
+        .to_string();
+    assert!(
+        err.contains("collide in the emitted namespace"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_param_colliding_with_server_signature() {
+    let src = r#"
+options {
+  server = server;
+  exit = 144;
+}
+contract Demo(int limit) {
+  function f(signature serverSig) {
+    require(limit >= 1);
+  }
+}
+"#;
+    let err = compile(src)
+        .expect_err("expected a namespace collision error")
+        .to_string();
+    assert!(
+        err.contains("collide in the emitted namespace"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn accepts_sibling_scope_reuse() {
     // let x in both branches; the same loop vars in two separate loops.
     let src = r#"

--- a/tests/no_shadowing_test.rs
+++ b/tests/no_shadowing_test.rs
@@ -1,0 +1,198 @@
+use arkade_compiler::compile;
+
+#[test]
+fn rejects_function_param_shadowing_constructor_param() {
+    let src = r#"
+contract Demo(int amount) {
+  function f(int amount) {
+    require(amount >= 1);
+  }
+}
+"#;
+    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    assert!(
+        err.contains("shadows constructor parameter"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn accepts_distinct_names() {
+    let src = r#"
+contract Demo(int limit) {
+  function f(signature sig, pubkey pk) {
+    require(checkSig(sig, pk));
+    require(limit >= 1);
+  }
+}
+"#;
+    assert!(
+        compile(src).is_ok(),
+        "expected clean compile: {:?}",
+        compile(src).err()
+    );
+}
+
+#[test]
+fn rejects_assignment_to_constructor_param() {
+    let src = r#"
+contract Demo(int amount) {
+  function f(signature sig, pubkey pk) {
+    amount = 5;
+    require(checkSig(sig, pk));
+  }
+}
+"#;
+    let err = compile(src)
+        .expect_err("expected an immutability error")
+        .to_string();
+    assert!(
+        err.contains("cannot assign to constructor parameter"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn allows_reassignment_of_local() {
+    // `int valid = 0;` then `valid = valid + 1;` — the documented pattern.
+    let src = r#"
+contract Demo(pubkey[] ks) {
+  function f(signature[] sigs, bytes32 msg) {
+    int valid = 0;
+    for (i, s) in sigs {
+      if (checkSigFromStack(s, ks[i], msg)) {
+        valid = valid + 1;
+      }
+    }
+    require(valid >= 1);
+  }
+}
+"#;
+    assert!(
+        compile(src).is_ok(),
+        "expected clean compile: {:?}",
+        compile(src).err()
+    );
+}
+
+#[test]
+fn rejects_local_shadowing_function_param() {
+    let src = r#"
+contract Demo(int limit) {
+  function f(int amount) {
+    int amount = 5;
+    require(amount >= 1);
+  }
+}
+"#;
+    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    assert!(
+        err.contains("shadows an in-scope binding"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_nested_local_shadowing_enclosing_local() {
+    let src = r#"
+contract Demo(int limit) {
+  function f(signature sig, pubkey pk) {
+    int x = 1;
+    if (limit >= 1) {
+      int x = 2;
+      require(x >= 1);
+    }
+    require(checkSig(sig, pk));
+  }
+}
+"#;
+    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    assert!(
+        err.contains("shadows an in-scope binding"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_inner_loop_var_shadowing_outer_loop_var() {
+    let src = r#"
+contract Demo(pubkey[] ks) {
+  function f(signature[] sigs, bytes32 msg) {
+    for (i, s) in sigs {
+      for (i, t) in sigs {
+        require(checkSigFromStack(s, ks[i], msg));
+      }
+    }
+  }
+}
+"#;
+    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    assert!(
+        err.contains("shadows an in-scope binding"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_loop_var_shadowing_constructor_param() {
+    let src = r#"
+contract Demo(int i) {
+  function f(signature[] sigs, pubkey[] ks, bytes32 msg) {
+    for (i, s) in sigs {
+      require(checkSigFromStack(s, ks[i], msg));
+    }
+  }
+}
+"#;
+    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    assert!(
+        err.contains("shadows an in-scope binding"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_identical_loop_variables() {
+    let src = r#"
+contract Demo(pubkey[] ks) {
+  function f(signature[] sigs, bytes32 msg) {
+    for (x, x) in sigs {
+      require(checkSigFromStack(x, ks[0], msg));
+    }
+  }
+}
+"#;
+    let err = compile(src)
+        .expect_err("expected a duplicate loop-variable error")
+        .to_string();
+    assert!(err.contains("must differ"), "unexpected error: {err}");
+}
+
+#[test]
+fn accepts_sibling_scope_reuse() {
+    // let x in both branches; the same loop vars in two separate loops.
+    let src = r#"
+contract Demo(pubkey[] ks) {
+  function f(signature[] sigs, bytes32 msg, int flag) {
+    if (flag >= 1) {
+      int x = 1;
+      require(x >= 1);
+    } else {
+      int x = 2;
+      require(x >= 1);
+    }
+    for (i, s) in sigs {
+      require(checkSigFromStack(s, ks[i], msg));
+    }
+    for (i, s) in sigs {
+      require(checkSigFromStack(s, ks[i], msg));
+    }
+  }
+}
+"#;
+    assert!(
+        compile(src).is_ok(),
+        "expected clean compile: {:?}",
+        compile(src).err()
+    );
+}

--- a/tests/no_shadowing_test.rs
+++ b/tests/no_shadowing_test.rs
@@ -9,7 +9,9 @@ contract Demo(int amount) {
   }
 }
 "#;
-    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    let err = compile(src)
+        .expect_err("expected a shadowing error")
+        .to_string();
     assert!(
         err.contains("shadows constructor parameter"),
         "unexpected error: {err}"
@@ -85,7 +87,9 @@ contract Demo(int limit) {
   }
 }
 "#;
-    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    let err = compile(src)
+        .expect_err("expected a shadowing error")
+        .to_string();
     assert!(
         err.contains("shadows an in-scope binding"),
         "unexpected error: {err}"
@@ -106,7 +110,9 @@ contract Demo(int limit) {
   }
 }
 "#;
-    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    let err = compile(src)
+        .expect_err("expected a shadowing error")
+        .to_string();
     assert!(
         err.contains("shadows an in-scope binding"),
         "unexpected error: {err}"
@@ -126,7 +132,9 @@ contract Demo(pubkey[] ks) {
   }
 }
 "#;
-    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    let err = compile(src)
+        .expect_err("expected a shadowing error")
+        .to_string();
     assert!(
         err.contains("shadows an in-scope binding"),
         "unexpected error: {err}"
@@ -144,7 +152,9 @@ contract Demo(int i) {
   }
 }
 "#;
-    let err = compile(src).expect_err("expected a shadowing error").to_string();
+    let err = compile(src)
+        .expect_err("expected a shadowing error")
+        .to_string();
     assert!(
         err.contains("shadows an in-scope binding"),
         "unexpected error: {err}"
@@ -255,4 +265,32 @@ contract Demo(pubkey[] ks) {
         "expected clean compile: {:?}",
         compile(src).err()
     );
+}
+
+use std::fs;
+use std::path::Path;
+
+/// Every bundled example must still compile cleanly. A new failure here means
+/// either a real latent shadowing/collision bug in the example (fix the example
+/// per the spec) or a false positive in the rule (fix the rule).
+#[test]
+fn all_examples_still_compile() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let mut checked = 0;
+    for entry in fs::read_dir(&dir).expect("read examples dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|s| s.to_str()) != Some("ark") {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("read example");
+        let result = compile(&src);
+        assert!(
+            result.is_ok(),
+            "example {} failed to compile: {:?}",
+            path.display(),
+            result.err()
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "no .ark examples found in {}", dir.display());
 }


### PR DESCRIPTION
**Summary**

Adds two hard validation errors (in `validate_ast`, before any code generation) closing a class of silent miscompiles. The compiler resolves every variable reference to a name-keyed placeholder (`<name>`) with no scope-qualified lookup, so two distinct bindings that share a name — or two parameters whose names collide *after* ABI expansion — become indistinguishable in the emitted script. Both are now rejected up front.

**What changed**

- **Check 1 — lexical no-shadowing** (`src/validator/mod.rs`): a binding may not reuse a name still live in an enclosing scope. Covers function params shadowing constructor params, locals/loop vars shadowing outer bindings, and `for (x, x)`. Disjoint sibling scopes (separate `if`/`else` branches, separate loops) may reuse names freely. Also rejects assignment to a constructor parameter (they're immutable).
- **Check 2 — expanded-namespace uniqueness** (`src/validator/mod.rs`): parameter names must be unique in the *emitted* placeholder namespace, after array flattening (`xs` → `xs_0..2`), asset decomposition (`foo` → `foo_txid`/`foo_gidx`), and the reserved `serverSig`. Catches collisions invisible at the source level, e.g. `int[] xs` vs `int xs_0`. Reuses the emitter's expansion functions to avoid drift (`collect_lookup_asset_ids`, `decompose_constructor_params` made `pub(crate)` — visibility only, no emission logic changed).
- **Fixture fix** (`tests/bare_vtxo_test.rs`): the legacy contract declared an explicit `signature serverSig` param while the compiler auto-injects the server cosignature — a real duplicate the new check surfaces. Removed the redundant param; ASM output is unchanged.
- **Tests** (`tests/no_shadowing_test.rs`): positive sibling-reuse cases, Check 1/Check 2 negatives, and a sweep asserting every `examples/*.ark` still compiles.

**Notes**

- The conservative `{pk}Sig` reservation was dropped after the example sweep: the emitter deduplicates N-of-N signatures by name (`senderSig` reused for a `sender` pubkey), so reserving it produced false positives.
- The `serverSig` reservation matches current emission. It's pinned to today's transitional architecture; once the tapscript/covenant context split lands it should migrate to tapscript context (noted in the design docs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compiler adds stricter name-scoping checks: rejects parameter/variable shadowing and assignments to constructor parameters.
  * Added validation to ensure emitted placeholder names are unique, preventing collisions.

* **Bug Fixes**
  * Cooperative server mode now injects the server signature instead of requiring it as an explicit parameter.

* **Tests**
  * New and updated tests cover shadowing rules, emitted-name collisions, asset name collisions, and example compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->