### PR TITLE
feat: add streaming dividends example (DividendTreasury + StreamingShare)

### DIFF
--- a/examples/dividend_stream/dividend_stream.md
+++ b/examples/dividend_stream/dividend_stream.md
@@ -1,0 +1,152 @@
+# Streaming Dividends — a dividend every second
+
+A Bitcoin-native dividend rail for corporate issuers: the dividend accrues
+continuously at one-second granularity, is fixed in USD cents per unit per
+year, and pays out in sats at an oracle-attested BTC/USD price whenever the
+holder chooses to settle. Two contracts implement the program:
+
+| File | Contract | Role |
+|---|---|---|
+| `dividend_treasury.ark` | `DividendTreasury` | singleton BTC reserve; services claims, accepts top-ups, issuer recall |
+| `streaming_share.ark` | `StreamingShare` | per-holder position carrying `(units, lastClaim)`; claim / transfer / split |
+
+## The pilot: Metaplanet (hypothetical)
+
+Metaplanet — the Tokyo-listed Bitcoin treasury company — has been working to
+launch Japan's first listed perpetual preferred shares, funded by its Bitcoin
+Income Generation business. Two frictions in that plan are public record:
+
+- **The plumbing can't keep up with the ambition.** The stated goal of paying
+  dividends *monthly* is already exotic in Japan, where payouts are annual or
+  semiannual; the company has had to build bespoke systems for shareholder
+  verification, record-date management and recurring distribution runs.
+- **The listing gate is cash-flow credibility.** Exchange review asks for
+  evidence that recurring dividends are backed by sustainable recurring cash
+  flows — with only a short operating track record to show.
+
+Both frictions are artifacts of *batch* settlement. This program removes the
+batch. On Arkade the dividend is not an event but a rate: every unit accrues
+`annualDividendCents / 31,536,000` per second, continuously, and any holder
+settles whenever they like. A monthly dividend makes 12 payments a year; this
+makes the concept of "a payment" disappear — 31.5 million accrual ticks a
+year, of which claims are just checkpoints.
+
+The pilot shape that follows from this:
+
+1. **Phase 0 — internal demo.** One treasury, a handful of positions on
+   testnet. The income desk tops up the reserve on its real revenue cadence;
+   a dashboard shows per-second accrual against reserve coverage.
+2. **Phase 1 — closed pilot.** A small tranche of *dividend entitlement
+   units* (not the listed security itself) is allotted to qualified
+   investors; each allotment is deployed as a `StreamingShare`. The listed
+   preferred, when it lists, stays on the traditional register — the pilot
+   instrument is the payment rail, mirroring registry holdings.
+3. **Phase 2 — the rail becomes the register.** Continuous on-chain top-ups
+   from the income desk are themselves the auditable evidence of recurring
+   cash flow that batch reporting struggles to demonstrate: reserve coverage
+   is a public time series, not a quarterly disclosure.
+
+Nothing here is legal advice; a real pilot needs securities counsel in the
+issuer's jurisdiction. The contracts are jurisdiction-agnostic.
+
+## Why streaming kills the record date
+
+A record date exists because batch rails must snapshot ownership to know whom
+to pay. Continuous accrual makes the snapshot meaningless:
+
+- `transfer` is a key swap that carries `(units, lastClaim)` unchanged —
+  accrued-but-unclaimed dividends travel with the position and are priced
+  into the sale. Sell at 14:03:07 and you have earned exactly through
+  14:03:07. There is no ex-dividend cliff, so no dividend-capture trade.
+- `split` gives both children the parent's `lastClaim`; accrual is linear in
+  units, so splits are exactly accrual-fair with no division.
+- `claim` settles accrual and advances `lastClaim` to now, atomically with
+  the payout. Claims are independent per holder — no distribution run.
+
+## Mechanics
+
+**Accrual.** Time is `tx.offchainTime` (TEE-attested wallclock, unix
+seconds), giving one-second granularity:
+
+```
+elapsed      = now − lastClaim
+accruedCents = units × annualDividendCents × elapsed / 31536000
+payoutSats   = accruedCents × 1e8 / oraclePrice     // price in cents/BTC
+```
+
+The product `units × annualDividendCents × elapsed` must stay inside int64:
+1e6 units at $6.00/yr unclaimed for ten years is 1.9e17 — comfortably safe.
+Truncation loses under one cent per claim, and `accruedCents > 0` guards a
+zero-payout claim from advancing `lastClaim`.
+
+**Claim transaction.** A claim co-spends treasury and position; each covenant
+independently recomputes the accrual and protects its own side:
+
+```
+input[srvIdx]:  DividendTreasury  (service — permissionless)
+input[posIdx]:  StreamingShare    (claim — holder-signed)
+output[0]: treasury re-created, reserveSats − payoutSats
+output[1]: position re-created, lastClaim = now
+output[2]: payoutSats → holder
+```
+
+The treasury verifies the co-spent input is a genuine `StreamingShare` with
+the witness-declared `(holder, units, lastClaim)` (scriptPubKey equality
+binds the declaration), and only releases reserve against a position whose
+accrual basis simultaneously advances — the same second of dividend time can
+never be paid twice. The position verifies the holder authorized, the
+treasury is genuinely present, and the holder is paid. `service` itself is
+permissionless, so wallets or watchtowers can co-sponsor claims.
+
+**Funding.** `topUp` is permissionless and monotone — the reserve only
+grows. The income desk streams revenue in on whatever cadence it earns it,
+which is exactly the "recurring cash flow" evidence exchanges ask for, as a
+public time series.
+
+**Oracle.** Fuji-style signed feed, as in `stability/` and `hashprice/`:
+`msg = sha256(ticker || price || time)` verified with `checkSigFromStack`,
+freshness bounded to 600 seconds of `tx.offchainTime`. A claim needs a live
+oracle; accrual itself never does — if the oracle stalls, dividends keep
+accruing and claims resume with the feed.
+
+**Dust.** Claims below 331 sats are rejected (`payoutSats > 330`), matching
+the Taproot dust convention used across the examples. At $6.00/yr per unit
+and $100k BTC, one unit crosses dust in about two days; a holder of N units
+can claim N times as often. Accrual is per-second; claiming is whenever it's
+worth a UTXO.
+
+## Trust model — what the pilot does and doesn't enforce
+
+- **Reserve coverage is visible, not mandatory.** `recall` lets the issuer
+  withdraw reserve at will; claims fail when the reserve is exhausted. Every
+  recall and every top-up is on-chain the moment it happens, so coverage is
+  watchable in real time — but solvency is a legal obligation of the issuer,
+  not a covenant. Hardening path (deliberately out of pilot scope): a
+  timelocked recall notice, and the arrears clock + penalty-rate mechanics
+  prototyped in the `VariableDividendPreferred` example (PR #40).
+- **`totalUnits` is fixed at deployment.** The treasury sanity-checks
+  positions against it, but issuance integrity (that allotted positions sum
+  to `totalUnits`) is an off-chain deployment fact. An issuance-controlled
+  asset gating position creation — the `hashprice/` identity-singleton
+  pattern — is the natural upgrade.
+- **Clock and oracle.** `tx.offchainTime` is TEE wallclock: not
+  consensus-enforced, and guarded against regression but not against pause.
+  Oracle liveness gates claims, never accrual.
+- **Exit.** Both contracts carry CSV unilateral-exit leaves. The position
+  UTXO's sat value is dust; what exits is the *instrument*, whose entitlement
+  is then enforced against the issuer per program terms — same model as any
+  registered security, with a better audit trail.
+
+## Relation to the other examples
+
+- `stability/` — the oracle witness, `tx.offchainTime` accrual and
+  per-second rate idioms; this program is those idioms turned into a
+  corporate-action rail.
+- `bonds/` — the two-contract co-spend pattern (`repayment_pool` ⊗
+  `bond_mint`) that `service` ⊗ `claim` follows.
+- `hashprice/`, `options/` — the income side: covered calls and hashprice
+  vaults are ways a treasury desk *earns* the BTC that `topUp` streams into
+  this reserve.
+- `VariableDividendPreferred` (PR #40) — the single-UTXO, per-holder
+  preferred with arrears teeth; this program is its pooled, streaming,
+  transfer-friendly successor.

--- a/examples/dividend_stream/dividend_treasury.ark
+++ b/examples/dividend_stream/dividend_treasury.ark
@@ -1,0 +1,185 @@
+// DividendTreasury Contract
+//
+// The issuer-funded reserve of a streaming-dividend program: a corporate
+// treasury (e.g. a Bitcoin treasury company's income-generation desk) escrows
+// BTC that services dividend claims from StreamingShare positions. The
+// dividend is fixed in USD cents per unit per year, accrues continuously at
+// one-second granularity (tx.offchainTime), and is paid in sats at an
+// oracle-attested BTC/USD price at claim time.
+//
+// ── Why streaming ───────────────────────────────────────────────────────────
+//   Batch dividend rails need record dates, transfer agents and distribution
+//   runs; paying monthly is already exotic in most listed markets. Here the
+//   entitlement accrues per second and any holder can settle their accrued
+//   balance whenever it exceeds dust — the record date disappears because
+//   accrual follows the position continuously (see dividend_stream.md).
+//
+// ── Two contracts, one program ──────────────────────────────────────────────
+//   DividendTreasury (this file) — singleton reserve. Pays claims, accepts
+//     top-ups from the income desk, lets the issuer recall unallocated
+//     reserve (telegraphed on-chain; see trust model in dividend_stream.md).
+//   StreamingShare — per-holder position carrying (units, lastClaim). A claim
+//     co-spends both: the treasury verifies the position is genuine and that
+//     its accrual basis advances; the position verifies the holder is paid.
+//
+// ── Claim transaction layout (service ⊗ claim) ──────────────────────────────
+//   input[srvIdx]:  this treasury          (function: service)
+//   input[posIdx]:  a StreamingShare       (function: claim)
+//   output[0]: treasury re-created, reserveSats − payoutSats
+//   output[1]: position re-created, lastClaim = tx.offchainTime
+//   output[2]: payoutSats → holder (SingleSig)
+//
+// ── Accrual math (shared with StreamingShare) ───────────────────────────────
+//   elapsed      = tx.offchainTime − posLastClaim          [seconds]
+//   accruedCents = units × annualDividendCents × elapsed / 31536000
+//   payoutSats   = accruedCents × 1e8 / oraclePrice        [price in cents/BTC]
+//   int64 bound: units × annualDividendCents × elapsed < 9.2e18 — e.g. 1e6
+//   units at $6.00/yr (600 cents) unclaimed for 10 years is 1.9e17, safe.
+//   Truncation loses < 1 cent per claim; the accruedCents > 0 guard prevents
+//   a zero-payout claim from advancing lastClaim (no accrual griefing).
+//
+// ── Oracle model (Fuji-style signed price feed) ─────────────────────────────
+//   msg = sha256(ticker || price || timestamp), price/timestamp 8-byte LE.
+//   Freshness: tx.offchainTime − oracleTime within [0, 600] seconds.
+
+import "single_sig.ark";
+import "streaming_share.ark";
+
+contract DividendTreasury(
+  pubkey  issuerPk,            // issuer treasury key: recall + unilateral exit
+  pubkey  oraclePk,            // BTC/USD signed price feed
+  bytes32 ticker,              // feed id, e.g. sha256("BTC/USD")
+  int     annualDividendCents, // fixed dividend per unit per year, USD cents
+  int     totalUnits,          // units outstanding across all positions
+  int     reserveSats,         // sats escrowed for dividends; mutates on every spend
+  int     exit                 // exit timelock in blocks (shared with positions)
+) {
+
+  // -------------------------------------------------------------------------
+  // TOP UP — permissionless. The income desk (or anyone) streams revenue into
+  // the reserve. No sats can leave: the reserve only grows.
+  //   output[0]: treasury re-created with reserveSats + amount
+  // -------------------------------------------------------------------------
+  function topUp(int amount) {
+    require(amount > 0, "zero amount");
+
+    int newReserve = reserveSats + amount;
+
+    require(
+      tx.outputs[0].scriptPubKey == new DividendTreasury(
+        issuerPk, oraclePk, ticker, annualDividendCents, totalUnits,
+        newReserve, exit
+      ),
+      "invalid treasury recreation"
+    );
+    require(tx.outputs[0].value >= newReserve, "reserve not deposited");
+  }
+
+  // -------------------------------------------------------------------------
+  // SERVICE — permissionless servicing of one position's claim (the position
+  // input carries the holder's authorization). Verifies the co-spent input is
+  // a genuine StreamingShare with the witness-declared state, recomputes the
+  // accrual independently, pays the holder, and requires the position to be
+  // re-created with its accrual basis advanced to now — the reserve can only
+  // leave against dividend time that is simultaneously consumed.
+  // -------------------------------------------------------------------------
+  function service(
+    int       posIdx,
+    pubkey    posHolderPk,
+    int       posUnits,
+    int       posLastClaim,
+    int       oraclePrice,
+    int       oracleTime,
+    signature oracleSig
+  ) {
+    require(this.activeInputIndex != posIdx, "self-service disallowed");
+    require(posUnits > 0, "empty position");
+    require(posUnits <= totalUnits, "position exceeds issue");
+    require(oraclePrice > 0, "invalid oracle price");
+
+    require(
+      tx.inputs[posIdx].scriptPubKey == new StreamingShare(
+        posHolderPk, issuerPk, oraclePk, ticker,
+        annualDividendCents, posUnits, posLastClaim, exit
+      ),
+      "input not matching position"
+    );
+
+    int oracleAge = tx.offchainTime - oracleTime;
+    require(oracleAge >= 0, "future-dated oracle");
+    require(oracleAge <= 600, "stale oracle");
+    let oracleMsg = sha256(ticker + oraclePrice + oracleTime);
+    require(checkSigFromStack(oracleSig, oraclePk, oracleMsg), "invalid oracle signature");
+
+    int elapsed = tx.offchainTime - posLastClaim;
+    require(elapsed >= 0, "clock regression");
+    int annualCents  = posUnits * annualDividendCents;
+    int accruedCents = annualCents * elapsed / 31536000;
+    require(accruedCents > 0, "nothing accrued");
+    int payoutSats = accruedCents * 100000000 / oraclePrice;
+    require(payoutSats > 330, "dust claim; accrue longer");
+    require(payoutSats <= reserveSats, "reserve exhausted");
+
+    int newReserve = reserveSats - payoutSats;
+
+    require(
+      tx.outputs[0].scriptPubKey == new DividendTreasury(
+        issuerPk, oraclePk, ticker, annualDividendCents, totalUnits,
+        newReserve, exit
+      ),
+      "invalid treasury recreation"
+    );
+    require(tx.outputs[0].value >= newReserve, "reserve not preserved");
+
+    require(
+      tx.outputs[1].scriptPubKey == new StreamingShare(
+        posHolderPk, issuerPk, oraclePk, ticker,
+        annualDividendCents, posUnits, tx.offchainTime, exit
+      ),
+      "position basis not advanced"
+    );
+    require(tx.outputs[1].value >= 330, "position output dust");
+
+    require(tx.outputs[2].scriptPubKey == new SingleSig(posHolderPk, exit), "output 2 not holder");
+    require(tx.outputs[2].value >= payoutSats, "holder underpaid");
+  }
+
+  // -------------------------------------------------------------------------
+  // RECALL — issuer-gated reserve withdrawal (program wind-down or resizing).
+  // Recalls are visible on-chain the moment they happen, so holders can see
+  // reserve coverage shrink and act; the pilot trust model and its hardening
+  // path (timelocked recall notice, arrears penalties) are documented in
+  // dividend_stream.md.
+  //   output[0]: treasury re-created with reserveSats − amount
+  //   output[1]: amount → issuer
+  // -------------------------------------------------------------------------
+  function recall(signature issuerSig, int amount) {
+    require(checkSig(issuerSig, issuerPk), "invalid issuer sig");
+    require(amount > 0, "zero amount");
+    require(amount <= reserveSats, "exceeds reserve");
+
+    int newReserve = reserveSats - amount;
+
+    require(
+      tx.outputs[0].scriptPubKey == new DividendTreasury(
+        issuerPk, oraclePk, ticker, annualDividendCents, totalUnits,
+        newReserve, exit
+      ),
+      "invalid treasury recreation"
+    );
+    require(tx.outputs[0].value >= newReserve, "reserve not preserved");
+
+    require(tx.outputs[1].scriptPubKey == new SingleSig(issuerPk, exit), "output 1 not issuer");
+    require(tx.outputs[1].value >= amount, "issuer underpaid");
+  }
+
+  // -------------------------------------------------------------------------
+  // UNILATERAL EXIT (CSV) — issuer recovers the reserve if the Arkade
+  // operator goes offline. The issuer is the residual claimant of the
+  // reserve; holder positions carry their own exit leaf.
+  // -------------------------------------------------------------------------
+  function unilateral(signature issuerSig) tapscript {
+    require(older(exit));
+    require(checkSig(issuerSig, issuerPk));
+  }
+}

--- a/examples/dividend_stream/streaming_share.ark
+++ b/examples/dividend_stream/streaming_share.ark
@@ -1,0 +1,161 @@
+// StreamingShare Contract
+//
+// A per-holder dividend entitlement position in a streaming-dividend program
+// (see dividend_stream.md and dividend_treasury.ark). The position carries
+// (units, lastClaim): `units` preferred-share units whose fixed USD-cent
+// dividend has been accruing continuously — at one-second granularity —
+// since `lastClaim`.
+//
+//   accrued(t) = units × annualDividendCents × (t − lastClaim) / 31536000
+//
+// Accrual is linear in both units and time, which buys three properties:
+//   - claim any time: the holder settles accrued dividends whenever the sat
+//     value exceeds dust; lastClaim advances to now and the stream continues;
+//   - transfer without record dates: a key swap carries (units, lastClaim)
+//     unchanged, so accrued-but-unclaimed dividends travel with the position
+//     and are priced into the sale — there is no ex-dividend cliff;
+//   - exact splits: two children with the same lastClaim and units summing to
+//     the parent accrue exactly what the parent would have.
+//
+// A claim co-spends the DividendTreasury (which independently recomputes the
+// accrual and re-creates this position with lastClaim = now). This covenant
+// protects the holder's side: only the holder can authorize, the co-spent
+// input must be the genuine treasury, and the payout output must pay the
+// holder. Reserve accounting is the treasury covenant's job.
+//
+// Oracle model, accrual bounds and the claim tx layout are documented in
+// dividend_treasury.ark; both covenants enforce the same math.
+
+import "single_sig.ark";
+import "dividend_treasury.ark";
+
+contract StreamingShare(
+  pubkey  holderPk,            // beneficial owner; mutates on transfer
+  pubkey  issuerPk,            // issuer treasury key (binds position to program)
+  pubkey  oraclePk,            // BTC/USD signed price feed
+  bytes32 ticker,              // feed id, e.g. sha256("BTC/USD")
+  int     annualDividendCents, // fixed dividend per unit per year, USD cents
+  int     units,               // units in this position; mutates on split
+  int     lastClaim,           // unix seconds; accrual basis, mutates on claim
+  int     exit                 // exit timelock in blocks
+) {
+
+  // -------------------------------------------------------------------------
+  // CLAIM — holder settles the dividend accrued since lastClaim. The treasury
+  // input is located via `treasuryIdx` and its mutable state is declared as
+  // witness; the scriptPubKey equality binds the declaration.
+  //   input[treasuryIdx]: DividendTreasury (function: service)
+  //   output[1]: this position re-created with lastClaim = tx.offchainTime
+  //   output[2]: payoutSats → holder
+  // -------------------------------------------------------------------------
+  function claim(
+    signature holderSig,
+    int       treasuryIdx,
+    int       treasuryTotalUnits,
+    int       treasuryReserve,
+    int       oraclePrice,
+    int       oracleTime,
+    signature oracleSig
+  ) {
+    require(checkSig(holderSig, holderPk), "invalid holder sig");
+    require(this.activeInputIndex != treasuryIdx, "self-claim disallowed");
+    require(units > 0, "empty position");
+    require(oraclePrice > 0, "invalid oracle price");
+
+    require(
+      tx.inputs[treasuryIdx].scriptPubKey == new DividendTreasury(
+        issuerPk, oraclePk, ticker, annualDividendCents,
+        treasuryTotalUnits, treasuryReserve, exit
+      ),
+      "input not matching treasury"
+    );
+
+    int oracleAge = tx.offchainTime - oracleTime;
+    require(oracleAge >= 0, "future-dated oracle");
+    require(oracleAge <= 600, "stale oracle");
+    let oracleMsg = sha256(ticker + oraclePrice + oracleTime);
+    require(checkSigFromStack(oracleSig, oraclePk, oracleMsg), "invalid oracle signature");
+
+    int elapsed = tx.offchainTime - lastClaim;
+    require(elapsed >= 0, "clock regression");
+    int annualCents  = units * annualDividendCents;
+    int accruedCents = annualCents * elapsed / 31536000;
+    require(accruedCents > 0, "nothing accrued");
+    int payoutSats = accruedCents * 100000000 / oraclePrice;
+    require(payoutSats > 330, "dust claim; accrue longer");
+
+    require(
+      tx.outputs[1].scriptPubKey == new StreamingShare(
+        holderPk, issuerPk, oraclePk, ticker,
+        annualDividendCents, units, tx.offchainTime, exit
+      ),
+      "invalid position recreation"
+    );
+    require(tx.outputs[1].value >= 330, "position output dust");
+
+    require(tx.outputs[2].scriptPubKey == new SingleSig(holderPk, exit), "output 2 not holder");
+    require(tx.outputs[2].value >= payoutSats, "holder underpaid");
+  }
+
+  // -------------------------------------------------------------------------
+  // TRANSFER — pure key swap, no oracle. (units, lastClaim) carry over, so
+  // accrued-but-unclaimed dividends travel with the position: the stream
+  // never stops and no record date exists to snapshot.
+  // -------------------------------------------------------------------------
+  function transfer(signature holderSig, pubkey newHolderPk) {
+    require(checkSig(holderSig, holderPk), "invalid holder sig");
+
+    require(
+      tx.outputs[0].scriptPubKey == new StreamingShare(
+        newHolderPk, issuerPk, oraclePk, ticker,
+        annualDividendCents, units, lastClaim, exit
+      ),
+      "invalid transfer output"
+    );
+    require(tx.outputs[0].value >= 330, "position output dust");
+  }
+
+  // -------------------------------------------------------------------------
+  // SPLIT — divide the position into two. Both children keep lastClaim, so
+  // the split is exactly accrual-fair: accrual is linear in units, and the
+  // children's future (and pending) accrual sums to the parent's.
+  //   output[0]: splitUnits → newHolderPk
+  //   output[1]: units − splitUnits → holder
+  // -------------------------------------------------------------------------
+  function split(signature holderSig, int splitUnits, pubkey newHolderPk) {
+    require(checkSig(holderSig, holderPk), "invalid holder sig");
+    require(splitUnits > 0, "zero amount");
+    require(splitUnits < units, "amount exceeds units");
+
+    int remainingUnits = units - splitUnits;
+
+    require(
+      tx.outputs[0].scriptPubKey == new StreamingShare(
+        newHolderPk, issuerPk, oraclePk, ticker,
+        annualDividendCents, splitUnits, lastClaim, exit
+      ),
+      "invalid split output 0"
+    );
+    require(tx.outputs[0].value >= 330, "split output 0 dust");
+
+    require(
+      tx.outputs[1].scriptPubKey == new StreamingShare(
+        holderPk, issuerPk, oraclePk, ticker,
+        annualDividendCents, remainingUnits, lastClaim, exit
+      ),
+      "invalid split output 1"
+    );
+    require(tx.outputs[1].value >= 330, "split output 1 dust");
+  }
+
+  // -------------------------------------------------------------------------
+  // UNILATERAL EXIT (CSV) — holder recovers the position UTXO after the exit
+  // delay (Arkade operator offline). The position's sat value is dust-sized;
+  // the entitlement it represents is enforced against the issuer per the
+  // program terms documented in dividend_stream.md.
+  // -------------------------------------------------------------------------
+  function unilateral(signature holderSig) tapscript {
+    require(older(exit));
+    require(checkSig(holderSig, holderPk));
+  }
+}

--- a/playground/main.js
+++ b/playground/main.js
@@ -32,6 +32,14 @@ const projects = {
             'cash_secured_put.ark': contracts.cash_secured_put,
         }
     },
+    dividend_stream: {
+        name: 'Streaming Dividends',
+        description: 'Corporate dividends that accrue every second: a BTC treasury reserve services per-holder StreamingShare positions whose fixed USD-cent dividend accrues continuously (tx.offchainTime) and pays in sats at an oracle-attested BTC/USD price; transfers and splits carry accrual with them, so record dates disappear',
+        files: {
+            'dividend_treasury.ark': contracts.dividend_treasury,
+            'streaming_share.ark': contracts.streaming_share,
+        }
+    },
     bonds: {
         name: 'Bonds',
         description: "Fixed-maturity bond market with a phased lifecycle: borrowers self-issue 1:1 credit + debit tokens against collateral and sell credit on the order book for USDT (no interest rate); permissionless oracle-priced margin call (pre-maturity, fires when collateralValue < liqThresholdBps × mintedAmount / 10000) keeps every vault thresholded healthy so credit tokens are genuinely fungible; post-maturity auction window settles defaulted collateral; credit holders redeem pro-rata into single-sig wallets",

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -16,6 +16,8 @@ mod compilation_roundtrip;
 mod controlled_mint;
 #[path = "examples/covered_call.rs"]
 mod covered_call;
+#[path = "examples/dividend_stream.rs"]
+mod dividend_stream;
 #[path = "examples/fee_adapter.rs"]
 mod fee_adapter;
 #[path = "examples/fuji_safe.rs"]

--- a/tests/examples/compilation_roundtrip.rs
+++ b/tests/examples/compilation_roundtrip.rs
@@ -172,6 +172,26 @@ fn roundtrip_stability_offer() {
 }
 
 #[test]
+fn roundtrip_dividend_treasury() {
+    let output = compile_example("dividend_stream/dividend_treasury.ark");
+    assert_output_invariants(&output, "dividend_stream/dividend_treasury.ark");
+    assert_eq!(output.name, "DividendTreasury");
+    // 3 covenant groups (topUp, service, recall) + 1 standalone unilateral
+    // exit tapscript = 4 spend groups.
+    assert_eq!(output.functions.len(), 4);
+}
+
+#[test]
+fn roundtrip_streaming_share() {
+    let output = compile_example("dividend_stream/streaming_share.ark");
+    assert_output_invariants(&output, "dividend_stream/streaming_share.ark");
+    assert_eq!(output.name, "StreamingShare");
+    // 3 covenant groups (claim, transfer, split) + 1 standalone unilateral
+    // exit tapscript = 4 spend groups.
+    assert_eq!(output.functions.len(), 4);
+}
+
+#[test]
 fn roundtrip_arkade_kitties() {
     let output = compile_example("arkade_kitties/arkade_kitties.ark");
     assert_output_invariants(&output, "arkade_kitties/arkade_kitties.ark");

--- a/tests/examples/dividend_stream.rs
+++ b/tests/examples/dividend_stream.rs
@@ -1,0 +1,275 @@
+//! Streaming-dividend program: DividendTreasury (reserve hub) + StreamingShare
+//! (per-holder position). Dividends accrue per second in USD cents and pay in
+//! sats at an oracle-attested BTC/USD price; a claim co-spends both contracts.
+
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CAT, OP_CHECKSEQUENCEVERIFY, OP_CHECKSIGFROMSTACK, OP_DIV64, OP_MUL64,
+    OP_PUSHCURRENTINPUTINDEX, OP_SHA256,
+};
+
+use crate::common::{arkade_asm, arkade_asm_tokens, arkade_inputs, group, user_signatures};
+
+const TREASURY_CODE: &str = include_str!("../../examples/dividend_stream/dividend_treasury.ark");
+const SHARE_CODE: &str = include_str!("../../examples/dividend_stream/streaming_share.ark");
+
+const SECONDS_PER_YEAR: &str = "31536000";
+
+#[test]
+fn test_treasury_compiles_with_4_groups() {
+    // topUp, service, recall (covenants) + unilateral (standalone tapscript)
+    let out = compile(TREASURY_CODE).expect("treasury compile");
+    assert_eq!(out.name, "DividendTreasury");
+    assert_eq!(out.functions.len(), 4);
+}
+
+#[test]
+fn test_share_compiles_with_4_groups() {
+    // claim, transfer, split (covenants) + unilateral (standalone tapscript)
+    let out = compile(SHARE_CODE).expect("share compile");
+    assert_eq!(out.name, "StreamingShare");
+    assert_eq!(out.functions.len(), 4);
+}
+
+#[test]
+fn test_claim_paths_verify_oracle_and_cross_input() {
+    // Both halves of the claim tx must verify exactly one oracle attestation
+    // (sha256(ticker || price || time) via 2×OP_CAT + OP_SHA256) and inspect
+    // the sibling input's scriptPubKey via the current-input-index opcode.
+    for (code, fn_name) in [(TREASURY_CODE, "service"), (SHARE_CODE, "claim")] {
+        let out = compile(code).unwrap();
+        let tokens = arkade_asm_tokens(&out, fn_name);
+        let csfs = tokens
+            .iter()
+            .filter(|t| t.as_str() == OP_CHECKSIGFROMSTACK)
+            .count();
+        let cats = tokens.iter().filter(|t| t.as_str() == OP_CAT).count();
+        let shas = tokens.iter().filter(|t| t.as_str() == OP_SHA256).count();
+        assert_eq!(csfs, 1, "{fn_name}: exactly one oracle verification");
+        assert_eq!(cats, 2, "{fn_name}: ticker||price||time needs two OP_CAT");
+        assert_eq!(shas, 1, "{fn_name}: one message digest");
+        let asm = tokens.join(" ");
+        assert!(
+            asm.contains(OP_PUSHCURRENTINPUTINDEX),
+            "{fn_name}: must emit OP_PUSHCURRENTINPUTINDEX for the sibling check"
+        );
+        assert!(
+            asm.contains("OP_INSPECTINPUTSCRIPTPUBKEY"),
+            "{fn_name}: must inspect the co-spent input's scriptPubKey"
+        );
+    }
+}
+
+#[test]
+fn test_accrual_math_normalizes_per_second_and_converts_to_sats() {
+    // accruedCents = units × annualDividendCents × elapsed / 31536000, then
+    // payoutSats = accruedCents × 1e8 / price: at least one multiply and two
+    // divides, with the seconds-per-year constant pushed literally.
+    for (code, fn_name) in [(TREASURY_CODE, "service"), (SHARE_CODE, "claim")] {
+        let out = compile(code).unwrap();
+        let tokens = arkade_asm_tokens(&out, fn_name);
+        let divs = tokens.iter().filter(|t| t.as_str() == OP_DIV64).count();
+        let muls = tokens.iter().filter(|t| t.as_str() == OP_MUL64).count();
+        assert!(divs >= 2, "{fn_name}: year + price divides expected");
+        assert!(muls >= 2, "{fn_name}: units×rate and cents×1e8 expected");
+        assert!(
+            tokens.iter().any(|t| t.as_str() == SECONDS_PER_YEAR),
+            "{fn_name}: must normalize by 31536000 seconds/year"
+        );
+    }
+}
+
+#[test]
+fn test_topup_and_service_are_permissionless() {
+    // topUp takes only `amount`; service authenticates via the co-spent
+    // position (whose claim carries the holder sig) plus the oracle — no
+    // user signature of its own.
+    let out = compile(TREASURY_CODE).unwrap();
+    assert_eq!(
+        arkade_inputs(&out, "topUp"),
+        vec!["amount".to_string()],
+        "topUp must take only `amount`"
+    );
+    assert_eq!(
+        user_signatures(&out, "service"),
+        vec!["oracleSig".to_string()],
+        "service must carry no user signature besides the oracle attestation"
+    );
+}
+
+#[test]
+fn test_recall_is_issuer_gated_and_oracle_free() {
+    let out = compile(TREASURY_CODE).unwrap();
+    assert_eq!(
+        user_signatures(&out, "recall"),
+        vec!["issuerSig".to_string()],
+        "recall must require exactly the issuer signature"
+    );
+    let asm = arkade_asm(&out, "recall");
+    assert!(
+        !asm.contains(OP_CHECKSIGFROMSTACK),
+        "recall must not consult the oracle"
+    );
+}
+
+#[test]
+fn test_claim_requires_holder_sig() {
+    let out = compile(SHARE_CODE).unwrap();
+    assert_eq!(
+        user_signatures(&out, "claim"),
+        vec!["holderSig".to_string(), "oracleSig".to_string()],
+        "claim must carry the holder signature and the oracle attestation"
+    );
+}
+
+#[test]
+fn test_transfer_and_split_are_pure_key_operations() {
+    // No oracle, no cross-input introspection: accrual state carries over
+    // unchanged, which is what makes record dates unnecessary.
+    let out = compile(SHARE_CODE).unwrap();
+    for fn_name in ["transfer", "split"] {
+        let asm = arkade_asm(&out, fn_name);
+        assert!(
+            !asm.contains(OP_CHECKSIGFROMSTACK),
+            "{fn_name}: must not consult the oracle"
+        );
+        assert!(
+            !asm.contains(OP_PUSHCURRENTINPUTINDEX),
+            "{fn_name}: must not inspect sibling inputs"
+        );
+        assert!(
+            !asm.contains(SECONDS_PER_YEAR),
+            "{fn_name}: must not touch accrual math"
+        );
+    }
+}
+
+#[test]
+fn test_service_advances_position_basis_to_now() {
+    // The treasury may only release reserve against a position re-created
+    // with lastClaim = tx.offchainTime — the recreation placeholder must
+    // carry the wallclock, not the stale basis.
+    let out = compile(TREASURY_CODE).unwrap();
+    let asm = arkade_asm(&out, "service");
+    assert!(
+        asm.contains("<VTXO:StreamingShare(<posHolderPk>,<issuerPk>,<oraclePk>,<ticker>,<annualDividendCents>,<posUnits>,<tx.offchainTime>,<exit>)>"),
+        "service must re-create the position with lastClaim advanced to tx.offchainTime"
+    );
+}
+
+#[test]
+fn test_claim_recreates_position_and_pays_holder() {
+    let out = compile(SHARE_CODE).unwrap();
+    let asm = arkade_asm(&out, "claim");
+    assert!(
+        asm.contains("<VTXO:StreamingShare(<holderPk>,<issuerPk>,<oraclePk>,<ticker>,<annualDividendCents>,<units>,<tx.offchainTime>,<exit>)>"),
+        "claim must re-create the position with lastClaim advanced"
+    );
+    assert!(
+        asm.contains("<VTXO:SingleSig(<holderPk>,<exit>)>"),
+        "claim must route the payout to the holder"
+    );
+    assert!(
+        asm.contains("<VTXO:DividendTreasury("),
+        "claim must bind the co-spent input to the genuine treasury"
+    );
+}
+
+#[test]
+fn test_dust_floor_present_in_claim_paths() {
+    for (code, fn_name) in [(TREASURY_CODE, "service"), (SHARE_CODE, "claim")] {
+        let out = compile(code).unwrap();
+        let tokens = arkade_asm_tokens(&out, fn_name);
+        assert!(
+            tokens.iter().any(|t| t.as_str() == "330"),
+            "{fn_name}: 330-sat dust floor must be enforced"
+        );
+    }
+}
+
+#[test]
+fn test_unilateral_exits_are_pure_csv_tapscripts() {
+    for (code, key) in [(TREASURY_CODE, "<issuerPk>"), (SHARE_CODE, "<holderPk>")] {
+        let out = compile(code).unwrap();
+        let g = group(&out, "unilateral");
+        assert!(
+            g.arkade.is_none(),
+            "unilateral must be a standalone tapscript, no covenant"
+        );
+        assert_eq!(g.leaves.len(), 1);
+        let asm = g.leaves[0].asm.join(" ");
+        assert!(
+            asm.contains(OP_CHECKSEQUENCEVERIFY),
+            "unilateral must be CSV-gated"
+        );
+        assert!(asm.contains(key), "unilateral must check the owner key");
+        assert!(
+            !asm.contains("OP_INSPECT"),
+            "unilateral must carry no introspection"
+        );
+    }
+}
+
+#[test]
+fn test_covenant_groups_get_synthesized_cooperative_leaf() {
+    for code in [TREASURY_CODE, SHARE_CODE] {
+        let out = compile(code).unwrap();
+        for g in out.functions.iter().filter(|g| g.arkade.is_some()) {
+            assert_eq!(g.leaves.len(), 1, "{}: one leaf expected", g.name);
+            let leaf = &g.leaves[0];
+            assert!(
+                leaf.witness.iter().all(|w| w.injected),
+                "{}: cooperative leaf witnesses must all be injected",
+                g.name
+            );
+            let asm = leaf.asm.join(" ");
+            assert!(
+                asm.contains("<SERVER_KEY>"),
+                "{}: leaf must include server key",
+                g.name
+            );
+            assert!(
+                asm.contains(&format!("<EMULATOR_KEY:{}>", g.name)),
+                "{}: leaf must include function-tweaked emulator key",
+                g.name
+            );
+        }
+    }
+}
+
+#[test]
+fn test_constructor_schemas_share_program_parameters() {
+    // Both contracts must agree on the program-defining fields so the
+    // cross-input scriptPubKey reconstructions can bind them.
+    let treasury = compile(TREASURY_CODE).unwrap();
+    let share = compile(SHARE_CODE).unwrap();
+    for (name, ty) in [
+        ("issuerPk", "pubkey"),
+        ("oraclePk", "pubkey"),
+        ("ticker", "bytes32"),
+        ("annualDividendCents", "int"),
+        ("exit", "int"),
+    ] {
+        for (label, out) in [("treasury", &treasury), ("share", &share)] {
+            let p = out
+                .parameters
+                .iter()
+                .find(|p| p.name == name)
+                .unwrap_or_else(|| panic!("{label} missing constructor input {name}"));
+            assert_eq!(p.param_type, ty, "{label}.{name}");
+        }
+    }
+    // Role-specific state
+    for name in ["totalUnits", "reserveSats"] {
+        assert!(
+            treasury.parameters.iter().any(|p| p.name == name),
+            "treasury missing {name}"
+        );
+    }
+    for name in ["holderPk", "units", "lastClaim"] {
+        assert!(
+            share.parameters.iter().any(|p| p.name == name),
+            "share missing {name}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a complete streaming-dividend program demonstrating continuous per-second accrual of fixed USD-cent dividends paid in sats at an oracle-attested BTC/USD price. The program consists of two covenants that co-spend in claim transactions: `DividendTreasury` (singleton reserve) and `StreamingShare` (per-holder position).

## Key Changes

- **New contracts:**
  - `examples/dividend_stream/dividend_treasury.ark` — issuer-funded reserve with `topUp` (permissionless), `service` (permissionless claim servicing), `recall` (issuer-gated withdrawal), and CSV unilateral exit
  - `examples/dividend_stream/streaming_share.ark` — per-holder position with `claim` (holder-signed dividend settlement), `transfer` (key swap), `split` (accrual-fair division), and CSV unilateral exit
  - `examples/dividend_stream/dividend_stream.md` — design documentation covering accrual mechanics, claim transaction layout, oracle model, trust model, and relation to other examples

- **New test suite** (`tests/examples/dividend_stream.rs`):
  - Compilation and function count assertions
  - Oracle verification and cross-input introspection validation (OP_CHECKSIGFROMSTACK, OP_CAT, OP_SHA256, OP_PUSHCURRENTINPUTINDEX)
  - Accrual math verification (OP_DIV64, OP_MUL64, seconds-per-year constant)
  - Permission model checks (topUp permissionless, service oracle-only, recall issuer-gated, claim holder-signed)
  - Position basis advancement and payout routing
  - Dust floor enforcement (330 sats)
  - Unilateral exit structure (CSV tapscripts)
  - Cooperative leaf synthesis
  - Constructor schema alignment between treasury and share

- **Integration test updates** (`tests/examples/compilation_roundtrip.rs`):
  - Added roundtrip compilation tests for both contracts

- **Playground registration** (`playground/main.js`):
  - Registered `dividend_stream` project with name and description

- **Test module registration** (`tests/examples.rs`):
  - Added `dividend_stream` module to test suite

## Implementation Details

The program demonstrates several Arkade patterns:
- **Two-contract co-spend:** `service` and `claim` functions in separate contracts verify each other's scriptPubKey via witness-declared state
- **Oracle integration:** Fuji-style signed price feed (sha256(ticker || price || time)) with freshness bounds (600 seconds)
- **Per-second accrual:** Uses `tx.offchainTime` for one-second granularity; accrual formula: `units × annualDividendCents × elapsed / 31536000`
- **Record-date elimination:** `transfer` and `split` preserve `lastClaim`, so accrued-but-unclaimed dividends travel with the position
- **Dust handling:** 330-sat minimum enforced on all outputs; zero-payout claims blocked by `accruedCents > 0` guard
- **Unilateral exits:** Both contracts include CSV-gated tapscript leaves for operator offline recovery
- **Cooperative signing:** Covenant functions synthesize default collaborative leaves with server and emulator keys

The test suite validates the complete specification: oracle attestation paths, accrual math bounds, permission gates, position state advancement, and output routing.

https://claude.ai/code/session_01CmsjJ5rEDp6DE42kvauYD2