### PR TITLE
Add Subscription example: pull payments without escrow lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,17 @@ If the playground, WASM bridge, or examples used by it changed, also run:
 ./playground/build.sh
 ```
 
+`build.sh` needs the `wasm32-unknown-unknown` target and the `wasm-pack` CLI; a fresh environment has neither:
+
+```bash
+rustup target add wasm32-unknown-unknown
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+```
+
+`wasm-pack`'s own `wasm-opt`/binaryen download can fail in a network-restricted sandbox even when the URL is reachable directly (`curl`). Build with `wasm-pack build --target web --out-dir playground/pkg --no-opt -- --features wasm` in that case (skips optimization only, no `Cargo.toml` change) and let CI verify the optimized artifact.
+
+Adding a file under `examples/` makes it compile through the WASM build automatically (`playground/contracts.js` is generated from every `.ark` file), but it does not add it to the playground's file-tree UI — `playground/main.js` lists a hand-curated subset in its `projects`/`examples` objects. Add an entry there only if the example should be browsable in the playground.
+
 For fast compiler inspection against a contract:
 
 ```bash

--- a/examples/subscription/subscription.ark
+++ b/examples/subscription/subscription.ark
@@ -55,9 +55,9 @@ contract Subscription(
   function cancel(signature customerSig) {
     require(checkSig(customerSig, customerPk), "invalid customer sig");
 
-    if (tx.offchainTime >= nextPullTime) {
+    int elapsed = tx.offchainTime - nextPullTime;
+    if (elapsed >= 0) {
       let balance = tx.input.current.value;
-      int elapsed = tx.offchainTime - nextPullTime;
       int periodsDue = elapsed / interval + 1;
 
       // periodsDue >= maxPeriods implies the debt strictly exceeds the

--- a/examples/subscription/subscription.ark
+++ b/examples/subscription/subscription.ark
@@ -1,0 +1,91 @@
+// Subscription Contract
+// Pull-payment alternative to PaymentAuthorization's escrow (lock, then
+// capture-or-refund). This coin is the customer's own spendable balance with
+// a bounded allowance carved out of it:
+// 1. The merchant may pull exactly pullAmount once per interval; change
+//    recreates the contract with the schedule advanced one period.
+// 2. The customer can cancel (spend) at any time with their own signature;
+//    periods already due are settled to the merchant first.
+//
+// Billing is in advance: a period's fee is due at its start (nextPullTime),
+// not its end, so pull and cancel agree on exactly what is owed at any
+// instant and neither path can be front-run by the other.
+
+contract Subscription(
+  pubkey customerPk,     // owner; can cancel/spend anytime
+  pubkey merchantPk,     // authorizes each pull
+  bytes  merchantScript, // P2TR scriptPubKey receiving each pull
+  int    pullAmount,     // sats per billing period; agreed > 330 off-chain
+  int    interval,       // seconds between pulls; agreed > 0 off-chain
+  int    nextPullTime,   // unix seconds when the next pull unlocks; mutates
+  int    exit            // unilateral exit CSV delay in blocks
+) {
+
+  // PULL — merchant collects one period; missed periods accrue and can be
+  // caught up with consecutive pulls (anchor advances by interval, not to
+  // now), so billing dates never drift.
+  function pull(signature merchantSig) {
+    require(checkSig(merchantSig, merchantPk), "invalid merchant sig");
+    require(tx.offchainTime >= nextPullTime, "period not due");
+
+    let balance = tx.input.current.value;
+    require(balance >= pullAmount, "insufficient balance");
+
+    require(tx.outputs[0].value >= pullAmount, "merchant underpaid");
+    require(tx.outputs[0].scriptPubKey == merchantScript, "output 0 not merchant");
+
+    int remainder = balance - pullAmount;
+    int newNextPullTime = nextPullTime + interval;
+    if (remainder > 330) {
+      require(
+        tx.outputs[1].scriptPubKey == new Subscription(
+          customerPk, merchantPk, merchantScript,
+          pullAmount, interval, newNextPullTime, exit
+        ),
+        "invalid renewal output"
+      );
+      require(tx.outputs[1].value >= remainder, "renewal underfunded");
+    }
+  }
+
+  // CANCEL — customer exits anytime, but periods already unlocked (past
+  // nextPullTime) are settled to the merchant first; the rest of the outputs
+  // are unconstrained because the customer signs the transaction. The period
+  // in progress is owed in full (no proration).
+  function cancel(signature customerSig) {
+    require(checkSig(customerSig, customerPk), "invalid customer sig");
+
+    if (tx.offchainTime >= nextPullTime) {
+      let balance = tx.input.current.value;
+      int elapsed = tx.offchainTime - nextPullTime;
+      int periodsDue = elapsed / interval + 1;
+
+      // periodsDue >= maxPeriods implies the debt strictly exceeds the
+      // balance, so the whole balance settles to the merchant. Capping
+      // before multiplying keeps periodsDue * pullAmount within the balance
+      // bound (avoids overflow from a long-neglected subscription).
+      int maxPeriods = balance / pullAmount + 1;
+      if (periodsDue >= maxPeriods) {
+        require(tx.outputs[0].value >= balance, "merchant underpaid");
+        require(tx.outputs[0].scriptPubKey == merchantScript, "output 0 not merchant");
+      } else {
+        int owed = periodsDue * pullAmount;
+        // Sub-dust debt is forgiven rather than forcing an unviable output.
+        if (owed > 330) {
+          require(tx.outputs[0].value >= owed, "merchant underpaid");
+          require(tx.outputs[0].scriptPubKey == merchantScript, "output 0 not merchant");
+        }
+      }
+    }
+  }
+
+  // Unilateral exit (CSV): customer recovers on L1 if the operator
+  // disappears. This path has no output introspection (tapscript leaves
+  // can't), so it bypasses merchant settlement — the merchant's real
+  // exposure is limited to due-but-unpulled periods if the customer goes
+  // unilateral, mitigated by pulling promptly once a period unlocks.
+  function unilateral(signature customerSig) tapscript {
+    require(older(exit));
+    require(checkSig(customerSig, customerPk));
+  }
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -28,6 +28,8 @@ mod layerzero;
 mod repayment_pool;
 #[path = "examples/stability_vault.rs"]
 mod stability_vault;
+#[path = "examples/subscription.rs"]
+mod subscription;
 #[path = "examples/threshold_oracle.rs"]
 mod threshold_oracle;
 #[path = "examples/token_vault.rs"]

--- a/tests/examples/compilation_roundtrip.rs
+++ b/tests/examples/compilation_roundtrip.rs
@@ -184,6 +184,15 @@ fn roundtrip_payment_auth() {
 }
 
 #[test]
+fn roundtrip_subscription() {
+    let output = compile_example("subscription/subscription.ark");
+    assert_output_invariants(&output, "subscription/subscription.ark");
+    assert_eq!(output.name, "Subscription");
+    // 2 function-backed groups (pull, cancel) + 1 standalone unilateral = 3.
+    assert_eq!(output.functions.len(), 3);
+}
+
+#[test]
 fn roundtrip_repayment_pool() {
     let output = compile_example("bonds/repayment_pool.ark");
     assert_output_invariants(&output, "bonds/repayment_pool.ark");

--- a/tests/examples/subscription.rs
+++ b/tests/examples/subscription.rs
@@ -5,7 +5,8 @@ use arkade_compiler::opcodes::{
 };
 
 use crate::common::{
-    arkade_asm, arkade_asm_tokens, arkade_inputs, group, opcode_count_in_arkade, user_signatures,
+    arkade_asm, arkade_asm_tokens, arkade_inputs, group, leaf_asm, opcode_count_in_arkade,
+    user_signatures, witness_names,
 };
 
 // Pull-payment alternative to PaymentAuthorization's escrow: the coin stays
@@ -75,6 +76,25 @@ fn test_pull_checks_balance_and_pins_merchant_payout() {
     assert!(
         asm.contains(OP_SUB),
         "pull must compute the remainder (balance - pullAmount)"
+    );
+
+    // pull's covenant pins TWO outputs (merchant payout at 0, renewal VTXO at
+    // 1) via structurally identical opcodes, so mere opcode presence can't
+    // tell them apart — a regression that dropped the output-0 merchant pin
+    // while keeping the output-1 renewal pin would still pass a
+    // presence-only check. Anchor on the exact contiguous token sequence for
+    // output index 0 instead.
+    assert!(
+        asm.contains(&format!(
+            "0 {OP_INSPECTOUTPUTVALUE} <pullAmount> {OP_GREATERTHANOREQUAL}"
+        )),
+        "pull must check tx.outputs[0].value >= pullAmount, got: {asm}"
+    );
+    assert!(
+        asm.contains(&format!(
+            "0 {OP_INSPECTOUTPUTSCRIPTPUBKEY} OP_DROP <merchantScript> OP_EQUAL"
+        )),
+        "pull must pin tx.outputs[0].scriptPubKey == merchantScript, got: {asm}"
     );
 }
 
@@ -188,22 +208,20 @@ fn test_unilateral_is_csv_and_customer_only() {
         "unilateral should have no arkade covenant (pure tapscript exit)"
     );
 
-    let leaf = &unilateral_group.leaves[0];
-    let leaf_asm = leaf.asm.join(" ");
+    let asm = leaf_asm(&output, "unilateral", "unilateral");
     assert!(
-        leaf_asm.contains(OP_CHECKSEQUENCEVERIFY),
+        asm.contains(OP_CHECKSEQUENCEVERIFY),
         "unilateral must enforce the exit CSV delay"
     );
     assert!(
-        leaf_asm.contains("<customerPk>"),
+        asm.contains("<customerPk>"),
         "unilateral must check the customer's key, not the merchant's"
     );
-    assert!(leaf_asm.contains(OP_CHECKSIG));
+    assert!(asm.contains(OP_CHECKSIG));
 
-    let witness_names: Vec<&str> = leaf.witness.iter().map(|w| w.name.as_str()).collect();
     assert_eq!(
-        witness_names,
-        vec!["customerSig"],
+        witness_names(&output, "unilateral", "unilateral"),
+        vec!["customerSig".to_string()],
         "unilateral witness must be exactly the customer's signature"
     );
 }

--- a/tests/examples/subscription.rs
+++ b/tests/examples/subscription.rs
@@ -1,0 +1,249 @@
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_ADD, OP_CHECKSEQUENCEVERIFY, OP_CHECKSIG, OP_DIV, OP_GREATERTHAN, OP_GREATERTHANOREQUAL,
+    OP_INSPECTINPUTVALUE, OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE, OP_MUL, OP_SUB,
+};
+
+use crate::common::{
+    arkade_asm, arkade_asm_tokens, arkade_inputs, group, opcode_count_in_arkade, user_signatures,
+};
+
+// Pull-payment alternative to PaymentAuthorization's escrow: the coin stays
+// customer-spendable at all times, with a merchant allowance of exactly
+// pullAmount per interval carved out by the covenant.
+const CODE: &str = include_str!("../../examples/subscription/subscription.ark");
+
+#[test]
+fn test_subscription_compiles() {
+    let output = compile(CODE).expect("compilation failed");
+    assert_eq!(output.name, "Subscription");
+    // 2 covenant functions (pull, cancel) + 1 standalone unilateral = 3 groups.
+    assert_eq!(output.functions.len(), 3);
+
+    let names: Vec<&str> = output.parameters.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "customerPk",
+            "merchantPk",
+            "merchantScript",
+            "pullAmount",
+            "interval",
+            "nextPullTime",
+            "exit",
+        ]
+    );
+}
+
+#[test]
+fn test_pull_requires_merchant_sig_and_due_period() {
+    let output = compile(CODE).expect("compilation failed");
+    let asm = arkade_asm(&output, "pull");
+    assert!(asm.contains(OP_CHECKSIG), "pull must verify merchant sig");
+    assert!(
+        asm.contains(OP_GREATERTHANOREQUAL),
+        "pull must gate on tx.offchainTime >= nextPullTime"
+    );
+
+    // Exactly one user signature: the merchant's. The customer is not
+    // involved in a pull.
+    let user_sigs = user_signatures(&output, "pull");
+    assert_eq!(
+        user_sigs.len(),
+        1,
+        "pull must require exactly the merchant sig, got: {user_sigs:?}"
+    );
+    assert!(user_sigs.iter().any(|s| s == "merchantSig"));
+}
+
+#[test]
+fn test_pull_checks_balance_and_pins_merchant_payout() {
+    let output = compile(CODE).expect("compilation failed");
+    let asm = arkade_asm(&output, "pull");
+    assert!(
+        asm.contains(OP_INSPECTINPUTVALUE),
+        "pull must read the coin's current balance"
+    );
+    assert!(
+        asm.contains(OP_INSPECTOUTPUTVALUE),
+        "pull must check output values"
+    );
+    assert!(
+        asm.contains(OP_INSPECTOUTPUTSCRIPTPUBKEY),
+        "pull must pin output scriptPubKeys"
+    );
+    assert!(
+        asm.contains(OP_SUB),
+        "pull must compute the remainder (balance - pullAmount)"
+    );
+}
+
+#[test]
+fn test_pull_renewal_recreates_subscription_with_advanced_schedule() {
+    // The renewal output must be a recursive Subscription instantiation whose
+    // nextPullTime argument is the ADVANCED schedule (nextPullTime +
+    // interval), not tx.offchainTime — missed periods must accrue rather
+    // than reset the anchor to "now". The whole instantiation lowers to a
+    // single `<VTXO:Subscription(...)>` placeholder token (not split per
+    // argument), so this checks for the newNextPullTime argument as a
+    // substring of that one token rather than a standalone token.
+    let output = compile(CODE).expect("compilation failed");
+    let tokens = arkade_asm_tokens(&output, "pull");
+    let vtxo_token = tokens
+        .iter()
+        .find(|t| t.starts_with("<VTXO:Subscription("))
+        .unwrap_or_else(|| {
+            panic!("pull must recreate a Subscription output for the renewal branch, tokens: {tokens:?}")
+        });
+    assert!(
+        vtxo_token.contains("newNextPullTime"),
+        "renewal output must derive nextPullTime from the newNextPullTime let-binding, not a literal or tx.offchainTime: {vtxo_token}"
+    );
+}
+
+#[test]
+fn test_cancel_requires_only_customer_sig() {
+    let output = compile(CODE).expect("compilation failed");
+    let asm = arkade_asm(&output, "cancel");
+    assert!(asm.contains(OP_CHECKSIG), "cancel must verify customer sig");
+
+    let user_sigs = user_signatures(&output, "cancel");
+    assert_eq!(
+        user_sigs.len(),
+        1,
+        "cancel must require exactly the customer sig, got: {user_sigs:?}"
+    );
+    assert!(user_sigs.iter().any(|s| s == "customerSig"));
+}
+
+#[test]
+fn test_cancel_settles_due_periods_before_release() {
+    // SECURITY: cancel must compute periodsDue and settle at least that much
+    // to the merchant before the (unconstrained) remainder is released to
+    // the customer. Without this, cancel would be a bare sig check and the
+    // merchant could lose an already-due period to a same-block cancel.
+    let output = compile(CODE).expect("compilation failed");
+    let asm = arkade_asm(&output, "cancel");
+    assert!(
+        asm.contains(OP_DIV),
+        "cancel must compute periodsDue = elapsed / interval + 1"
+    );
+    assert!(
+        asm.contains(OP_ADD),
+        "cancel must add 1 to account for the in-progress period"
+    );
+    assert!(
+        asm.contains(OP_MUL),
+        "cancel must compute owed = periodsDue * pullAmount in the bounded branch"
+    );
+    assert!(
+        asm.contains(OP_GREATERTHANOREQUAL),
+        "cancel must gate settlement on tx.offchainTime >= nextPullTime and compare periodsDue against maxPeriods"
+    );
+    // Exact-token count, not substring: OP_GREATERTHAN is a substring of
+    // OP_GREATERTHANOREQUAL (which cancel also emits 4x), so a plain
+    // `asm.contains(OP_GREATERTHAN)` on the joined string would pass
+    // vacuously even if the dust-forgiveness check were deleted.
+    assert!(
+        opcode_count_in_arkade(&output, "cancel", OP_GREATERTHAN) >= 1,
+        "cancel must forgive sub-dust debt via owed > 330"
+    );
+    assert!(
+        asm.contains(OP_INSPECTOUTPUTVALUE) && asm.contains(OP_INSPECTOUTPUTSCRIPTPUBKEY),
+        "cancel must pin the merchant settlement output when debt is owed"
+    );
+}
+
+#[test]
+fn test_cancel_caps_debt_before_multiplying() {
+    // Overflow guard: cancel must compare periodsDue against maxPeriods
+    // (balance / pullAmount + 1) BEFORE computing periodsDue * pullAmount,
+    // so a long-neglected subscription can never overflow the product. The
+    // OP_MUL for `owed` must be lexically reachable only after the
+    // periodsDue >= maxPeriods branch has already been decided (OP_IF /
+    // OP_ELSE), which we approximate by requiring an OP_ELSE between the
+    // cap comparison and the multiplication.
+    let output = compile(CODE).expect("compilation failed");
+    let tokens = arkade_asm_tokens(&output, "cancel");
+    let mul_idx = tokens
+        .iter()
+        .position(|t| t == OP_MUL)
+        .expect("cancel must contain OP_MUL");
+    let else_idx = tokens
+        .iter()
+        .position(|t| t == "OP_ELSE")
+        .expect("cancel must branch on the debt cap via OP_ELSE");
+    assert!(
+        else_idx < mul_idx,
+        "the periodsDue >= maxPeriods branch (OP_ELSE) must precede the owed = periodsDue * pullAmount multiplication, tokens: {tokens:?}"
+    );
+}
+
+#[test]
+fn test_unilateral_is_csv_and_customer_only() {
+    let output = compile(CODE).expect("compilation failed");
+    let unilateral_group = group(&output, "unilateral");
+    assert!(
+        unilateral_group.arkade.is_none(),
+        "unilateral should have no arkade covenant (pure tapscript exit)"
+    );
+
+    let leaf = &unilateral_group.leaves[0];
+    let leaf_asm = leaf.asm.join(" ");
+    assert!(
+        leaf_asm.contains(OP_CHECKSEQUENCEVERIFY),
+        "unilateral must enforce the exit CSV delay"
+    );
+    assert!(
+        leaf_asm.contains("<customerPk>"),
+        "unilateral must check the customer's key, not the merchant's"
+    );
+    assert!(leaf_asm.contains(OP_CHECKSIG));
+
+    let witness_names: Vec<&str> = leaf.witness.iter().map(|w| w.name.as_str()).collect();
+    assert_eq!(
+        witness_names,
+        vec!["customerSig"],
+        "unilateral witness must be exactly the customer's signature"
+    );
+}
+
+#[test]
+fn test_pull_and_cancel_have_no_customer_or_merchant_cross_signing() {
+    // pull must never accept a customer sig (merchant alone triggers a
+    // pull), and cancel must never accept a merchant sig (customer alone
+    // triggers a cancel) — each function's authority is single-party by
+    // design, with the settlement covenant (not a second signer) protecting
+    // the other side.
+    let output = compile(CODE).expect("compilation failed");
+    let pull_inputs = arkade_inputs(&output, "pull");
+    assert!(!pull_inputs.iter().any(|w| w == "customerSig"));
+    let cancel_inputs = arkade_inputs(&output, "cancel");
+    assert!(!cancel_inputs.iter().any(|w| w == "merchantSig"));
+}
+
+#[test]
+fn test_subscription_cli() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("subscription.ark");
+    fs::write(&input, CODE).unwrap();
+    let out = dir.path().join("subscription.json");
+
+    let result = std::process::Command::new(env!("CARGO_BIN_EXE_arkadec"))
+        .arg(input.to_str().unwrap())
+        .arg("-o")
+        .arg(out.to_str().unwrap())
+        .output()
+        .expect("failed to run arkadec");
+
+    assert!(
+        result.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let json = fs::read_to_string(&out).unwrap();
+    assert!(json.contains("\"contractName\": \"Subscription\""));
+}


### PR DESCRIPTION
## Summary

- Adds `examples/subscription/subscription.ark`: a pull-payment alternative to `payment_auth`'s authorize/capture escrow. Instead of locking the customer's funds until the merchant captures or a timelock refunds, the coin stays customer-spendable at all times; the covenant carves out a bounded merchant allowance of exactly `pullAmount` once per `interval`.
- `pull(merchantSig)`: merchant collects one period once it's due (`tx.offchainTime >= nextPullTime`); the remainder recreates the contract with the schedule advanced by `interval` (missed periods accrue rather than resetting to "now", so billing dates never drift).
- `cancel(customerSig)`: customer exits anytime, but any already-due periods are settled to the merchant first (billed-in-advance, so `pull` and `cancel` always agree on what's currently owed). Debt is capped against the coin's balance before multiplying, to avoid overflow on a long-neglected subscription; sub-dust debt is forgiven.
- `unilateral(customerSig)` tapscript CSV exit, matching the project's standard L1 fallback pattern.
- Wires the new example into `tests/examples/compilation_roundtrip.rs` and adds a dedicated `tests/examples/subscription.rs` with structural assertions on spend-group count, witness/signature shape per function, the overflow-safe debt-cap ordering, and the recursive renewal output.

## Test plan

- [x] `cargo test --test examples subscription` — 11/11 new tests pass
- [x] `cargo test --workspace` — full suite passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- examples/subscription/subscription.ark -o /tmp/contract.json` — compiles


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHvV2GNtc89oDFzEAg4XNn)_