### PR TITLE
Add hashprice miner option vaults (BTC- and USD-quoted)

### DIFF
--- a/examples/hashprice/hashprice.md
+++ b/examples/hashprice/hashprice.md
@@ -41,7 +41,17 @@ price of a leg *is* its premium.
 
 ## Miner strategies
 
-Everything the desk needs reduces to holding or selling the two legs:
+Of the four option positions a miner could take, only two hedge mining
+revenue — and those are the two this design targets:
+
+- **buy put** — insure the downside when hashprice falls, and
+- **sell call** — monetise the upside the rig is already long.
+
+The other two — *buying a call* or *selling a put* — are directional bets on
+hashprice, not hedges of a mining book. They are ordinary speculation,
+already well served by existing derivatives venues (Deribit and the like), so
+this design does not try to serve them. Each hedge reduces to holding or
+selling one of the two legs:
 
 - **Long put on hashprice — insure the downside.** Buy DOWN tokens of a vault
   whose `highPrice` is the strike. If hashprice falls, DOWN pays out exactly
@@ -63,6 +73,36 @@ Everything the desk needs reduces to holding or selling the two legs:
   free: buy extra put coverage to profit from a hashrate increase, sell only
   part of the upside, or trade out of a leg mid-life by selling it — no vault
   interaction, no counterparty negotiation.
+
+## Standing the other side: a pool for puts, RFQ for calls
+
+The two hedges are not symmetric in how their counterparty is sourced, and
+that asymmetry is what shapes the market structure around each vault.
+
+- **Sell call — an easy RFQ for a desk.** When a miner sells the call it is
+  the *writer*: it mints the pair from its own BTC and posts the collateral
+  itself (the escrowed band width). The counterparty merely *buys* the UP
+  leg and pays a premium in cash. Because that counterparty gives out nothing
+  but the premium — no standing BTC, no collateral locked for the life of the
+  series — a desk can quote it on request (RFQ) and hedge elsewhere. This is
+  the side that bootstraps easily.
+
+- **Buy put — this one needs a standing pool.** When a miner buys the put it
+  is the *buyer*, so someone else has to *write* it, and a written put must
+  keep BTC posted as collateral for the whole life of the option. Miners are
+  structurally one-directional buyers of downside protection, so this is a
+  large, standing, one-way demand. It cannot be met by desk RFQ: no market
+  maker keeps a hot wallet full of BTC sitting idle, ready to lock on demand.
+  The capital has to be *deployed standing* — which is exactly what the
+  two-token vault is for. The vault **is** the pool: liquidity providers
+  deposit BTC up front, the pool mints the pairs and stands as the
+  collateralised put writer, and the DOWN legs it posts for sale (as standing
+  Arkade-intent orders) are the puts miners buy. Premium accrues to the pool
+  as legs are taken; the collateral is committed for the series and released
+  at settlement. The pool is left holding the residual UP legs — a long-call
+  position it can shed to desks through the very RFQ that makes the call side
+  easy — so providing standing put capital need not leave the pool
+  directionally exposed.
 
 ## Collateral: why BTC, and where the cap sits
 

--- a/examples/hashprice/hashprice.md
+++ b/examples/hashprice/hashprice.md
@@ -1,0 +1,121 @@
+# Hashprice Options for Miners
+
+Hashprice is a miner's revenue per unit of hashrate-time (e.g. per PH/s per
+day). It is the single number a mining operation's top line depends on, and it
+moves with BTC price, network difficulty and fees. These contracts let a miner
+hedge that number directly on Arkade, with BTC collateral, using plain
+European options — no perps, no margin accounts.
+
+Two vaults implement the same primitive in the two quote currencies:
+
+| File | Contract | Quote | Settlement |
+|---|---|---|---|
+| `hashprice_btc_vault.ark` | `HashpriceBtcVault` | sats per contract | single oracle fixing, exact split, fully collateralized |
+| `hashprice_usd_vault.ark` | `HashpriceUsdVault` | USD cents per contract | hashprice + BTC/USD fixings, payout capped by escrow |
+
+One vault exists per (oracle feed, price band, maturity) — a listed option
+series. A "contract" is a fixed quantity of hashrate-time (e.g. 100 PH·days),
+set off-chain for the series; prices are quoted per contract.
+
+## The primitive: a two-token range vault
+
+Each vault carries a price band `[lowPrice, highPrice]`. Depositing collateral
+mints equal amounts of two fungible Arkade Assets and burning a matched pair
+redeems it 1:1 — issuance can never be mispriced. At maturity the pot splits
+by the oracle fixing S:
+
+```
+UP   (call spread):  clamp(S − lowPrice,  0, width)   per pair
+DOWN (put  spread):  clamp(highPrice − S, 0, width)   per pair
+```
+
+UP + DOWN always equals the escrowed width, so the vault holds exactly the
+right BTC at every price: no margin calls, no liquidations, no keeper bots.
+With `lowPrice = 0`, UP is the full underlying exposure and DOWN a plain put
+struck at `highPrice`.
+
+The premium never touches the contract. Option legs are ordinary Arkade
+Assets, so they trade on the order book: miners and market makers place
+standing orders on UP/DOWN tokens with **Arkade intents**, and the market
+price of a leg *is* its premium.
+
+## Miner strategies
+
+Everything the desk needs reduces to holding or selling the two legs:
+
+- **Long put on hashprice — insure the downside.** Buy DOWN tokens of a vault
+  whose `highPrice` is the strike. If hashprice falls, DOWN pays out exactly
+  the shortfall in mining revenue per contract of hashrate covered. The miner
+  receives a payoff equal to the loss in mining revenues.
+
+- **Short call on hashprice — sell the upside.** Mint pairs (escrowing the
+  band width per pair), keep DOWN, sell UP via an intent. The sale proceeds
+  are the premium received. If hashprice rises, the rig earns the increase
+  while the sold UP leg pays it out — the miner pays a payoff equal to the
+  increase in mining revenues, capped at `highPrice`.
+
+- **Revenue lock — the collar.** Combine both across two vaults: buy DOWN in
+  a series struck below spot, mint-and-sell UP in a series struck above.
+  Premium received on the call offsets premium paid on the put; revenue is
+  locked inside the band.
+
+- **Any preferred ratio.** Because positions are fungible tokens, sizes are
+  free: buy extra put coverage to profit from a hashrate increase, sell only
+  part of the upside, or trade out of a leg mid-life by selling it — no vault
+  interaction, no counterparty negotiation.
+
+## Collateral: why BTC, and where the cap sits
+
+Collateral is BTC throughout — for a miner it is the native working asset,
+and it avoids the opportunity cost of parking stablecoins.
+
+- **BTC-quoted vault**: payoffs are defined in sats, so the band width *is*
+  the escrow and every payoff is exactly collateralized by construction.
+
+- **USD-quoted vault**: a USD payoff backed by BTC can never be fully
+  collateralized — the sats value of the band is unknown until maturity. Each
+  pair therefore escrows a fixed `pairCollateral` sats and the UP payout is
+  capped there. This is the on-chain form of capping the short-call writer's
+  maximum loss (choose `highPrice` ≈ 2–3× spot hashprice, and size
+  `pairCollateral` at the band width converted at a conservative BTC/USD
+  floor). The cap only binds in a joint tail — hashprice far above the band
+  *and* BTC sharply lower — which is the market maker's residual risk and is
+  priced as a small discount on the call premium.
+
+## Lifecycle
+
+1. **Deploy** the series: genesis-issue the UP/DOWN assets and the vault
+   identity singleton; both legs are mint-controlled by the identity, so
+   supply can only change inside genuine vault spends, and only in equal
+   amounts.
+2. **Issue / burn** (pre-maturity, permissionless): deposit collateral for
+   pairs, or return a matched pair for the deposit. Single-sided holders exit
+   by selling the leg, not by burning.
+3. **Trade**: legs move as plain asset transfers, priced by intents.
+4. **Settle** (once, permissionless): any party submits the oracle
+   fixing(s) — signed `sha256(feed || price || time)`, timestamps within
+   `±settleWindow` of `maturity` — and the pot splits into `upPot`/`downPot`.
+   No BTC leaves the vault.
+5. **Redeem** (post-settlement, permissionless): burn a leg for a pro-rata
+   slice of its pot. Numerator and denominator drain together, so every
+   holder gets the same rate regardless of redemption order. Payouts at or
+   below 330 sats (taproot dust) are absorbed rather than emitted.
+
+## Exit model and oracle liveness
+
+A pooled vault cannot express per-holder unilateral exit as a single CSV
+tapscript leaf, so these references carry no exit leaf; the `exit` parameter
+sizes the pre-signed recurrent exit tree maintained off-chain and refreshed
+on every issue/burn. If the oracle never attests inside the settlement
+window, the vault cannot settle — option holders bear that liveness risk, and
+venues should treat the settlement window as an SLA on the oracle.
+
+## Relation to the other examples
+
+- `options/covered_call.ark`, `options/cash_secured_put.ark` — single-buyer,
+  physically-settled options with no oracle; the buyer's exercise decision is
+  the settlement signal. Good for bilateral trades, not for a listed market.
+- `stability/stability_vault.ark` — the Fuji-style oracle attestation and
+  clamped cash-settlement math these vaults reuse.
+- `bonds/repayment_pool.ark` — the pro-rata pooled redemption shape
+  (`amount × pot / shares` with both sides draining together).

--- a/examples/hashprice/hashprice_btc_vault.ark
+++ b/examples/hashprice/hashprice_btc_vault.ark
@@ -1,0 +1,325 @@
+// HashpriceBtcVault Contract
+//
+// A two-sided, fully-collateralized range vault on BTC-denominated hashprice
+// (mining revenue per unit of hashrate-time, quoted in sats per contract).
+// One vault per (oracle feed, price band, maturity); change any one parameter
+// and it is a different vault. This follows the two-token vault design: both
+// legs are fungible Arkade Assets, so option positions are bought, sold and
+// sized like any other asset.
+//
+// ── Two tokens, one price band ──────────────────────────────────────────────
+//   The band [lowPrice, highPrice] (sats per contract) defines two
+//   complementary payoffs, settled at the maturity fixing S:
+//     UP   (call spread): clamp(S − lowPrice,  0, width)  sats per pair
+//     DOWN (put  spread): clamp(highPrice − S, 0, width)  sats per pair
+//   where width = highPrice − lowPrice = the sats escrowed per pair.
+//   UP + DOWN always equals width, so the vault is exactly collateralized in
+//   BTC at every price — no margin calls, no liquidation, and no division in
+//   settlement (payoffs are already sats).
+//
+// ── Miner hedging strategies ────────────────────────────────────────────────
+//   Long put — lock a revenue floor: buy DOWN tokens of a vault whose
+//     highPrice is the strike (lowPrice = 0 for a full put). Sized per
+//     contract of hashrate-time, DOWN pays exactly the shortfall in mining
+//     revenue below the strike.
+//   Short call — sell the upside: mint pairs (escrow width sats per pair),
+//     keep DOWN, sell UP on the order book. The sale proceeds are the
+//     premium; if hashprice rises, the rig earns the increase while the sold
+//     UP leg pays it out — net locked. The cap at highPrice (typically 2–3×
+//     spot hashprice) bounds the writer's maximum payout, which is what makes
+//     the short call fully collateralizable.
+//   Revenue lock (collar): combine both across two vaults (put strike below
+//     spot, call strike above). Amounts are free — every leg is a fungible
+//     token, so a miner can buy extra put coverage or sell only part of the
+//     upside, in any ratio.
+//
+// ── Premium via Arkade intents ──────────────────────────────────────────────
+//   The premium never touches this contract: UP and DOWN are plain Arkade
+//   Assets, so miners and market makers place standing orders on them with
+//   Arkade intents. Issuance and burning are pure 1:1 collateral operations
+//   and cannot be mispriced.
+//
+// ── Settlement & redemption ─────────────────────────────────────────────────
+//   settle: anyone submits an oracle attestation of the hashprice index whose
+//     timestamp falls within ±settleWindow of maturity (binds the fixing to
+//     the maturity moment); the pot splits into upPot/downPot per the payoffs
+//     above. No BTC leaves the vault.
+//   redeem: after settlement, burn UP (or DOWN) for a pro-rata slice of its
+//     pot. Numerator and denominator drain together, so the per-share rate is
+//     invariant under redemption order.
+//
+// ── Units & overflow ────────────────────────────────────────────────────────
+//   Prices are sats per CONTRACT — one contract covers a fixed quantity of
+//   hashrate-time (e.g. 100 PH·days), fixed off-chain per vault series. All
+//   arithmetic is int64 with overflow guards; pairs × width stays inside
+//   int64 for any realistic series (1e6 pairs × 1e7 sats/pair = 1e13).
+//
+// ── Exit model ──────────────────────────────────────────────────────────────
+//   A pooled vault cannot express per-holder unilateral exit as a single CSV
+//   leaf, so this reference carries no exit tapscript; `exit` parameterizes
+//   the pre-signed recurrent exit tree maintained off-chain (refreshed on
+//   every issue/burn). If the oracle never attests inside the window the
+//   vault cannot settle — option holders bear that liveness risk.
+
+contract HashpriceBtcVault(
+  pubkey  oraclePk,          // oracle-signed hashprice index feed
+  bytes32 ticker,            // feed id, e.g. sha256("HASHPRICE/BTC")
+  int     lowPrice,          // sats per contract — call strike / put floor
+  int     highPrice,         // sats per contract — put strike / call cap
+  int     maturity,          // maturity, unix seconds (oracle-timestamp domain)
+  int     settleWindow,      // seconds; fixing accepted within ±settleWindow of maturity
+  bytes32 upIdTxid,          // UP (call-spread) asset id — issuance txid
+  int     upIdGidx,          // UP asset id — issuance group index
+  bytes32 downIdTxid,        // DOWN (put-spread) asset id — issuance txid
+  int     downIdGidx,        // DOWN asset id — issuance group index
+  bytes32 contractIdTxid,    // vault identity singleton — genesis txid (mint control)
+  int     contractIdGidx,    // vault identity singleton — genesis group index
+  int     settled,           // 0 = open (pre-maturity), 1 = settled
+  int     upShares,          // pre: UP supply (== downShares == pairs). post: remaining UP supply
+  int     downShares,        // pre: DOWN supply (== upShares). post: remaining DOWN supply
+  int     upPot,             // pre: 0. post: sats remaining for the UP side
+  int     downPot,           // pre: 0. post: sats remaining for the DOWN side
+  int     exit               // exit timelock in blocks (off-chain recurrent exit tree)
+) {
+
+  // -------------------------------------------------------------------------
+  // ISSUE — permissionless, before maturity. Deposit `amount × width` sats;
+  // mint `amount` UP + `amount` DOWN to the depositor. Both supplies rise
+  // together, so the pool stays exactly collateralized.
+  //   input[0]:  this vault's Bitcoin output (holds the identity singleton)
+  //   input[1+]: depositor's sats (>= amount × width + fee)
+  //   output[0]: vault re-created (upShares+amount, downShares+amount)
+  //   output[1]: amount UP + amount DOWN → depositor
+  // -------------------------------------------------------------------------
+  function issue(int amount) {
+    require(settled == 0, "already settled");
+    require(amount > 0, "zero amount");
+    require(lowPrice >= 0, "negative low strike");
+    require(highPrice > lowPrice, "inverted price band");
+    int untilMaturity = maturity - tx.offchainTime;
+    require(untilMaturity > 0, "matured");
+
+    int width      = highPrice - lowPrice;
+    int newUp      = upShares + amount;
+    int newDown    = downShares + amount;
+    int newBacking = newUp * width;
+
+    // Identity-gated paired mint: UP and DOWN supply each rise by exactly
+    // `amount`, both controlled by the vault identity; identity unchanged.
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.delta == amount, "up supply != amount");
+    require(upGroup.controlIs(contractIdTxid, contractIdGidx), "wrong up control");
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.delta == amount, "down supply != amount");
+    require(downGroup.controlIs(contractIdTxid, contractIdGidx), "wrong down control");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    // Both freshly minted legs go to the depositor.
+    require(tx.outputs[1].assets.lookup(upIdTxid, upIdGidx) == amount, "up not delivered");
+    require(tx.outputs[1].assets.lookup(downIdTxid, downIdGidx) == amount, "down not delivered");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+        oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        settled, newUp, newDown, upPot, downPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= newBacking, "collateral not deposited");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+  }
+
+  // -------------------------------------------------------------------------
+  // BURN PAIR — permissionless, before maturity. Return `amount` UP + DOWN
+  // (a matched pair) and take `amount × width` sats back. The share burn
+  // authenticates (the holder must spend both legs as inputs). A single-sided
+  // holder cannot burn; their only pre-maturity exit is selling the leg via
+  // an Arkade intent.
+  //   output[0]: vault re-created (upShares-amount, downShares-amount)
+  //   output[1]: amount × width sats → burner
+  // -------------------------------------------------------------------------
+  function burnPair(int amount) {
+    require(settled == 0, "already settled");
+    require(amount > 0, "zero amount");
+    int untilMaturity = maturity - tx.offchainTime;
+    require(untilMaturity > 0, "matured");
+
+    int width      = highPrice - lowPrice;
+    int newUp      = upShares - amount;
+    int newDown    = downShares - amount;
+    int newBacking = newUp * width;
+    int refund     = amount * width;
+
+    // Burn exactly `amount` of BOTH legs; identity unchanged.
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.sumInputs == upGroup.sumOutputs + amount, "up not burned exactly");
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.sumInputs == downGroup.sumOutputs + amount, "down not burned exactly");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+        oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        settled, newUp, newDown, upPot, downPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= newBacking, "collateral not preserved");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+    require(tx.outputs[1].value >= refund, "burner underpaid");
+  }
+
+  // -------------------------------------------------------------------------
+  // SETTLE — permissionless, once, at maturity. Split the pot between the two
+  // sides using an oracle hashprice fixing attested within ±settleWindow of
+  // maturity. No BTC leaves the vault; this only records the split and flips
+  // `settled`. Payoffs are already sats, so no division is needed and the
+  // split is exact: downPot = totalPot − upPot.
+  //   output[0]: vault re-created (settled=1, upPot/downPot set)
+  // -------------------------------------------------------------------------
+  function settle(int spotPrice, int spotTime, signature oracleSig) {
+    require(settled == 0, "already settled");
+    require(upShares == downShares, "supply invariant broken");
+    require(spotPrice >= 0, "negative hashprice");
+
+    // The fixing must be attested inside the settlement window (binds the
+    // price to the maturity moment, not just "any fresh price after expiry").
+    int windowStart = maturity - settleWindow;
+    int windowEnd   = maturity + settleWindow;
+    require(spotTime >= windowStart, "before settlement window");
+    require(spotTime <= windowEnd, "after settlement window");
+    let oracleMsg = sha256(ticker + spotPrice + spotTime);
+    require(checkSigFromStack(oracleSig, oraclePk, oracleMsg), "invalid oracle signature");
+
+    int width    = highPrice - lowPrice;
+    int totalPot = upShares * width;
+
+    if (spotPrice <= lowPrice) {
+      // At or below the band: calls worthless, puts fully in the money.
+      require(
+        tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+          oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+          upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+          1, upShares, downShares, 0, totalPot, exit
+        ),
+        "invalid settle output"
+      );
+      require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+      require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+    } else {
+      if (spotPrice >= highPrice) {
+        // At or above the band: calls capped at width, puts worthless.
+        require(
+          tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+            oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+            upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+            1, upShares, downShares, totalPot, 0, exit
+          ),
+          "invalid settle output"
+        );
+        require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+        require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+      } else {
+        // Inside the band: UP gets the intrinsic value, DOWN gets the rest.
+        int upPerPair  = spotPrice - lowPrice;
+        int newUpPot   = upShares * upPerPair;
+        int newDownPot = totalPot - newUpPot;
+        require(
+          tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+            oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+            upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+            1, upShares, downShares, newUpPot, newDownPot, exit
+          ),
+          "invalid settle output"
+        );
+        require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+        require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // REDEEM UP — after settlement. Burn `amount` UP for a pro-rata slice of
+  // the UP pot; numerator and denominator drain together so the rate is
+  // order-invariant. DOWN supply must not move.
+  //   output[0]: vault re-created (upShares-amount, upPot-payout)
+  //   output[1]: payout sats → redeemer (when above dust)
+  // -------------------------------------------------------------------------
+  function redeemUp(int amount) {
+    require(settled == 1, "not settled");
+    require(amount > 0, "zero amount");
+    require(amount <= upShares, "exceeds up supply");
+    require(upShares > 0, "no up supply");
+
+    int payout    = amount * upPot / upShares;
+    int newUpPot  = upPot - payout;
+    int newUp     = upShares - amount;
+    int remaining = newUpPot + downPot;
+
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.sumInputs == upGroup.sumOutputs + amount, "up not burned exactly");
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.delta == 0, "down must not move");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+        oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        1, newUp, downShares, newUpPot, downPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= remaining, "pot not preserved");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+    if (payout > 330) {
+      require(tx.outputs[1].value >= payout, "redeemer underpaid");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // REDEEM DOWN — after settlement. Mirror of redeemUp on the DOWN pot.
+  //   output[0]: vault re-created (downShares-amount, downPot-payout)
+  //   output[1]: payout sats → redeemer (when above dust)
+  // -------------------------------------------------------------------------
+  function redeemDown(int amount) {
+    require(settled == 1, "not settled");
+    require(amount > 0, "zero amount");
+    require(amount <= downShares, "exceeds down supply");
+    require(downShares > 0, "no down supply");
+
+    int payout     = amount * downPot / downShares;
+    int newDownPot = downPot - payout;
+    int newDown    = downShares - amount;
+    int remaining  = upPot + newDownPot;
+
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.sumInputs == downGroup.sumOutputs + amount, "down not burned exactly");
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.delta == 0, "up must not move");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceBtcVault(
+        oraclePk, ticker, lowPrice, highPrice, maturity, settleWindow,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        1, upShares, newDown, upPot, newDownPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= remaining, "pot not preserved");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+    if (payout > 330) {
+      require(tx.outputs[1].value >= payout, "redeemer underpaid");
+    }
+  }
+}

--- a/examples/hashprice/hashprice_usd_vault.ark
+++ b/examples/hashprice/hashprice_usd_vault.ark
@@ -1,0 +1,341 @@
+// HashpriceUsdVault Contract
+//
+// A two-sided range vault on USD-denominated hashprice (mining revenue per
+// unit of hashrate-time, quoted in whole USD cents per contract), margined
+// and settled in BTC. One vault per (oracle feed, price band, maturity).
+// The companion `hashprice_btc_vault.ark` documents the shared two-token
+// design (UP/DOWN legs as Arkade Assets, premium via Arkade intents, pooled
+// exit model); this file documents only what the USD quote changes.
+//
+// ── What the USD quote changes ──────────────────────────────────────────────
+//   Payoffs are defined in USD but paid in sats, so settlement needs TWO
+//   oracle attestations inside the window: the hashprice fixing (ticker) and
+//   the BTC/USD fixing (btcUsdTicker), both signed by oraclePk over
+//   sha256(feed || price || time). The USD intrinsic converts at the attested
+//   BTC/USD price:
+//     upPerPairSats = clamp(S − lowPrice, 0, widthUsd) × 1e8 / btcUsdPrice
+//
+//   Unlike the BTC-quoted vault, a USD payoff backed by BTC can NEVER be
+//   fully collateralized: the sats value of the USD band is unknown until
+//   maturity. Each pair therefore escrows a fixed `pairCollateral` sats and
+//   the UP payout is capped there:
+//     upPot = min(upShares × upPerPairSats, upShares × pairCollateral)
+//   Writers size pairCollateral so the cap only binds in a joint tail
+//   (hashprice deep above the band AND BTC sharply lower) — e.g. the band
+//   width converted at a conservative BTC/USD floor. The residual tail risk
+//   is the market maker's problem and is priced as a small premium discount,
+//   symmetric for the DOWN side when BTC rallies (the USD put pays fewer
+//   sats). This cap is exactly the "max loss ≈ 2–3× hashprice" bound a
+//   miner-facing venue quotes for under-collateralizable short calls.
+//
+// ── Units & overflow ────────────────────────────────────────────────────────
+//   lowPrice/highPrice and the oracle hashprice are WHOLE USD CENTS per
+//   contract; btcUsdPrice is WHOLE USD CENTS per BTC. The conversion
+//   intrinsicUsd × 1e8 stays inside int64 for any realistic band
+//   (2e6 cents × 1e8 = 2e14), and upShares × pairCollateral for any
+//   realistic series (1e6 pairs × 1e7 sats = 1e13).
+
+contract HashpriceUsdVault(
+  pubkey  oraclePk,          // signs both feeds below
+  bytes32 ticker,            // hashprice feed id, e.g. sha256("HASHPRICE/USD")
+  bytes32 btcUsdTicker,      // conversion feed id, e.g. sha256("BTC/USD")
+  int     lowPrice,          // USD cents per contract — call strike / put floor
+  int     highPrice,         // USD cents per contract — put strike / call cap
+  int     maturity,          // maturity, unix seconds (oracle-timestamp domain)
+  int     settleWindow,      // seconds; fixings accepted within ±settleWindow of maturity
+  int     pairCollateral,    // sats escrowed per pair; caps the UP payout (see header)
+  bytes32 upIdTxid,          // UP (call-spread) asset id — issuance txid
+  int     upIdGidx,          // UP asset id — issuance group index
+  bytes32 downIdTxid,        // DOWN (put-spread) asset id — issuance txid
+  int     downIdGidx,        // DOWN asset id — issuance group index
+  bytes32 contractIdTxid,    // vault identity singleton — genesis txid (mint control)
+  int     contractIdGidx,    // vault identity singleton — genesis group index
+  int     settled,           // 0 = open (pre-maturity), 1 = settled
+  int     upShares,          // pre: UP supply (== downShares == pairs). post: remaining UP supply
+  int     downShares,        // pre: DOWN supply (== upShares). post: remaining DOWN supply
+  int     upPot,             // pre: 0. post: sats remaining for the UP side
+  int     downPot,           // pre: 0. post: sats remaining for the DOWN side
+  int     exit               // exit timelock in blocks (off-chain recurrent exit tree)
+) {
+
+  // -------------------------------------------------------------------------
+  // ISSUE — permissionless, before maturity. Deposit `amount × pairCollateral`
+  // sats; mint `amount` UP + `amount` DOWN to the depositor.
+  //   input[0]:  this vault's Bitcoin output (holds the identity singleton)
+  //   input[1+]: depositor's sats (>= amount × pairCollateral + fee)
+  //   output[0]: vault re-created (upShares+amount, downShares+amount)
+  //   output[1]: amount UP + amount DOWN → depositor
+  // -------------------------------------------------------------------------
+  function issue(int amount) {
+    require(settled == 0, "already settled");
+    require(amount > 0, "zero amount");
+    require(lowPrice >= 0, "negative low strike");
+    require(highPrice > lowPrice, "inverted price band");
+    require(pairCollateral > 330, "collateral below dust");
+    int untilMaturity = maturity - tx.offchainTime;
+    require(untilMaturity > 0, "matured");
+
+    int newUp      = upShares + amount;
+    int newDown    = downShares + amount;
+    int newBacking = newUp * pairCollateral;
+
+    // Identity-gated paired mint: UP and DOWN supply each rise by exactly
+    // `amount`, both controlled by the vault identity; identity unchanged.
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.delta == amount, "up supply != amount");
+    require(upGroup.controlIs(contractIdTxid, contractIdGidx), "wrong up control");
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.delta == amount, "down supply != amount");
+    require(downGroup.controlIs(contractIdTxid, contractIdGidx), "wrong down control");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    // Both freshly minted legs go to the depositor.
+    require(tx.outputs[1].assets.lookup(upIdTxid, upIdGidx) == amount, "up not delivered");
+    require(tx.outputs[1].assets.lookup(downIdTxid, downIdGidx) == amount, "down not delivered");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+        oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        settled, newUp, newDown, upPot, downPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= newBacking, "collateral not deposited");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+  }
+
+  // -------------------------------------------------------------------------
+  // BURN PAIR — permissionless, before maturity. Return `amount` UP + DOWN
+  // (a matched pair) and take `amount × pairCollateral` sats back. The share
+  // burn authenticates.
+  //   output[0]: vault re-created (upShares-amount, downShares-amount)
+  //   output[1]: amount × pairCollateral sats → burner
+  // -------------------------------------------------------------------------
+  function burnPair(int amount) {
+    require(settled == 0, "already settled");
+    require(amount > 0, "zero amount");
+    int untilMaturity = maturity - tx.offchainTime;
+    require(untilMaturity > 0, "matured");
+
+    int newUp      = upShares - amount;
+    int newDown    = downShares - amount;
+    int newBacking = newUp * pairCollateral;
+    int refund     = amount * pairCollateral;
+
+    // Burn exactly `amount` of BOTH legs; identity unchanged.
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.sumInputs == upGroup.sumOutputs + amount, "up not burned exactly");
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.sumInputs == downGroup.sumOutputs + amount, "down not burned exactly");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+        oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        settled, newUp, newDown, upPot, downPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= newBacking, "collateral not preserved");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+    require(tx.outputs[1].value >= refund, "burner underpaid");
+  }
+
+  // -------------------------------------------------------------------------
+  // SETTLE — permissionless, once, at maturity. Requires BOTH fixings
+  // (hashprice and BTC/USD) attested inside the window; converts the USD
+  // intrinsic to sats at the attested BTC/USD price and splits the pot,
+  // capping the UP side at the escrowed collateral. No BTC leaves the vault.
+  //   output[0]: vault re-created (settled=1, upPot/downPot set)
+  // -------------------------------------------------------------------------
+  function settle(
+    int       spotPrice,
+    int       spotTime,
+    signature spotSig,
+    int       btcUsdPrice,
+    int       btcUsdTime,
+    signature btcUsdSig
+  ) {
+    require(settled == 0, "already settled");
+    require(upShares == downShares, "supply invariant broken");
+    require(spotPrice >= 0, "negative hashprice");
+    require(btcUsdPrice > 0, "invalid btcusd price");
+
+    // Both fixings must be attested inside the settlement window (binds both
+    // prices to the maturity moment).
+    int windowStart = maturity - settleWindow;
+    int windowEnd   = maturity + settleWindow;
+    require(spotTime >= windowStart, "hashprice before window");
+    require(spotTime <= windowEnd, "hashprice after window");
+    require(btcUsdTime >= windowStart, "btcusd before window");
+    require(btcUsdTime <= windowEnd, "btcusd after window");
+
+    let spotMsg = sha256(ticker + spotPrice + spotTime);
+    require(checkSigFromStack(spotSig, oraclePk, spotMsg), "invalid hashprice signature");
+    let btcUsdMsg = sha256(btcUsdTicker + btcUsdPrice + btcUsdTime);
+    require(checkSigFromStack(btcUsdSig, oraclePk, btcUsdMsg), "invalid btcusd signature");
+
+    int totalPot = upShares * pairCollateral;
+
+    if (spotPrice <= lowPrice) {
+      // At or below the band: calls worthless, puts fully in the money.
+      require(
+        tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+          oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+          upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+          1, upShares, downShares, 0, totalPot, exit
+        ),
+        "invalid settle output"
+      );
+      require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+      require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+    } else {
+      if (spotPrice >= highPrice) {
+        // At or above the band: USD intrinsic capped at the band width, then
+        // converted to sats and capped at the escrowed collateral.
+        int widthUsd       = highPrice - lowPrice;
+        int capPerPairSats = widthUsd * 100000000 / btcUsdPrice;
+        if (capPerPairSats >= pairCollateral) {
+          // BTC fell far enough that the escrow binds: UP takes the whole pot.
+          require(
+            tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+              oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+              upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+              1, upShares, downShares, totalPot, 0, exit
+            ),
+            "invalid settle output"
+          );
+          require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+          require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+        } else {
+          int upPotCapped   = upShares * capPerPairSats;
+          int downPotCapped = totalPot - upPotCapped;
+          require(
+            tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+              oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+              upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+              1, upShares, downShares, upPotCapped, downPotCapped, exit
+            ),
+            "invalid settle output"
+          );
+          require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+          require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+        }
+      } else {
+        // Inside the band: convert the USD intrinsic to sats, cap at escrow.
+        int intrinsicUsd  = spotPrice - lowPrice;
+        int upPerPairSats = intrinsicUsd * 100000000 / btcUsdPrice;
+        if (upPerPairSats >= pairCollateral) {
+          require(
+            tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+              oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+              upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+              1, upShares, downShares, totalPot, 0, exit
+            ),
+            "invalid settle output"
+          );
+          require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+          require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+        } else {
+          int newUpPot   = upShares * upPerPairSats;
+          int newDownPot = totalPot - newUpPot;
+          require(
+            tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+              oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+              upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+              1, upShares, downShares, newUpPot, newDownPot, exit
+            ),
+            "invalid settle output"
+          );
+          require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+          require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+        }
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // REDEEM UP — after settlement. Burn `amount` UP for a pro-rata slice of
+  // the UP pot; numerator and denominator drain together so the rate is
+  // order-invariant. DOWN supply must not move.
+  //   output[0]: vault re-created (upShares-amount, upPot-payout)
+  //   output[1]: payout sats → redeemer (when above dust)
+  // -------------------------------------------------------------------------
+  function redeemUp(int amount) {
+    require(settled == 1, "not settled");
+    require(amount > 0, "zero amount");
+    require(amount <= upShares, "exceeds up supply");
+    require(upShares > 0, "no up supply");
+
+    int payout    = amount * upPot / upShares;
+    int newUpPot  = upPot - payout;
+    int newUp     = upShares - amount;
+    int remaining = newUpPot + downPot;
+
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.sumInputs == upGroup.sumOutputs + amount, "up not burned exactly");
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.delta == 0, "down must not move");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+        oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        1, newUp, downShares, newUpPot, downPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= remaining, "pot not preserved");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+    if (payout > 330) {
+      require(tx.outputs[1].value >= payout, "redeemer underpaid");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // REDEEM DOWN — after settlement. Mirror of redeemUp on the DOWN pot.
+  //   output[0]: vault re-created (downShares-amount, downPot-payout)
+  //   output[1]: payout sats → redeemer (when above dust)
+  // -------------------------------------------------------------------------
+  function redeemDown(int amount) {
+    require(settled == 1, "not settled");
+    require(amount > 0, "zero amount");
+    require(amount <= downShares, "exceeds down supply");
+    require(downShares > 0, "no down supply");
+
+    int payout     = amount * downPot / downShares;
+    int newDownPot = downPot - payout;
+    int newDown    = downShares - amount;
+    int remaining  = upPot + newDownPot;
+
+    let downGroup = tx.assetGroups.find(downIdTxid, downIdGidx);
+    require(downGroup.sumInputs == downGroup.sumOutputs + amount, "down not burned exactly");
+    let upGroup = tx.assetGroups.find(upIdTxid, upIdGidx);
+    require(upGroup.delta == 0, "up must not move");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new HashpriceUsdVault(
+        oraclePk, ticker, btcUsdTicker, lowPrice, highPrice, maturity, settleWindow, pairCollateral,
+        upIdTxid, upIdGidx, downIdTxid, downIdGidx, contractIdTxid, contractIdGidx,
+        1, upShares, newDown, upPot, newDownPot, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= remaining, "pot not preserved");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+    if (payout > 330) {
+      require(tx.outputs[1].value >= payout, "redeemer underpaid");
+    }
+  }
+}

--- a/playground/main.js
+++ b/playground/main.js
@@ -32,6 +32,14 @@ const projects = {
             'cash_secured_put.ark': contracts.cash_secured_put,
         }
     },
+    hashprice: {
+        name: 'Hashprice',
+        description: 'Miner hashprice options: two-token range vaults whose UP (call-spread) and DOWN (put-spread) legs are fungible Arkade Assets priced via intents; long put = buy DOWN, capped short call = mint pairs and sell UP, revenue lock = both; BTC-quoted vault settles a single oracle fixing exactly, USD-quoted vault adds a BTC/USD fixing with an escrow-capped payout',
+        files: {
+            'hashprice_btc_vault.ark': contracts.hashprice_btc_vault,
+            'hashprice_usd_vault.ark': contracts.hashprice_usd_vault,
+        }
+    },
     bonds: {
         name: 'Bonds',
         description: "Fixed-maturity bond market with a phased lifecycle: borrowers self-issue 1:1 credit + debit tokens against collateral and sell credit on the order book for USDT (no interest rate); permissionless oracle-priced margin call (pre-maturity, fires when collateralValue < liqThresholdBps × mintedAmount / 10000) keeps every vault thresholded healthy so credit tokens are genuinely fungible; post-maturity auction window settles defaulted collateral; credit holders redeem pro-rata into single-sig wallets",

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -20,6 +20,8 @@ mod covered_call;
 mod fee_adapter;
 #[path = "examples/fuji_safe.rs"]
 mod fuji_safe;
+#[path = "examples/hashprice.rs"]
+mod hashprice;
 #[path = "examples/htlc.rs"]
 mod htlc;
 #[path = "examples/layerzero.rs"]

--- a/tests/examples/compilation_roundtrip.rs
+++ b/tests/examples/compilation_roundtrip.rs
@@ -133,6 +133,18 @@ fn roundtrip_fuji_safe() {
 }
 
 #[test]
+fn roundtrip_hashprice_btc_vault() {
+    let output = compile_example("hashprice/hashprice_btc_vault.ark");
+    assert_output_invariants(&output, "hashprice/hashprice_btc_vault.ark");
+}
+
+#[test]
+fn roundtrip_hashprice_usd_vault() {
+    let output = compile_example("hashprice/hashprice_usd_vault.ark");
+    assert_output_invariants(&output, "hashprice/hashprice_usd_vault.ark");
+}
+
+#[test]
 fn roundtrip_stability_vault() {
     let output = compile_example("stability/stability_vault.ark");
     assert_output_invariants(&output, "stability/stability_vault.ark");

--- a/tests/examples/hashprice.rs
+++ b/tests/examples/hashprice.rs
@@ -1,0 +1,252 @@
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CAT, OP_CHECKSIGFROMSTACK, OP_DIV64, OP_FINDASSETGROUPBYASSETID, OP_INSPECTOUTASSETLOOKUP,
+    OP_MUL64, OP_SHA256,
+};
+
+use crate::common::{arkade_asm, arkade_asm_tokens, arkade_inputs, group};
+
+const BTC_CODE: &str = include_str!("../../examples/hashprice/hashprice_btc_vault.ark");
+const USD_CODE: &str = include_str!("../../examples/hashprice/hashprice_usd_vault.ark");
+
+#[test]
+fn test_btc_vault_compiles_with_5_groups() {
+    // 5 covenant functions, no author tapscript (pooled exit lives off-chain)
+    let out = compile(BTC_CODE).expect("btc vault compile");
+    assert_eq!(out.name, "HashpriceBtcVault");
+    assert_eq!(out.functions.len(), 5);
+}
+
+#[test]
+fn test_usd_vault_compiles_with_5_groups() {
+    let out = compile(USD_CODE).expect("usd vault compile");
+    assert_eq!(out.name, "HashpriceUsdVault");
+    assert_eq!(out.functions.len(), 5);
+}
+
+#[test]
+fn test_all_paths_are_permissionless() {
+    // Every function authenticates via asset burns / oracle attestations, not
+    // user signatures: the only signature witnesses are oracle sigs on settle.
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        for name in ["issue", "burnPair", "redeemUp", "redeemDown"] {
+            let names = arkade_inputs(&out, name);
+            assert_eq!(
+                names,
+                vec!["amount".to_string()],
+                "{name} must take only `amount`"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_btc_settle_verifies_single_oracle_fixing() {
+    // settle must reconstruct sha256(ticker || price || time) via OP_CAT +
+    // OP_SHA256 and verify exactly one oracle signature against it.
+    let out = compile(BTC_CODE).unwrap();
+    let tokens = arkade_asm_tokens(&out, "settle");
+    let csfs = tokens
+        .iter()
+        .filter(|t| t.as_str() == OP_CHECKSIGFROMSTACK)
+        .count();
+    let cats = tokens.iter().filter(|t| t.as_str() == OP_CAT).count();
+    let shas = tokens.iter().filter(|t| t.as_str() == OP_SHA256).count();
+    assert_eq!(csfs, 1, "btc settle: exactly one oracle verification");
+    assert_eq!(cats, 2, "btc settle: ticker||price||time needs two OP_CAT");
+    assert_eq!(shas, 1, "btc settle: one message digest");
+    assert_eq!(
+        arkade_inputs(&out, "settle"),
+        vec!["spotPrice", "spotTime", "oracleSig"],
+        "btc settle witness"
+    );
+}
+
+#[test]
+fn test_usd_settle_verifies_both_fixings_and_converts() {
+    // The USD vault needs the hashprice fixing AND the BTC/USD fixing, both
+    // signed, and a division for the USD→sats conversion.
+    let out = compile(USD_CODE).unwrap();
+    let tokens = arkade_asm_tokens(&out, "settle");
+    let csfs = tokens
+        .iter()
+        .filter(|t| t.as_str() == OP_CHECKSIGFROMSTACK)
+        .count();
+    let cats = tokens.iter().filter(|t| t.as_str() == OP_CAT).count();
+    let shas = tokens.iter().filter(|t| t.as_str() == OP_SHA256).count();
+    assert_eq!(csfs, 2, "usd settle: two oracle verifications");
+    assert_eq!(cats, 4, "usd settle: two messages, two OP_CAT each");
+    assert_eq!(shas, 2, "usd settle: two message digests");
+    let asm = tokens.join(" ");
+    assert!(
+        asm.contains(OP_DIV64),
+        "usd settle: must divide by btcUsdPrice"
+    );
+    assert_eq!(
+        arkade_inputs(&out, "settle"),
+        vec![
+            "spotPrice",
+            "spotTime",
+            "spotSig",
+            "btcUsdPrice",
+            "btcUsdTime",
+            "btcUsdSig"
+        ],
+        "usd settle witness"
+    );
+}
+
+#[test]
+fn test_btc_settle_splits_without_division() {
+    // Sats-quoted payoffs split the pot exactly — no division, so no
+    // truncation dust in settlement (division only appears in redemption).
+    let out = compile(BTC_CODE).unwrap();
+    let asm = arkade_asm(&out, "settle");
+    assert!(!asm.contains(OP_DIV64), "btc settle must not divide: {asm}");
+}
+
+#[test]
+fn test_oracle_only_consulted_at_settlement() {
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        for name in ["issue", "burnPair", "redeemUp", "redeemDown"] {
+            let asm = arkade_asm(&out, name);
+            assert!(
+                !asm.contains(OP_CHECKSIGFROMSTACK),
+                "{name}: must not invoke oracle"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_issue_mints_both_legs_to_depositor() {
+    // issue must find all three asset groups (UP, DOWN, identity) and verify
+    // delivery of both legs on output[1].
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        let tokens = arkade_asm_tokens(&out, "issue");
+        let finds = tokens
+            .iter()
+            .filter(|t| t.as_str() == OP_FINDASSETGROUPBYASSETID)
+            .count();
+        assert!(
+            finds >= 3,
+            "issue must inspect UP, DOWN and identity groups; got {finds}"
+        );
+        let lookups = tokens
+            .iter()
+            .filter(|t| t.as_str() == OP_INSPECTOUTASSETLOOKUP)
+            .count();
+        // two leg deliveries on output[1] + identity retention on output[0]
+        assert!(
+            lookups >= 3,
+            "issue must look up both legs and the identity on outputs; got {lookups}"
+        );
+    }
+}
+
+#[test]
+fn test_redeem_is_pro_rata() {
+    // redemption pays amount × pot / shares — multiplication AND division.
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        for name in ["redeemUp", "redeemDown"] {
+            let asm = arkade_asm(&out, name);
+            assert!(asm.contains(OP_MUL64), "{name}: pro-rata multiply missing");
+            assert!(asm.contains(OP_DIV64), "{name}: pro-rata divide missing");
+        }
+    }
+}
+
+#[test]
+fn test_all_groups_use_synthesized_cooperative_leaf() {
+    // No author tapscripts: every group's single leaf is the synthesized
+    // collaborative leaf with injected server + emulator signatures.
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        for g in &out.functions {
+            assert_eq!(g.leaves.len(), 1, "{}: one leaf expected", g.name);
+            let leaf = &g.leaves[0];
+            assert!(
+                leaf.witness.iter().all(|w| w.injected),
+                "{}: cooperative leaf witnesses must all be injected",
+                g.name
+            );
+            let asm = leaf.asm.join(" ");
+            assert!(
+                asm.contains("<SERVER_KEY>"),
+                "{}: leaf must include server key",
+                g.name
+            );
+            assert!(
+                asm.contains(&format!("<EMULATOR_KEY:{}>", g.name)),
+                "{}: leaf must include function-tweaked emulator key",
+                g.name
+            );
+        }
+    }
+}
+
+#[test]
+fn test_asset_ids_are_two_explicit_params() {
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        for (txid_name, gidx_name) in [
+            ("upIdTxid", "upIdGidx"),
+            ("downIdTxid", "downIdGidx"),
+            ("contractIdTxid", "contractIdGidx"),
+        ] {
+            let txid = out
+                .parameters
+                .iter()
+                .find(|p| p.name == txid_name)
+                .unwrap_or_else(|| panic!("missing constructor input {txid_name}"));
+            assert_eq!(txid.param_type, "bytes32");
+            let gidx = out
+                .parameters
+                .iter()
+                .find(|p| p.name == gidx_name)
+                .unwrap_or_else(|| panic!("missing constructor input {gidx_name}"));
+            assert_eq!(gidx.param_type, "int");
+        }
+    }
+}
+
+#[test]
+fn test_usd_vault_has_conversion_feed_and_escrow_cap() {
+    // The USD vault must carry the second feed id and the per-pair sats
+    // escrow that caps the UP payout; the BTC vault must carry neither.
+    let usd = compile(USD_CODE).unwrap();
+    for (name, ty) in [("btcUsdTicker", "bytes32"), ("pairCollateral", "int")] {
+        let p = usd
+            .parameters
+            .iter()
+            .find(|p| p.name == name)
+            .unwrap_or_else(|| panic!("usd vault missing {name}"));
+        assert_eq!(p.param_type, ty);
+    }
+    let btc = compile(BTC_CODE).unwrap();
+    for name in ["btcUsdTicker", "pairCollateral"] {
+        assert!(
+            !btc.parameters.iter().any(|p| p.name == name),
+            "btc vault must not carry {name}"
+        );
+    }
+}
+
+#[test]
+fn test_settle_flips_state_via_recreation() {
+    // Every settle branch recreates the vault with settled=1; the recreation
+    // placeholder embeds the constructor call.
+    for code in [BTC_CODE, USD_CODE] {
+        let out = compile(code).unwrap();
+        let g = group(&out, "settle");
+        let asm = g.arkade.as_ref().expect("settle covenant").asm.join(" ");
+        assert!(
+            asm.contains("<VTXO:"),
+            "settle must recreate the vault via constructor placeholder"
+        );
+    }
+}

--- a/tests/examples/hashprice.rs
+++ b/tests/examples/hashprice.rs
@@ -1,7 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_CAT, OP_CHECKSIGFROMSTACK, OP_DIV64, OP_FINDASSETGROUPBYASSETID, OP_INSPECTOUTASSETLOOKUP,
-    OP_MUL64, OP_SHA256,
+    OP_CAT, OP_CHECKSIGFROMSTACK, OP_DIV, OP_FINDASSETGROUPBYASSETID, OP_INSPECTOUTASSETLOOKUP,
+    OP_MUL, OP_SHA256,
 };
 
 use crate::common::{arkade_asm, arkade_asm_tokens, arkade_inputs, group};
@@ -80,7 +80,7 @@ fn test_usd_settle_verifies_both_fixings_and_converts() {
     assert_eq!(shas, 2, "usd settle: two message digests");
     let asm = tokens.join(" ");
     assert!(
-        asm.contains(OP_DIV64),
+        asm.contains(OP_DIV),
         "usd settle: must divide by btcUsdPrice"
     );
     assert_eq!(
@@ -103,7 +103,7 @@ fn test_btc_settle_splits_without_division() {
     // truncation dust in settlement (division only appears in redemption).
     let out = compile(BTC_CODE).unwrap();
     let asm = arkade_asm(&out, "settle");
-    assert!(!asm.contains(OP_DIV64), "btc settle must not divide: {asm}");
+    assert!(!asm.contains(OP_DIV), "btc settle must not divide: {asm}");
 }
 
 #[test]
@@ -154,8 +154,8 @@ fn test_redeem_is_pro_rata() {
         let out = compile(code).unwrap();
         for name in ["redeemUp", "redeemDown"] {
             let asm = arkade_asm(&out, name);
-            assert!(asm.contains(OP_MUL64), "{name}: pro-rata multiply missing");
-            assert!(asm.contains(OP_DIV64), "{name}: pro-rata divide missing");
+            assert!(asm.contains(OP_MUL), "{name}: pro-rata multiply missing");
+            assert!(asm.contains(OP_DIV), "{name}: pro-rata divide missing");
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds hashprice options for miners as two-token **range vaults**: everything is expressed with plain European options, sized freely, margined and settled in BTC.

- **Long put on hashprice** — miner buys DOWN tokens; pays exactly the shortfall in mining revenue below the strike.
- **Short call on hashprice** — miner mints pairs (escrowing the band width), keeps DOWN, sells UP on the order book; the sale price is the premium and the payout of the increase is capped at the band top.
- **Revenue lock (collar)** — combine both across two series in any ratio; every leg is a fungible Arkade Asset, so miners buy extra coverage or sell only part of the upside via Arkade intents (standing orders) — the premium never touches the contract.

Only these two positions hedge mining revenue and are what the design targets; buying a call or selling a put are directional speculation, left to venues like Deribit. The doc also covers the counterparty asymmetry: **sell call** is a desk-friendly RFQ (only the premium is given out), while **buy put** needs a **standing pool** — a written put must keep BTC posted for the option's life, so one-directional miner demand is served by the vault-as-pool rather than on-demand desk RFQ.

## New contracts: `examples/hashprice/`

Both follow the two-token vault design (paired UP/DOWN mint gated by a contract-identity singleton, 1:1 issue/burn, oracle fixing inside `±settleWindow` of maturity, order-invariant pro-rata redemption with the 330-sat dust convention):

- **`hashprice_btc_vault.ark`** (`HashpriceBtcVault`) — band quoted in sats per contract. The band width *is* the per-pair escrow, so every payoff is fully collateralized by construction and settlement splits the pot exactly, with **no division**. Single oracle attestation (`sha256(ticker || price || time)` via `checkSigFromStack`).
- **`hashprice_usd_vault.ark`** (`HashpriceUsdVault`) — band quoted in USD cents, paid in sats. Settlement requires **two** attestations (hashprice + BTC/USD) and converts the USD intrinsic at the attested BTC/USD price. Since a USD payoff backed by BTC can never be fully collateralized, each pair escrows a fixed `pairCollateral` sats that caps the UP payout — the on-chain form of capping a short-call writer's maximum loss (band top ≈ 2–3× spot hashprice), with the residual joint-tail risk left to the market maker's premium.
- **`hashprice.md`** — miner strategy guide (strategies, pool-vs-RFQ market structure, cap economics, lifecycle, exit model, relation to the options/stability/bonds examples).

Exit model matches the pooled-vault convention: no single CSV leaf can express per-holder exit, so `exit` parameterizes the off-chain recurrent exit tree and the oracle-liveness assumption is documented.

## Tests

`tests/examples/hashprice.rs` (registered in `tests/examples.rs`, plus roundtrip entries): group counts, permissionless `amount`-only witnesses on issue/burn/redeem, oracle opcodes confined to `settle` (1 verification for BTC, 2 for USD, exact `OP_CAT`/`OP_SHA256` counts), no division in BTC settlement, `OP_MUL`/`OP_DIV` pro-rata redemption, identity/leg asset-group inspection, synthesized cooperative leaves with injected server/emulator sigs, and constructor schema (two-param asset ids; USD-only `btcUsdTicker`/`pairCollateral`). Full workspace suite green, `cargo fmt --check` clean.

> Rebased onto current master (`02d10ff`), whose "generalize comparisons" refactor emits the unsuffixed int-arithmetic opcodes `OP_MUL`/`OP_DIV` in place of `OP_MUL64`/`OP_DIV64`; the redeem and USD-settle assertions were updated to match. Contract behavior is unchanged.

## Playground

`playground/main.js` registers a **Hashprice** project with both vaults; sources flow through the auto-generated `contracts.js` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xSv5NJ3LFu9qSrZvbou1W

---
_Generated by [Claude Code](https://claude.ai/code/session_019xSv5NJ3LFu9qSrZvbou1W)_