### PR TITLE
feat: LVGA payout bridge + stable-value (stability-vault) variant

### DIFF
--- a/examples/bridge/lvga_bridge.md
+++ b/examples/bridge/lvga_bridge.md
@@ -1,0 +1,130 @@
+# LVGA payout bridge (Arkade → SwissLedger) + stable-value option
+
+A merchant-payment bridge-out for wrapped LVGA. Real **LVGA** sits in a
+liquidity pool on **SwissLedger** (an EVM chain); wrapped **wLVGA** — a
+BTC-backed bearer claim — is spent on Arkade to trigger an LVGA payout to a
+merchant. This PR is the productization layer; the general bridging research
+(attested / SPV deposits, HTLC swaps) lives separately.
+
+Contracts:
+
+- [`wlvga_payout.ark`](wlvga_payout.ark) — the Arkade payout leg.
+- [`swissledger_pool.md`](swissledger_pool.md) — spec for the EVM pool
+  contract that automatically releases LVGA (Flavor A).
+- [`../stability/stability_lvga_payout.ark`](../stability/stability_lvga_payout.ark)
+  — the stable-value variant, backing the spending balance with a
+  Bitcoin-collateralized, oracle-marked CHF claim.
+
+## Hard requirement: LVGA is transfer-restricted
+
+Only whitelisted addresses hold LVGA, and it flows one way (pool → merchant):
+**wLVGA can never be redeemed for LVGA.** So wLVGA is *not* a wrapper you
+unwrap — it is a BTC-backed bearer instrument, liquidatable for BTC only. The
+BTC side and the LVGA side are connected solely through the liquidity
+provider's balance sheet, which is why the payout must compensate the LP in
+BTC, not in LVGA.
+
+## `wlvga_payout.ark` — two payout modes
+
+The wLVGA is a claim on the BTC a user locked at mint time. Two roles may be
+**separate parties**: the BTC side (issued wLVGA, holds the BTC backing) and
+the **LVGA liquidity provider (LP)** who funds the pool. A naive burn
+compensates no one, so:
+
+- **`payOut()` — two parties (default).** The wLVGA claim is **transferred to
+  the LP**, not destroyed. The LP releases LVGA on SwissLedger and receives
+  the BTC-backed claim on Arkade (redeemable for BTC, never for LVGA), so the
+  BTC side and the LP can be different entities and the LP stays solvent.
+- **`burnOut()` — same party (option).** The wLVGA is **burned**. Only solvent
+  when the LP is *also* the party that received the BTC at mint time (an
+  integrated market maker). Kept for deployments that are one legal entity.
+
+Both modes:
+
+- **Authorize** the payee with the merchant's secp256k1 key via
+  `checkSigFromStack` over
+  `sha256(protocolTag ‖ merchantEvmAddr ‖ amount ‖ burnNonce)`;
+- **Commit** an OP_RETURN output `protocolTag ‖ merchantEvmAddr ‖ num2bin(amount, 8)`
+  that the SwissLedger pool reads;
+- Bound replay with `burnNonce`.
+
+`merchantPk`/`merchantSig` (pubkey/signature) appear **only** inside
+`checkSigFromStack` — never in a `+` concat — so every hashed/committed field
+is bytes/int and `+` lowers to `OP_CAT`, matching the merchant's off-chain
+signing and the EVM reconstruction byte-for-byte.
+
+**LP economics.** Because LVGA is one-way, the LP is a market maker: per
+payout it gives up **LVGA** (a CHF-pegged position), receives **BTC** via the
+wLVGA claim (hedgeable to USDT), and earns **fees** priced into its quote —
+CHF/BTC exposure for fee income, with the covenant guaranteeing it is paid in
+BTC for every LVGA payout it services.
+
+## One key, two chains
+
+EVM and Bitcoin/Arkade both use **secp256k1**, so a single merchant key is
+verified two ways over the *same* message: `checkSigFromStack` on Arkade and
+`ecrecover` on the SwissLedger pool. The 20-byte `merchantEvmAddr` is committed
+in the OP_RETURN (explicit, auditable payee) and the signature rides the
+witness for the EVM `ecrecover`. See `swissledger_pool.md`.
+
+## Automated release (Flavor A)
+
+The destination pool contract releases LVGA **automatically** on a valid
+report — the operator cannot withhold or redirect a payment. A trusted
+reporter attests the Arkade burn/transfer happened, but the contract's
+`ecrecover` + whitelist + `paid[burnNonce]` checks keep the reporter contained
+to **liveness**, not correctness; with reporter = pool operator it is
+incentive-aligned (a false report drains the operator's own pool for no BTC).
+Full spec, byte layout, and reference Solidity in `swissledger_pool.md`.
+
+## Stable-value payouts (stability-vault fusion)
+
+`wlvga_payout` spends a **BTC-backed** claim — its value floats with BTC
+between mint and spend. For a peg-stable spending balance, fuse the payout
+with a stability vault:
+[`../stability/stability_lvga_payout.ark`](../stability/stability_lvga_payout.ark).
+
+`stability_vault.ark` manufactures a BTC-collateralized, oracle-marked fiat
+claim (seeker holds a fixed target; provider posts collateral and carries the
+price risk; funding compensates them). Point the `ticker` at a **CHF/BTC**
+feed and the claim is synthetic CHF. `StabilityPayout.seekerPayout()` settles
+it *not* to BTC for the seeker but as a **CHF-denominated LVGA payment**:
+
+- funding accrues, the exit fee applies → `payoutCHF`;
+- the merchant invoice is verified (`checkSigFromStack`, mirrored by EVM
+  `ecrecover`) and committed in the OP_RETURN as `payoutCHF`;
+- the seeker's BTC entitlement at the oracle price (`seekerRaw`) goes to the
+  **LP**; the collateral remainder returns to the **provider**.
+
+The same oracle prices both sides, so the merchant receives exactly the
+claim's CHF value regardless of BTC moves during the holding period.
+Crucially this is **where the CHF/BTC exposure lives**: the vault provider
+carries it as a funded, over-collateralized, oracle-marked position — not the
+bridge LP and not the user. Set `lpPk = providerPk` to run both roles as one
+**delta-neutral market maker**; keep them distinct for two independent
+parties.
+
+Net, the full launch flow is a single stable-value rail: **BTC → CHF
+stability-vault claim → LVGA merchant payment**, one oracle, one settlement,
+with price risk isolated in the vault and the destination release automated by
+the SwissLedger pool.
+
+## Trust model
+
+| Property | Where the trust sits |
+|---|---|
+| Payout authorization | On-chain — a valid spend + merchant signature; no quorum signs the release |
+| LP solvency (two-party) | `payOut` transfers the BTC-backed claim to the LP; the LP is paid **in BTC** (LVGA is one-way) — BTC side and LP may differ |
+| Pool liquidity | The SwissLedger pool must hold enough LVGA to service payouts |
+| Release automation | The pool contract releases automatically on a valid report; residual is a **trusted reporter** (Flavor A) — liveness only, contained by `ecrecover`/whitelist/nonce |
+| Price risk (stable variant) | Carried by the **stability-vault provider** (funded, over-collateralized, oracle-marked), not the bridge |
+| Correct payee | `ecrecover` on EVM + the committed `evmAddr`; the merchant key binds both chains |
+
+## Local checks
+
+```bash
+cargo run -- examples/bridge/wlvga_payout.ark -o /tmp/wlvga_payout.json
+cargo run -- examples/stability/stability_lvga_payout.ark -o /tmp/stability_lvga_payout.json
+cargo test --test examples wlvga_payout
+cargo test --test examples stability_lvga_payout
+```

--- a/examples/bridge/swissledger_pool.md
+++ b/examples/bridge/swissledger_pool.md
@@ -1,0 +1,129 @@
+# SwissLedger LVGA Pool — automated payout contract (Flavor A)
+
+The destination-chain counterpart to `wlvga_payout.ark`. It receives reports
+of Arkade wLVGA payouts and **automatically releases LVGA** to the committed
+merchant — no human in the loop, and the pool operator cannot withhold or
+redirect an individual payment. This is the **Flavor A** design: a *trusted
+reporter* attests that the Arkade burn/transfer happened; the contract still
+independently binds the destination, amount, and uniqueness so the reporter
+is trusted for **liveness only**, not for correctness.
+
+This contract is Solidity (it runs on SwissLedger, an EVM chain), so it lives
+here as a spec, not as a compiled `.ark` artifact. The Arkade side
+(`wlvga_payout.ark`) already emits everything below — no Arkade change is
+needed.
+
+## Roles
+
+- **Reporter** — the party that tells the pool an Arkade payout occurred.
+  Natural choice: the **pool operator / Arkade operator** itself, because the
+  Arkade operator already knows the true VTXO state, and a *false* report
+  releases LVGA from the operator's own pool with no BTC received in return —
+  self-harm. So with reporter = pool operator the trust is aligned by
+  incentive and reduces in practice to **"the operator stays online to
+  report"** (censorship/liveness). A third-party reporter should be bonded.
+- **Merchant** — the payee. Authorizes the exact payout with a signature over
+  the payout message; holds a whitelisted LVGA address.
+- **LP / pool operator** — funds the pool with LVGA. Solvency (keeping the
+  pool funded) is theirs; per-payment discretion is removed by this contract.
+
+## What the reporter submits
+
+`release(merchantEvmAddr, amount, burnNonce, merchantSig)` — where
+`merchantEvmAddr` and `amount` are read from the Arkade OP_RETURN commitment,
+and `burnNonce` + `merchantSig` are read from the Arkade spend's witness. (If
+the reporter is not implicitly authorized, add a reporter signature /
+`onlyReporter` guard — the Flavor A trust anchor.)
+
+## Byte layout — must match `wlvga_payout.ark` exactly
+
+The merchant signs the **payout message**, verified on Arkade by
+`checkSigFromStack` and re-derived here for `ecrecover`:
+
+```
+payoutPreimage = protocolTag              (P bytes, fixed)
+              ‖ merchantEvmAddr           (20 bytes)
+              ‖ amount                    (8 bytes, LITTLE-endian)
+              ‖ burnNonce                 (8 bytes, LITTLE-endian)
+payoutMsg      = sha256(payoutPreimage)   (32 bytes)
+```
+
+The Arkade OP_RETURN commitment carries `protocolTag ‖ merchantEvmAddr ‖
+amount(8 LE)` (no `burnNonce`, no hash — it is the raw committed record); the
+reporter supplies `burnNonce` and `merchantSig` alongside it.
+
+Two integration details that will silently break `ecrecover` if missed:
+
+1. **Little-endian ints.** `amount` and `burnNonce` are 8-byte *little-endian*
+   in the preimage (that is how the Arkade `+` concat encodes them). EVM is
+   big-endian natively, so the contract must byte-reverse before packing.
+2. **Signature scheme.** `merchantSig` must be a *recoverable secp256k1 ECDSA*
+   signature over the raw 32-byte `payoutMsg` — **not** an EIP-191
+   (`\x19Ethereum Signed Message`) signature and **not** over a keccak hash.
+   Solidity's `ecrecover` precompile takes an arbitrary 32-byte hash, so
+   `ecrecover(payoutMsg, v, r, s)` recovers the merchant address directly, and
+   the *same* signature is what Arkade's `checkSigFromStack` verifies over the
+   sha256 digest — one key, two chains. (If Arkade's CSFS is Schnorr-only in a
+   given deployment, the merchant instead provides two signatures over the
+   same `payoutMsg`; the binding below is unchanged.)
+
+## On-chain checks (in order)
+
+```solidity
+function release(
+    bytes  calldata protocolTag,     // must equal the pool's configured tag
+    address merchantEvmAddr,
+    uint64  amount,                  // LVGA smallest unit == CHF cents
+    uint64  burnNonce,
+    uint8 v, bytes32 r, bytes32 s    // merchant's recoverable ECDSA sig
+) external onlyReporter {            // (1) Flavor A: trusted reporter attests the Arkade burn
+    require(keccak256(protocolTag) == keccak256(POOL_TAG), "wrong protocol");
+    require(!paid[burnNonce], "already paid");            // (2) replay protection
+
+    // (3) reconstruct the exact Arkade payout message (little-endian ints)
+    bytes32 payoutMsg = sha256(abi.encodePacked(
+        protocolTag,
+        merchantEvmAddr,
+        _le64(amount),
+        _le64(burnNonce)
+    ));
+
+    // (4) the merchant authorized THIS destination + amount + nonce
+    require(ecrecover(payoutMsg, v, r, s) == merchantEvmAddr, "bad merchant sig");
+
+    // (5) LVGA transfer restriction: payee must be whitelisted
+    require(LVGA.isWhitelisted(merchantEvmAddr), "merchant not whitelisted");
+
+    paid[burnNonce] = true;                               // (6) mark + pay
+    LVGA.transfer(merchantEvmAddr, amount);
+}
+```
+
+`_le64` packs a `uint64` as 8 little-endian bytes to match the Arkade preimage.
+
+## Trust model (honest)
+
+| Concern | Who / what | Note |
+|---|---|---|
+| "Did an Arkade payout really happen?" | **Trusted reporter** (Flavor A) | The only real trust. With reporter = pool operator it is incentive-aligned (a false report drains the operator's own pool for no BTC) and reduces to liveness. Bond a third-party reporter. |
+| Redirecting a payment | **Blocked** | `ecrecover` ties the payout to the merchant-signed `merchantEvmAddr`; the reporter cannot change the payee. |
+| Forging amount / double-pay | **Blocked** | `amount`/`burnNonce` are inside the merchant-signed message; `paid[burnNonce]` stops replays. |
+| Paying a non-compliant address | **Blocked** | LVGA whitelist check. |
+| Censorship / withholding | **Residual** | A silent reporter can stall a payout (liveness). Mitigate with multiple/permissionless reporters — anyone, including the merchant, can submit if the guard allows. |
+| Pool solvency | **LP** | The pool must hold LVGA; automation removes per-payment discretion, not the need to fund. |
+
+**Versus Flavor B (SPV-verified).** Flavor A trusts the reporter to attest
+the burn; Flavor B would replace `onlyReporter` with an on-EVM Bitcoin SPV
+proof of the burn tx (a BTC-Relay-style light client), removing that trust at
+the cost of a heavy verifier and Bitcoin-settlement latency. Because LVGA is
+already a permissioned/regulated token with a known operator, Flavor A's
+trusted-reporter model is consistent with the existing trust surface; the
+`ecrecover`/whitelist/nonce checks keep the reporter contained to liveness.
+
+## End-to-end recap
+
+1. `wlvga_payout.ark` `payOut()` — merchant-authorized (CSFS), transfers the
+   BTC-backed wLVGA claim to the LP, pins the OP_RETURN commitment.
+2. Reporter observes the Arkade spend, calls `release(...)` here.
+3. This contract binds destination/amount/uniqueness and transfers real LVGA
+   to the whitelisted merchant — automatically.

--- a/examples/bridge/wlvga_payout.ark
+++ b/examples/bridge/wlvga_payout.ark
@@ -1,0 +1,136 @@
+// wLVGA Payout — bridge-OUT (Arkade → SwissLedger)
+//
+// A merchant-payment bridge-out for wrapped LVGA. Real LVGA lives in a
+// liquidity pool on SwissLedger (an EVM chain); wLVGA is a BTC-backed claim
+// issued on Arkade (a user pays BTC → gets wLVGA). To pay a merchant in real
+// LVGA, the wLVGA is spent on Arkade with a commitment naming the merchant,
+// and the SwissLedger pool contract reads that commitment and releases LVGA.
+//
+// HARD REQUIREMENT — LVGA is a TRANSFER-RESTRICTED token: wLVGA can NEVER be
+// redeemed for real LVGA (only whitelisted addresses hold LVGA, and payouts
+// flow one way, pool → merchant). So wLVGA is purely a BTC-backed BEARER
+// claim; it is liquidatable for BTC, not for LVGA. The BTC side and the LVGA
+// side are linked only through the LP's balance sheet.
+//
+// CLOSING THE LOOP — who is paid for the released LVGA. The wLVGA is a claim
+// on the BTC a user locked at mint time. Two roles can be separate parties:
+//   - the BTC side (whoever issued the wLVGA and holds the BTC backing), and
+//   - the LVGA liquidity provider (LP) who funds the SwissLedger pool.
+// If they are separate, the LP must be compensated for the LVGA it releases
+// or it bleeds out. The LP is a market maker: it releases LVGA (a CHF-pegged
+// position) and receives the BTC-backed wLVGA claim (hedgeable to USDT), plus
+// fees priced into its quote — i.e. it takes CHF/BTC exposure for fee income.
+// This contract offers two payout modes:
+//
+//   payOut()  (default, TWO parties): the wLVGA is TRANSFERRED to the LP,
+//             not destroyed. The LP receives the BTC-backed claim (redeemable
+//             for BTC, never for LVGA), so releasing LVGA on SwissLedger is
+//             matched by receiving BTC value on Arkade — the loop is closed
+//             and the BTC side and the LP may be different parties.
+//
+//   burnOut() (option, SAME party): the wLVGA is BURNED. This is only
+//             solvent when the LP is also the party that received the BTC at
+//             mint time (an integrated market maker), because a burn
+//             compensates no one. Kept for deployments where that is legally
+//             and operationally a single entity.
+//
+// Both modes commit (protocolTag ‖ merchantEvmAddr ‖ amount) in an OP_RETURN
+// and authorize the payee with the merchant's secp256k1 key via
+// OP_CHECKSIGFROMSTACK — mirrored on SwissLedger by ecrecover over the same
+// message (one key, two chains; see README). Residual trust in both modes is
+// that the pool/LP honors the release; the two-party mode fixes SOLVENCY
+// (the LP is paid), not release-liveness (use a bonded/permissioned LP, or
+// the trustless swap_htlc.ark route when a live counterparty is available).
+//
+// Types: merchantPk/merchantSig appear ONLY inside checkSigFromStack — never
+// in a `+` concat — so every hashed/committed field is bytes/int and `+`
+// lowers to OP_CAT, matching the merchant's off-chain signing and the EVM
+// reconstruction byte-for-byte. Replay is bounded by burnNonce.
+
+import "single_sig.ark";
+
+contract WlvgaPayout(
+  // wrapped LVGA asset (a BTC-backed claim) issued on Arkade
+  bytes32 tokenAssetIdTxid,
+  int     tokenAssetIdGidx,
+  // Arkade key of the LVGA liquidity provider who funds the SwissLedger pool;
+  // receives the wLVGA claim as compensation in the two-party payOut() mode
+  pubkey  lpPk,
+  // domain/protocol tag prefixing the signed message and the commitment
+  bytes   protocolTag,
+  int     exit
+) {
+  // TWO-PARTY payout (default): transfer the wLVGA claim to the LP, commit
+  // the merchant payout for the SwissLedger pool. The LP is compensated by
+  // receiving the BTC-backed wLVGA, so the BTC side and the LP may differ.
+  //
+  // Transaction layout:
+  //   input[0]:  wLVGA being spent
+  //   output[0]: wLVGA → LP (SingleSig(lpPk))            compensation
+  //   output[commitIndex]: OP_RETURN commitment          merchant payout
+  function payOut(
+    int       amount,
+    bytes     merchantEvmAddr,
+    pubkey    merchantPk,
+    signature merchantSig,
+    int       burnNonce,
+    int       commitIndex
+  ) {
+    require(amount > 0, "zero payout");
+    require(size(merchantEvmAddr) == 20, "bad evm address");
+
+    let payoutMsg = sha256(protocolTag + merchantEvmAddr + amount + burnNonce);
+    require(
+      checkSigFromStack(merchantSig, merchantPk, payoutMsg),
+      "bad merchant sig"
+    );
+
+    // Compensate the LP: the wLVGA claim moves to them (not burned).
+    require(
+      tx.outputs[0].scriptPubKey == new SingleSig(lpPk, exit),
+      "payout not to lp"
+    );
+    require(
+      tx.outputs[0].assets.lookup(tokenAssetIdTxid, tokenAssetIdGidx) >= amount,
+      "lp claim short"
+    );
+
+    // Commitment the SwissLedger pool reads.
+    let commitment = protocolTag + merchantEvmAddr + num2bin(amount, 8);
+    require(
+      tx.outputs[commitIndex].scriptPubKey == commitment,
+      "missing payout commitment"
+    );
+  }
+
+  // SAME-PARTY payout (option): burn the wLVGA. Only solvent when the LP also
+  // received the BTC at mint time (integrated market maker) — a burn
+  // compensates no one on its own.
+  function burnOut(
+    int       amount,
+    bytes     merchantEvmAddr,
+    pubkey    merchantPk,
+    signature merchantSig,
+    int       burnNonce,
+    int       commitIndex
+  ) {
+    require(amount > 0, "zero payout");
+    require(size(merchantEvmAddr) == 20, "bad evm address");
+
+    let payoutMsg = sha256(protocolTag + merchantEvmAddr + amount + burnNonce);
+    require(
+      checkSigFromStack(merchantSig, merchantPk, payoutMsg),
+      "bad merchant sig"
+    );
+
+    // Burn: wLVGA supply shrinks by exactly `amount`.
+    let g = tx.assetGroups.find(tokenAssetIdTxid, tokenAssetIdGidx);
+    require(g.sumInputs >= g.sumOutputs + amount, "burn short");
+
+    let commitment = protocolTag + merchantEvmAddr + num2bin(amount, 8);
+    require(
+      tx.outputs[commitIndex].scriptPubKey == commitment,
+      "missing payout commitment"
+    );
+  }
+}

--- a/examples/stability/stability_lvga_payout.ark
+++ b/examples/stability/stability_lvga_payout.ark
@@ -1,0 +1,123 @@
+// StabilityPayout — CHF-stable vault settled directly as an LVGA payment
+//
+// The capstone that fuses two pieces:
+//   - the StabilityVault settlement (examples/stability/stability_vault.ark):
+//     a BTC-collateralized claim denominated in a fiat unit, marked to an
+//     oracle-signed price, with a provider taking the BTC price risk and
+//     funding compensating them; and
+//   - the wLVGA payout bridge-out (examples/bridge/wlvga_payout.ark): pay a
+//     merchant real LVGA on SwissLedger via an OP_RETURN commitment the pool
+//     reads (settled automatically — see examples/bridge/swissledger_pool.md).
+//
+// Point the vault's `ticker` at a CHF/BTC feed and the seeker's claim is a
+// synthetic, Bitcoin-collateralized CHF position. `seekerPayout()` settles
+// that claim NOT to BTC for the seeker, but as a CHF-denominated LVGA payment
+// to a merchant: the seeker's BTC entitlement goes to the LVGA liquidity
+// provider (LP) as compensation, and the committed CHF amount is released to
+// the merchant by the SwissLedger pool. One oracle prices both sides, so the
+// merchant receives exactly the claim's CHF value regardless of BTC moves
+// during the holding period.
+//
+// Where the exposure lives (the point of combining):
+//   - The PROVIDER carries BTC price risk (funded, over-collateralized,
+//     oracle-marked) — a managed vault position, not naked bridge risk.
+//   - The LP sources LVGA and receives the seeker's BTC at the oracle price
+//     at settlement, so its CHF↔BTC leg is locked at that instant.
+//   - Set lpPk = providerPk to run BOTH as one delta-neutral market maker
+//     (long BTC collateral hedged by short CHF/LVGA released; funding + fees
+//     as income). Keep them distinct for two independent parties.
+//
+// LVGA is transfer-restricted: wLVGA/CHF is never redeemed for LVGA; the
+// merchant address must be whitelisted by the pool. The merchant signs an
+// invoice (checkSigFromStack here, ecrecover on SwissLedger — one secp256k1
+// key, two chains). Replay is bounded by burnNonce.
+
+import "single_sig.ark";
+
+contract StabilityPayout(
+  pubkey  seekerPk,           // holder of the CHF claim (the payer)
+  pubkey  providerPk,         // collateral provider; carries the BTC long
+  pubkey  oraclePk,           // CHF/BTC price feed signer
+  bytes32 ticker,             // feed id, e.g. sha256("CHF/BTC")
+  pubkey  lpPk,               // LVGA LP; receives the seeker's settled BTC
+  bytes   protocolTag,        // OP_RETURN / invoice domain tag
+  int     targetCHF,          // seeker's CHF claim in cents; accrues funding
+  int     totalCollateral,    // sats locked
+  int     fundingRatePerSec,  // signed fixed-point at scale 1e12
+  int     lastUpdate,         // unix seconds; funding basis
+  int     seekerExitFee,      // basis points (1e4) charged on payout
+  int     exit                // exit timelock in blocks
+) {
+  // Settle the CHF claim as an LVGA merchant payment.
+  //
+  // Transaction layout (seekerRaw < totalCollateral):
+  //   output[0]:            seekerRaw sats → LP        (LP compensation)
+  //   output[1]:            remainder     → provider   (if > 330)
+  //   output[commitIndex]:  OP_RETURN commitment       (merchant LVGA payout)
+  function seekerPayout(
+    signature seekerSig,
+    bytes     merchantEvmAddr,
+    pubkey    merchantPk,
+    signature merchantSig,
+    int       burnNonce,
+    int       commitIndex,
+    int       oraclePrice,
+    int       oracleTime,
+    signature oracleSig
+  ) {
+    require(checkSig(seekerSig, seekerPk), "invalid seeker sig");
+    require(size(merchantEvmAddr) == 20, "bad evm address");
+    require(oraclePrice > 0, "invalid oracle price");
+
+    // Oracle freshness + signature over the CHF/BTC feed.
+    int oracleAge = tx.offchainTime - oracleTime;
+    require(oracleAge >= 0, "future-dated oracle");
+    require(oracleAge <= 600, "stale oracle");
+    let oracleMsg = sha256(ticker + oraclePrice + oracleTime);
+    require(checkSigFromStack(oracleSig, oraclePk, oracleMsg), "invalid oracle signature");
+
+    // Funding accrual → net CHF the seeker spends (after the exit fee).
+    int elapsed           = tx.offchainTime - lastUpdate;
+    require(elapsed >= 0, "clock regression");
+    int rateElapsedScaled = fundingRatePerSec * elapsed / 1000000;
+    int delta             = targetCHF * rateElapsedScaled / 1000000;
+    int newTargetCHF      = targetCHF + delta;
+    int payoutCHF         = newTargetCHF * (10000 - seekerExitFee) / 10000;
+    require(payoutCHF > 0, "claim wiped; use provider exit");
+
+    // Merchant invoice: same message the SwissLedger pool ecrecovers.
+    let payoutMsg = sha256(protocolTag + merchantEvmAddr + payoutCHF + burnNonce);
+    require(checkSigFromStack(merchantSig, merchantPk, payoutMsg), "bad merchant invoice");
+
+    // Seeker's BTC entitlement at the oracle price → the LP.
+    int seekerRaw = payoutCHF * 100000000 / oraclePrice;
+    require(seekerRaw > 0, "dust payout");
+
+    // Commitment the SwissLedger pool reads to release `payoutCHF` LVGA.
+    let commitment = protocolTag + merchantEvmAddr + num2bin(payoutCHF, 8);
+    require(tx.outputs[commitIndex].scriptPubKey == commitment, "missing commitment");
+
+    if (seekerRaw >= totalCollateral) {
+      // Provider fully drawn down: all collateral compensates the LP.
+      require(tx.outputs[0].value >= totalCollateral, "lp underpaid");
+      require(tx.outputs[0].scriptPubKey == new SingleSig(lpPk, exit), "output 0 not lp");
+    } else {
+      require(tx.outputs[0].value >= seekerRaw, "lp underpaid");
+      require(tx.outputs[0].scriptPubKey == new SingleSig(lpPk, exit), "output 0 not lp");
+      int providerPayout = totalCollateral - seekerRaw;
+      if (providerPayout > 330) {
+        require(tx.outputs[1].value >= providerPayout, "provider underpaid");
+        require(tx.outputs[1].scriptPubKey == new SingleSig(providerPk, exit), "output 1 not provider");
+      }
+    }
+  }
+
+  // Unilateral exit (CSV): seeker recovers the claim's collateral if the
+  // Arkade operator is offline. Full vault lifecycle (funding updates,
+  // add/remove capital, provider exit, transfer/split/merge) lives in
+  // stability_vault.ark; this variant focuses on the payout fusion.
+  function unilateral(signature seekerSig) tapscript {
+    require(older(exit));
+    require(checkSig(seekerSig, seekerPk));
+  }
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -26,9 +26,13 @@ mod htlc;
 mod layerzero;
 #[path = "examples/repayment_pool.rs"]
 mod repayment_pool;
+#[path = "examples/stability_lvga_payout.rs"]
+mod stability_lvga_payout;
 #[path = "examples/stability_vault.rs"]
 mod stability_vault;
 #[path = "examples/threshold_oracle.rs"]
 mod threshold_oracle;
 #[path = "examples/token_vault.rs"]
 mod token_vault;
+#[path = "examples/wlvga_payout.rs"]
+mod wlvga_payout;

--- a/tests/examples/stability_lvga_payout.rs
+++ b/tests/examples/stability_lvga_payout.rs
@@ -1,0 +1,82 @@
+//! StabilityPayout tests — the stability-vault + LVGA-payout fusion.
+//!
+//! `seekerPayout` settles an oracle-priced CHF claim as a merchant LVGA
+//! payment: the seeker's BTC entitlement goes to the LP, and an OP_RETURN
+//! commitment authorizes the SwissLedger pool release.
+
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CAT, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_NUM2BIN, OP_SHA256,
+};
+
+use crate::common::{arkade_asm, arkade_asm_tokens};
+
+const CODE: &str = include_str!("../../examples/stability/stability_lvga_payout.ark");
+
+#[test]
+fn test_structure() {
+    let output = compile(CODE).unwrap();
+    assert_eq!(output.name, "StabilityPayout");
+    // seekerPayout (function-backed) + unilateral (standalone tapscript).
+    assert_eq!(output.functions.len(), 2);
+    let names: Vec<&str> = output.functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"seekerPayout"), "Got: {names:?}");
+    assert!(names.contains(&"unilateral"), "Got: {names:?}");
+}
+
+#[test]
+fn test_two_signature_checks_oracle_and_merchant() {
+    // Oracle price feed AND merchant invoice are both verified with
+    // checkSigFromStack; the seeker authorizes the spend with a plain checkSig.
+    let output = compile(CODE).unwrap();
+    let tokens = arkade_asm_tokens(&output, "seekerPayout");
+    let csfs = tokens.iter().filter(|s| *s == OP_CHECKSIGFROMSTACK).count();
+    assert_eq!(csfs, 2, "expected oracle + merchant CSFS, got {csfs}");
+    let asm = arkade_asm(&output, "seekerPayout");
+    assert!(
+        asm.contains(OP_CHECKSIG),
+        "seeker must authorize with checkSig: {asm}"
+    );
+    assert!(
+        asm.contains(OP_SHA256),
+        "oracle + invoice messages are hashed: {asm}"
+    );
+}
+
+#[test]
+fn test_seeker_btc_goes_to_lp() {
+    // The settled BTC is pinned to the LP (compensation), not to the seeker.
+    let output = compile(CODE).unwrap();
+    let asm = arkade_asm(&output, "seekerPayout");
+    assert!(
+        asm.contains("<VTXO:SingleSig(<lpPk>"),
+        "seeker's settled BTC must be pinned to the LP: {asm}"
+    );
+    assert!(
+        asm.contains("<VTXO:SingleSig(<providerPk>"),
+        "collateral remainder must be pinned to the provider: {asm}"
+    );
+    assert!(
+        !asm.contains("<VTXO:SingleSig(<seekerPk>"),
+        "the seeker is paying out, not receiving BTC here: {asm}"
+    );
+}
+
+#[test]
+fn test_pins_opreturn_commitment() {
+    let output = compile(CODE).unwrap();
+    let asm = arkade_asm(&output, "seekerPayout");
+    assert!(
+        asm.contains(OP_INSPECTOUTPUTSCRIPTPUBKEY) && asm.contains(OP_NUM2BIN),
+        "the LVGA payout commitment must be pinned with a fixed-width CHF amount: {asm}"
+    );
+    // Oracle message (2 CATs) + invoice message (3) + commitment (2) = 7.
+    let cats = arkade_asm_tokens(&output, "seekerPayout")
+        .iter()
+        .filter(|s| *s == OP_CAT)
+        .count();
+    assert_eq!(
+        cats, 7,
+        "expected 7 {OP_CAT} across oracle/invoice/commitment, got {cats}"
+    );
+}

--- a/tests/examples/wlvga_payout.rs
+++ b/tests/examples/wlvga_payout.rs
@@ -1,0 +1,100 @@
+//! WlvgaPayout tests — bridge-out (two-party transfer + same-party burn).
+//!
+//! `payOut` transfers the BTC-backed wLVGA claim to the LVGA liquidity
+//! provider (two distinct parties); `burnOut` destroys it (integrated
+//! market maker). Both authorize the payee with a merchant secp256k1 key via
+//! checkSigFromStack (mirrored by ecrecover on the SwissLedger pool) and pin
+//! an OP_RETURN commitment the pool reads.
+
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CAT, OP_CHECKSIGFROMSTACK, OP_FINDASSETGROUPBYASSETID, OP_INSPECTASSETGROUPSUM,
+    OP_INSPECTOUTASSETLOOKUP, OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_NUM2BIN, OP_SHA256,
+};
+
+use crate::common::{arkade_asm, arkade_asm_tokens};
+
+const CODE: &str = include_str!("../../examples/bridge/wlvga_payout.ark");
+
+#[test]
+fn test_structure() {
+    let output = compile(CODE).unwrap();
+    assert_eq!(output.name, "WlvgaPayout");
+    // Two covenant modes: payOut (two parties) + burnOut (integrated).
+    assert_eq!(output.functions.len(), 2);
+    let names: Vec<&str> = output.functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(names.contains(&"payOut"), "Got: {names:?}");
+    assert!(names.contains(&"burnOut"), "Got: {names:?}");
+}
+
+#[test]
+fn test_payout_transfers_claim_to_lp() {
+    // Two-party mode: the BTC-backed wLVGA claim is transferred to the LP
+    // (compensation), NOT burned — so no supply-shrinking burn accounting.
+    let output = compile(CODE).unwrap();
+    let asm = arkade_asm(&output, "payOut");
+    assert!(
+        asm.contains("<VTXO:SingleSig(<lpPk>"),
+        "wLVGA claim must be transferred to the LP: {asm}"
+    );
+    assert!(
+        asm.contains(OP_INSPECTOUTASSETLOOKUP),
+        "LP output must carry the wLVGA amount: {asm}"
+    );
+    assert!(
+        !asm.contains(OP_INSPECTASSETGROUPSUM),
+        "payOut transfers (not burns), so no supply-shrink accounting: {asm}"
+    );
+}
+
+#[test]
+fn test_burnout_shrinks_supply() {
+    // Same-party option: the wLVGA is burned (supply shrinks).
+    let output = compile(CODE).unwrap();
+    let asm = arkade_asm(&output, "burnOut");
+    assert!(
+        asm.contains(OP_FINDASSETGROUPBYASSETID) && asm.contains(OP_INSPECTASSETGROUPSUM),
+        "burn must be accounted via asset-group sums: {asm}"
+    );
+    assert!(
+        !asm.contains("<VTXO:SingleSig(<lpPk>"),
+        "burnOut destroys the claim; it does not transfer to the LP: {asm}"
+    );
+}
+
+#[test]
+fn test_merchant_csfs_and_concat() {
+    // Both modes authorize the payee with CSFS over a byte-CONCATENATED
+    // message (OP_CAT, not arithmetic OP_ADD), so the digest matches the
+    // merchant's off-chain signature and the EVM ecrecover reconstruction.
+    let output = compile(CODE).unwrap();
+    for mode in ["payOut", "burnOut"] {
+        let asm = arkade_asm(&output, mode);
+        assert!(
+            asm.contains(OP_CHECKSIGFROMSTACK) && asm.contains(OP_SHA256),
+            "{mode}: merchant authorization must be CSFS over a hash: {asm}"
+        );
+        let cats = arkade_asm_tokens(&output, mode)
+            .iter()
+            .filter(|s| *s == OP_CAT)
+            .count();
+        assert_eq!(
+            cats, 5,
+            "{mode}: expected 5 {OP_CAT} (message + commitment), got {cats}"
+        );
+    }
+}
+
+#[test]
+fn test_pins_opreturn_commitment() {
+    // Both modes pin the commitment the SwissLedger pool reads, built as
+    // protocolTag || evmAddr || num2bin(amount, 8).
+    let output = compile(CODE).unwrap();
+    for mode in ["payOut", "burnOut"] {
+        let asm = arkade_asm(&output, mode);
+        assert!(
+            asm.contains(OP_INSPECTOUTPUTSCRIPTPUBKEY) && asm.contains(OP_NUM2BIN),
+            "{mode}: commitment output must be pinned with a fixed-width amount: {asm}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The LVGA productization layer of the cross-chain bridging work: a merchant-payment **bridge-out** from Arkade to a SwissLedger (EVM) LVGA liquidity pool, plus a **stable-value** variant that backs the spending balance with a Bitcoin-collateralized, oracle-marked CHF claim.

Split out from the general bridge research (#56) so this PR is just the LVGA-specific pieces. Depends on nothing from #56 — the contracts use only primitives already on `master`.

## Contracts

- **`examples/bridge/wlvga_payout.ark` (`WlvgaPayout`)** — the Arkade payout leg, two modes:
  - `payOut()` (two parties, default) — **transfer** the BTC-backed wLVGA claim to the LVGA liquidity provider (LP), so the LP is compensated **in BTC** for the LVGA it releases. LVGA is transfer-restricted / one-way (never redeemed for wLVGA), so the BTC side and the LP can be distinct entities.
  - `burnOut()` (same party) — **burn** the wLVGA; only solvent when the LP also received the BTC at mint (integrated market maker).
  - Both authorize the payee with the merchant's secp256k1 key via `checkSigFromStack` (mirrored by `ecrecover` on the pool) and pin an OP_RETURN commitment `protocolTag ‖ merchantEvmAddr ‖ num2bin(amount, 8)`; replay bounded by `burnNonce`.

- **`examples/bridge/swissledger_pool.md`** — spec for the EVM pool contract that **auto-releases** LVGA (Flavor A: a trusted reporter attests the burn; `ecrecover` + whitelist + `paid[nonce]` keep it contained to liveness, not correctness). Includes byte layout, the little-endian / recoverable-ECDSA integration notes, and a reference Solidity sketch.

- **`examples/stability/stability_lvga_payout.ark` (`StabilityPayout`)** — stable-value variant. `seekerPayout()` settles a BTC-collateralized, oracle-marked CHF claim directly as a merchant LVGA payment: verifies the CHF/BTC oracle price and the merchant invoice, routes the seeker's BTC entitlement to the LP, and commits `payoutCHF`. The merchant receives a stable amount regardless of BTC moves; price risk sits with the vault provider, not the bridge. Set `lpPk = providerPk` for a single delta-neutral market maker.

- **`examples/bridge/lvga_bridge.md`** — overview doc tying the flow together.

## Design notes

- **One key, two chains.** A single merchant secp256k1 key is verified by `checkSigFromStack` on Arkade and `ecrecover` on the EVM pool over the same message.
- **Correct economics for transfer-restricted LVGA.** LVGA never round-trips, so the LP's compensation is the BTC-backed claim (`payOut` transfer), and the CHF/BTC exposure is isolated in the stability vault's funded provider role — not dumped on the bridge or the user.
- `pubkey`/`signature` stay strictly inside `checkSigFromStack`, so hashed/committed fields concat via `OP_CAT` and the digest matches off-chain signing and the EVM reconstruction byte-for-byte.

## Testing

- `tests/examples/wlvga_payout.rs` (5) + `tests/examples/stability_lvga_payout.rs` (4).
- `cargo fmt --check` clean; full examples suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ttf3oxgKCxBsYWJrQYfUfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ttf3oxgKCxBsYWJrQYfUfE)_