### PR TITLE
Add payment hold contracts with authorize-and-capture flow

### DIFF
--- a/examples/payment_hold/asset_payment_hold.ark
+++ b/examples/payment_hold/asset_payment_hold.ark
@@ -1,0 +1,92 @@
+// Asset Payment Hold Contract (authorize and capture, asset denominated)
+// Same gas-pump flow as payment_hold.ark, but the hold is an Arkade asset
+// amount (e.g. 100 units of a USD stable asset) riding on the VTXO:
+//
+// 1. Authorize: customer funds this covenant with the asset hold.
+// 2. Capture: merchant takes the metered asset amount (witness value, up to
+//    the hold); the remaining asset units return to the customer.
+// 3. Void: merchant returns the full hold to the customer immediately.
+// 4. Refund: after releaseBlockHeight anyone can return the hold — the
+//    automatic release if the merchant never charges.
+//
+// Processor fee routing is omitted here to keep the asset mechanics in
+// focus; see payment_hold.ark for basis-point fee handling.
+
+contract AssetPaymentHold(
+  // Asset ID of the held asset (txid, group index)
+  bytes32 assetIdTxid,
+  int assetIdGidx,
+
+  // Output scripts (P2TR scriptPubKeys)
+  bytes merchantScript,
+  bytes customerScript,
+
+  // Auto-release timelock (block height)
+  int releaseBlockHeight,
+
+  // Capture/void authorization key
+  pubkey merchantPubkey,
+
+  // Exit timelock in blocks
+  int exit
+) {
+
+  // Capture: merchant takes captureAmount of the held asset; the remainder
+  // returns to the customer. Output count is pinned, so the merchant cannot
+  // attach own change outputs; relax when merchant-funded fees are needed.
+  function capture(int captureAmount, signature merchantSig) {
+    require(checkSig(merchantSig, merchantPubkey), "invalid merchant signature");
+    require(this.activeInputIndex == 0, "hold must be input 0");
+
+    int heldAssets = tx.inputs[0].assets.lookup(assetIdTxid, assetIdGidx);
+    require(captureAmount > 0, "zero capture");
+    require(captureAmount <= heldAssets, "capture exceeds hold");
+
+    require(tx.outputs[0].scriptPubKey == merchantScript, "merchant script incorrect");
+    require(tx.outputs[0].assets.lookup(assetIdTxid, assetIdGidx) == captureAmount, "merchant asset amount incorrect");
+    require(tx.outputs[0].value >= 330, "merchant output below dust");
+
+    int changeAssets = heldAssets - captureAmount;
+    if (changeAssets > 0) {
+      require(tx.numOutputs == 2, "expected 2 outputs for partial capture");
+      require(tx.outputs[1].scriptPubKey == customerScript, "change script incorrect");
+      require(tx.outputs[1].assets.lookup(assetIdTxid, assetIdGidx) == changeAssets, "change asset amount incorrect");
+      require(tx.outputs[1].value >= 330, "change output below dust");
+    } else {
+      require(tx.numOutputs == 1, "expected 1 output for full capture");
+    }
+  }
+
+  // Void: merchant cancels the authorization; the full asset hold and the
+  // riding sats return to the customer without waiting for the timelock.
+  function void(signature merchantSig) {
+    require(checkSig(merchantSig, merchantPubkey), "invalid merchant signature");
+    require(this.activeInputIndex == 0, "hold must be input 0");
+
+    int heldAssets = tx.inputs[0].assets.lookup(assetIdTxid, assetIdGidx);
+    require(tx.numOutputs == 1, "expected 1 output for void");
+    require(tx.outputs[0].scriptPubKey == customerScript, "release script incorrect");
+    require(tx.outputs[0].assets.lookup(assetIdTxid, assetIdGidx) == heldAssets, "release asset amount incorrect");
+    require(tx.outputs[0].value >= tx.inputs[0].value, "riding sats not returned");
+  }
+
+  // Refund: timelocked automatic release back to the customer.
+  function refund() {
+    require(tx.time >= releaseBlockHeight, "release timelock not reached");
+    require(this.activeInputIndex == 0, "hold must be input 0");
+
+    int heldAssets = tx.inputs[0].assets.lookup(assetIdTxid, assetIdGidx);
+    require(tx.numOutputs == 1, "expected 1 output for refund");
+    require(tx.outputs[0].scriptPubKey == customerScript, "refund script incorrect");
+    require(tx.outputs[0].assets.lookup(assetIdTxid, assetIdGidx) == heldAssets, "refund asset amount incorrect");
+    require(tx.outputs[0].value >= tx.inputs[0].value, "riding sats not returned");
+  }
+
+  // Unilateral exit (CSV): merchant reclaims after the CSV delay.
+  // Note: customer's exit is via the refund path above; no single customer
+  // pubkey exists.
+  function unilateral(signature merchantSig) tapscript {
+    require(older(exit));
+    require(checkSig(merchantSig, merchantPubkey));
+  }
+}

--- a/examples/payment_hold/payment_hold.ark
+++ b/examples/payment_hold/payment_hold.ark
@@ -1,0 +1,124 @@
+// Payment Hold Contract (authorize and capture)
+// Gas-pump style card payment over a BTC hold:
+//
+// 1. Authorize: customer taps and funds this covenant with the hold amount
+//    (e.g. 100 000 sats before fueling starts). The funded VTXO value IS the
+//    hold; no separate amount parameter is needed.
+// 2. Capture: merchant settles the actual amount — chosen at capture time as
+//    a witness value, up to the hold — minus the processor fee. The unused
+//    remainder returns to the customer as change.
+// 3. Void: merchant cancels the authorization and returns the full hold to
+//    the customer immediately.
+// 4. Refund: after releaseBlockHeight anyone can return the hold to the
+//    customer — the automatic release if the merchant never charges.
+//
+// Unlike payment_auth.ark, the settled amount is not fixed at authorization
+// time: capture takes it as a witness, so one covenant covers any final
+// charge up to the hold.
+
+contract PaymentHold(
+  // Processor fee in basis points of the captured amount
+  int feeRateBasisPoints,
+
+  // Output scripts (P2TR scriptPubKeys)
+  bytes merchantScript,
+  bytes processorScript,
+  bytes customerScript,
+
+  // Auto-release timelock (block height)
+  int releaseBlockHeight,
+
+  // Capture/void authorization key
+  pubkey merchantPubkey,
+
+  // Exit timelock in blocks
+  int exit
+) {
+
+  // Capture: merchant-authorized settlement of captureAmount <= hold.
+  // Sub-dust fee or change is routed into the merchant payout because a
+  // sub-330-sat Taproot output is not viable.
+  function capture(int captureAmount, signature merchantSig) {
+    require(checkSig(merchantSig, merchantPubkey), "invalid merchant signature");
+
+    let held = tx.input.current.value;
+    require(captureAmount > 330, "capture below dust");
+    require(captureAmount <= held, "capture exceeds hold");
+    // 21 000 BTC ceiling keeps captureAmount * feeRateBasisPoints inside i64
+    require(captureAmount <= 2100000000000, "capture too large");
+    require(feeRateBasisPoints >= 0, "negative fee rate");
+    require(feeRateBasisPoints <= 10000, "fee rate > 100%");
+
+    int processorFee = captureAmount * feeRateBasisPoints / 10000;
+    int merchantAmount = captureAmount - processorFee;
+    require(merchantAmount > 330, "merchant payout below dust");
+    int change = held - captureAmount;
+
+    if (processorFee > 330) {
+      if (change > 330) {
+        // Full split: merchant + processor + customer change
+        require(tx.numOutputs == 3, "expected 3 outputs");
+        require(tx.outputs[0].value == merchantAmount, "merchant amount incorrect");
+        require(tx.outputs[0].scriptPubKey == merchantScript, "merchant script incorrect");
+        require(tx.outputs[1].value == processorFee, "processor fee incorrect");
+        require(tx.outputs[1].scriptPubKey == processorScript, "processor script incorrect");
+        require(tx.outputs[2].value == change, "change amount incorrect");
+        require(tx.outputs[2].scriptPubKey == customerScript, "change script incorrect");
+      } else {
+        // Sub-dust change rounds up into the merchant payout
+        require(tx.numOutputs == 2, "expected 2 outputs");
+        int merchantWithChange = merchantAmount + change;
+        require(tx.outputs[0].value == merchantWithChange, "merchant amount incorrect");
+        require(tx.outputs[0].scriptPubKey == merchantScript, "merchant script incorrect");
+        require(tx.outputs[1].value == processorFee, "processor fee incorrect");
+        require(tx.outputs[1].scriptPubKey == processorScript, "processor script incorrect");
+      }
+    } else {
+      // Sub-dust fee rides with the merchant payout; processor settles out of band
+      if (change > 330) {
+        require(tx.numOutputs == 2, "expected 2 outputs");
+        int merchantWithFee = merchantAmount + processorFee;
+        require(tx.outputs[0].value == merchantWithFee, "merchant amount incorrect");
+        require(tx.outputs[0].scriptPubKey == merchantScript, "merchant script incorrect");
+        require(tx.outputs[1].value == change, "change amount incorrect");
+        require(tx.outputs[1].scriptPubKey == customerScript, "change script incorrect");
+      } else {
+        // Full capture: everything goes to the merchant
+        require(tx.numOutputs == 1, "expected 1 output");
+        require(tx.outputs[0].value == held, "merchant amount incorrect");
+        require(tx.outputs[0].scriptPubKey == merchantScript, "merchant script incorrect");
+      }
+    }
+  }
+
+  // Void: merchant cancels the authorization; the full hold returns to the
+  // customer without waiting for the timelock.
+  function void(signature merchantSig) {
+    require(checkSig(merchantSig, merchantPubkey), "invalid merchant signature");
+
+    let held = tx.input.current.value;
+    require(tx.numOutputs == 1, "expected 1 output for void");
+    require(tx.outputs[0].value == held, "release amount incorrect");
+    require(tx.outputs[0].scriptPubKey == customerScript, "release script incorrect");
+  }
+
+  // Refund: timelocked automatic release back to the customer.
+  // Becomes valid after releaseBlockHeight — effectively anyone-can-spend
+  // into customerScript.
+  function refund() {
+    require(tx.time >= releaseBlockHeight, "release timelock not reached");
+
+    let held = tx.input.current.value;
+    require(tx.numOutputs == 1, "expected 1 output for refund");
+    require(tx.outputs[0].value == held, "refund amount incorrect");
+    require(tx.outputs[0].scriptPubKey == customerScript, "refund script incorrect");
+  }
+
+  // Unilateral exit (CSV): merchant reclaims after the CSV delay.
+  // Note: customer's exit is via the refund path above; no single customer
+  // pubkey exists.
+  function unilateral(signature merchantSig) tapscript {
+    require(older(exit));
+    require(checkSig(merchantSig, merchantPubkey));
+  }
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -24,6 +24,8 @@ mod fuji_safe;
 mod htlc;
 #[path = "examples/layerzero.rs"]
 mod layerzero;
+#[path = "examples/payment_hold.rs"]
+mod payment_hold;
 #[path = "examples/repayment_pool.rs"]
 mod repayment_pool;
 #[path = "examples/stability_vault.rs"]

--- a/tests/examples/compilation_roundtrip.rs
+++ b/tests/examples/compilation_roundtrip.rs
@@ -184,6 +184,18 @@ fn roundtrip_payment_auth() {
 }
 
 #[test]
+fn roundtrip_payment_hold() {
+    let output = compile_example("payment_hold/payment_hold.ark");
+    assert_output_invariants(&output, "payment_hold/payment_hold.ark");
+}
+
+#[test]
+fn roundtrip_asset_payment_hold() {
+    let output = compile_example("payment_hold/asset_payment_hold.ark");
+    assert_output_invariants(&output, "payment_hold/asset_payment_hold.ark");
+}
+
+#[test]
 fn roundtrip_repayment_pool() {
     let output = compile_example("bonds/repayment_pool.ark");
     assert_output_invariants(&output, "bonds/repayment_pool.ark");

--- a/tests/examples/payment_hold.rs
+++ b/tests/examples/payment_hold.rs
@@ -1,0 +1,86 @@
+//! Authorize-and-capture payment hold examples (gas-pump flow).
+//!
+//! Both contracts share the same spend surface: `capture` settles a
+//! witness-chosen amount up to the hold, `void` is the merchant's early
+//! release, `refund` is the timelocked automatic release (no user witness),
+//! and `unilateral` is the merchant's CSV exit leaf.
+
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CHECKSEQUENCEVERIFY, OP_CHECKSIG, OP_INSPECTINASSETLOOKUP, OP_INSPECTOUTASSETLOOKUP,
+    OP_INSPECTOUTPUTVALUE, OP_PUSHCURRENTINPUTINDEX,
+};
+
+fn group_names(output: &arkade_compiler::models::ContractJson) -> Vec<&str> {
+    output.functions.iter().map(|g| g.name.as_str()).collect()
+}
+
+#[test]
+fn test_payment_hold_contract() {
+    let code = include_str!("../../examples/payment_hold/payment_hold.ark");
+    let output = compile(code).expect("payment_hold.ark must compile");
+
+    assert_eq!(output.name, "PaymentHold");
+    assert_eq!(
+        group_names(&output),
+        vec!["capture", "void", "refund", "unilateral"]
+    );
+
+    // Capture settles a witness-chosen amount: the covenant must take the
+    // amount and the merchant authorization from the spender.
+    assert_eq!(
+        crate::common::arkade_inputs(&output, "capture"),
+        vec!["captureAmount", "merchantSig"]
+    );
+    let capture_asm = crate::common::arkade_asm(&output, "capture");
+    assert!(
+        capture_asm.contains(OP_INSPECTOUTPUTVALUE),
+        "capture must pin output values: {capture_asm}"
+    );
+
+    // Refund is the automatic release: no user witness, only the timelock.
+    assert!(
+        crate::common::arkade_inputs(&output, "refund").is_empty(),
+        "refund must not require a user witness"
+    );
+
+    // Unilateral exit is a merchant CSV leaf.
+    let unilateral_asm = crate::common::leaf_asm(&output, "unilateral", "unilateral");
+    assert!(unilateral_asm.contains(OP_CHECKSEQUENCEVERIFY));
+    assert!(unilateral_asm.contains(OP_CHECKSIG));
+}
+
+#[test]
+fn test_asset_payment_hold_contract() {
+    let code = include_str!("../../examples/payment_hold/asset_payment_hold.ark");
+    let output = compile(code).expect("asset_payment_hold.ark must compile");
+
+    assert_eq!(output.name, "AssetPaymentHold");
+    assert_eq!(
+        group_names(&output),
+        vec!["capture", "void", "refund", "unilateral"]
+    );
+
+    assert_eq!(
+        crate::common::arkade_inputs(&output, "capture"),
+        vec!["captureAmount", "merchantSig"]
+    );
+
+    // Every covenant path moves the held asset: input lookup for the hold,
+    // output lookup(s) for the payout, pinned to input index 0.
+    for name in ["capture", "void", "refund"] {
+        let asm = crate::common::arkade_asm(&output, name);
+        assert!(
+            asm.contains(OP_INSPECTINASSETLOOKUP),
+            "{name} must read the held asset amount: {asm}"
+        );
+        assert!(
+            asm.contains(OP_INSPECTOUTASSETLOOKUP),
+            "{name} must pin the output asset amount: {asm}"
+        );
+        assert!(
+            asm.contains(OP_PUSHCURRENTINPUTINDEX),
+            "{name} must pin the hold to input 0: {asm}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Adds two new example contracts implementing a gas-pump style authorize-and-capture payment flow: `PaymentHold` for BTC-denominated holds and `AssetPaymentHold` for asset-denominated holds. Both contracts support merchant-authorized capture of variable amounts up to the hold, merchant void, timelocked automatic refund, and merchant CSV exit.

## Key Changes
- **payment_hold.ark**: BTC payment hold contract with:
  - `capture()` function that settles a witness-chosen amount (up to the hold) with basis-point processor fees
  - Flexible output routing handling sub-dust amounts (change/fees consolidated into merchant payout when needed)
  - `void()` for immediate merchant cancellation
  - `refund()` for timelocked automatic release to customer
  - `unilateral()` CSV exit for merchant reclaim after delay

- **asset_payment_hold.ark**: Asset-denominated variant with:
  - Same four-function spend surface as BTC version
  - Asset amount validation using `assets.lookup()` on inputs and outputs
  - Pinned input index (0) for the hold asset
  - Simplified fee handling (omitted for clarity; see payment_hold.ark for basis-point pattern)

- **tests/examples/payment_hold.rs**: Comprehensive test coverage verifying:
  - Contract compilation and function names
  - Witness requirements (capture takes amount + signature; refund takes none)
  - Output value pinning in capture path
  - Asset lookup operations in all asset contract paths
  - CSV and signature checks in unilateral exit

- **Integration**: Added roundtrip compilation tests and module registration in test suite

## Notable Implementation Details
- The hold amount is implicit (the VTXO value itself), eliminating a separate parameter
- Sub-dust handling in BTC version consolidates change/fees into merchant payout to avoid unspendable outputs
- Asset version requires the hold to be input 0, enabling deterministic asset routing
- Refund path requires no witness, making it anyone-can-spend after the timelock (automatic release mechanism)

https://claude.ai/code/session_01G9JEqcarRxL54WPaSyoFaR