### PR TITLE
Static arrays with declared sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ contract FujiSafe(
 - `bool`: Boolean value
 - `asset`: Asset identifier (for asset-aware contracts)
 
-Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles_0 … oracles_4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally.
+Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles_0 … oracles_4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally. Arrays are allowed in constructor and covenant function parameters; `tapscript` function inputs must be scalars.
 
 ### Contract Structure
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ contract FujiSafe(
 - `bool`: Boolean value
 - `asset`: Asset identifier (for asset-aware contracts)
 
+Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles_0 … oracles_4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally.
+
 ### Contract Structure
 
 An Arkade Language file may start with zero or more `import` declarations, followed by a `contract` declaration:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This language significantly lowers the barrier for Bitcoin-native app developmen
 
 ## Emulator E2E Tests
 
-The self-contained E2E suite builds the compiler and runs the counter and HTLC artifacts through the Arkade VM and btcd tapscript interpreter.
+The self-contained E2E suite builds the compiler and runs the counter, HTLC, symbolic-stack and static-array artifacts through the Arkade VM and btcd tapscript interpreter.
 
 ```bash
 ./scripts/e2e.sh -v

--- a/README.md
+++ b/README.md
@@ -430,21 +430,23 @@ Arkade Language compiles to Arkade Script and produces a JSON artifact for use w
 | Field                 | Description                                                                               |
 |-----------------------|-------------------------------------------------------------------------------------------|
 | `contractName`        | Contract identifier                                                                       |
-| `constructorInputs`   | Constructor parameters in source declaration order after array expansion                  |
+| `constructorInputs`   | Constructor parameters in source declaration order, one entry per parameter               |
 | `functions`           | Spend groups: `{ name, arkade?, leaves[] }`                                               |
 | `arkade`              | Optional emulator-run covenant `{ inputs, asm }`                                          |
-| `arkade.inputs`       | Function parameters in source declaration order after array expansion                     |
+| `arkade.inputs`       | Function parameters in source declaration order, one entry per parameter                  |
 | `leaves`              | L1 tapleaf objects `{ name, witness, asm }`                                               |
 | `witness`             | Spend-time tapleaf witness fields, with `injected: true` for infrastructure signatures    |
 | `asm`                 | Assembly tokens, including the explicit constructor prologue and covenant body            |
 
 ### Arkade Covenant Stack ABI
 
-`constructorInputs` and `arkade.inputs` describe the source ABI and remain in source declaration order after fixed-size arrays are expanded. They do not describe the physical VM stack order.
+`constructorInputs`, `arkade.inputs` and each leaf's `witness` describe the source ABI: one entry per source parameter, in declaration order. They do not describe the physical VM stack order.
+
+An array parameter stays one entry carrying its size in the type (`{ "name": "oracles", "type": "pubkey[3]" }`). Each array element is a separate stack item and a separate `<name_i>` placeholder, so clients expand an array entry into `name_0 … name_{N-1}` in index order.
 
 Clients serialize covenant function inputs in reverse `arkade.inputs` order. For example, source inputs `[amount, sig]` produce the physical bottom-to-top witness `[sig, amount]`.
 
-Every covenant `asm` begins with one constructor placeholder per expanded constructor input, also in reverse order. Contract instantiation resolves these placeholders to concrete data pushes before the covenant hash is computed. For source constructor inputs `[limit, owner]`, the prologue is `["<owner>", "<limit>"]`, leaving `limit` nearest the top within the constructor frame.
+Every covenant `asm` begins with one constructor placeholder per expanded constructor input — arrays contribute one placeholder per element — also in reverse order. Contract instantiation resolves these placeholders to concrete data pushes before the covenant hash is computed. For source constructor inputs `[limit, owner]`, the prologue is `["<owner>", "<limit>"]`, leaving `limit` nearest the top within the constructor frame.
 
 The VM installs the function witness before executing the covenant, so the reversed constructor prologue leaves constructor values above function inputs. Covenant body expressions access constructor parameters, function inputs, and local variables through stack operations such as `OP_PICK`; function inputs are not emitted as `<name>` body placeholders.
 

--- a/arkade-bindgen/src/ir.rs
+++ b/arkade-bindgen/src/ir.rs
@@ -131,12 +131,23 @@ pub struct ContractIR {
     pub compiler_version: Option<String>,
 }
 
-fn field_from_ark_type(name: &str, ark_type: &str) -> Field {
-    Field {
-        name: name.to_string(),
+/// Expand one artifact entry into generated fields.
+///
+/// The artifact keeps one entry per source parameter, so an array type
+/// (`pubkey[3]`) becomes the `name_0 … name_2` scalars the covenant asm and the
+/// witness stack actually carry.
+fn fields_from_ark_type(name: &str, ark_type: &str, is_injected: bool) -> Vec<Field> {
+    let field = |name: String, ark_type: &str| Field {
+        name,
         ark_type: ark_type.to_string(),
         encoding: Encoding::from_ark_type(ark_type),
-        is_injected: false,
+        is_injected,
+    };
+    match arkade_compiler::models::array_type_parts(ark_type) {
+        Some((element, length)) => (0..length)
+            .map(|index| field(format!("{name}_{index}"), element))
+            .collect(),
+        None => vec![field(name.to_string(), ark_type)],
     }
 }
 
@@ -145,7 +156,7 @@ pub fn build_ir(artifact: &ContractJson) -> Result<ContractIR, String> {
     let constructor_fields = artifact
         .parameters
         .iter()
-        .map(|p| field_from_ark_type(&p.name, &p.param_type))
+        .flat_map(|p| fields_from_ark_type(&p.name, &p.param_type, false))
         .collect();
 
     let groups = artifact
@@ -157,7 +168,7 @@ pub fn build_ir(artifact: &ContractJson) -> Result<ContractIR, String> {
                 inputs: cov
                     .inputs
                     .iter()
-                    .map(|i| field_from_ark_type(&i.name, &i.param_type))
+                    .flat_map(|i| fields_from_ark_type(&i.name, &i.param_type, false))
                     .collect(),
                 asm: cov.asm.clone(),
             }),
@@ -169,12 +180,7 @@ pub fn build_ir(artifact: &ContractJson) -> Result<ContractIR, String> {
                     witness_fields: leaf
                         .witness
                         .iter()
-                        .map(|w| Field {
-                            name: w.name.clone(),
-                            ark_type: w.elem_type.clone(),
-                            encoding: Encoding::parse(&w.encoding),
-                            is_injected: w.injected,
-                        })
+                        .flat_map(|w| fields_from_ark_type(&w.name, &w.elem_type, w.injected))
                         .collect(),
                     asm: leaf.asm.clone(),
                 })

--- a/arkade-bindgen/tests/ir_test.rs
+++ b/arkade-bindgen/tests/ir_test.rs
@@ -105,3 +105,60 @@ fn test_encoding_roundtrip() {
         assert_eq!(parsed.as_str(), s);
     }
 }
+
+#[test]
+fn test_ir_expands_grouped_array_fields() {
+    // The artifact carries one entry per source parameter; generated bindings
+    // need the per-element fields the asm placeholders and witness stack use.
+    let artifact = r#"{
+        "contractName": "Quorum",
+        "constructorInputs": [{ "name": "oracles", "type": "pubkey[3]" }],
+        "functions": [{
+            "name": "attest",
+            "arkade": {
+                "inputs": [{ "name": "sigs", "type": "signature[2]" }],
+                "asm": ["<oracles_2>", "<oracles_1>", "<oracles_0>", "OP_1"]
+            },
+            "leaves": [{
+                "name": "attest",
+                "witness": [{ "name": "sigs", "type": "signature[2]", "encoding": "array" }],
+                "asm": ["OP_1"]
+            }]
+        }]
+    }"#;
+
+    let ir = build_ir(&load_artifact_str(artifact).unwrap()).unwrap();
+
+    let names: Vec<&str> = ir
+        .constructor_fields
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    assert_eq!(names, ["oracles_0", "oracles_1", "oracles_2"]);
+    assert!(ir
+        .constructor_fields
+        .iter()
+        .all(|f| f.encoding == Encoding::Compressed33));
+
+    let group = &ir.groups[0];
+    let inputs: Vec<&str> = group
+        .covenant
+        .as_ref()
+        .unwrap()
+        .inputs
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    assert_eq!(inputs, ["sigs_0", "sigs_1"]);
+
+    let witness: Vec<&str> = group.leaves[0]
+        .witness_fields
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    assert_eq!(witness, ["sigs_0", "sigs_1"]);
+    assert!(group.leaves[0]
+        .witness_fields
+        .iter()
+        .all(|f| f.encoding == Encoding::Schnorr64));
+}

--- a/examples/threshold_oracle/threshold_oracle.ark
+++ b/examples/threshold_oracle/threshold_oracle.ark
@@ -2,8 +2,8 @@
 // Generic threshold signature verifier for multi-oracle attestations.
 //
 // This contract demonstrates:
-// - Array types in constructor params (pubkey[] oracles)
-// - Array types in function params (signature[] oracleSigs)
+// - Array types in constructor params (pubkey[3] oracles)
+// - Array types in function params (signature[3] oracleSigs)
 // - Array indexing (oracles[i])
 // - Loop unrolling with array iteration
 // - Threshold counting for quorum verification
@@ -15,7 +15,7 @@ contract ThresholdOracle(
   int tokenAssetIdGidx,
   bytes32 ctrlAssetIdTxid,
   int ctrlAssetIdGidx,
-  pubkey[] oracles,
+  pubkey[3] oracles,
   int threshold,
   int exit
 ) {
@@ -23,7 +23,7 @@ contract ThresholdOracle(
     int amount,
     bytes32 messageHash,
     bytes recipientScriptPubKey,
-    signature[] oracleSigs
+    signature[3] oracleSigs
   ) {
     require(amount > 0, "zero");
 

--- a/playground/codegen.js
+++ b/playground/codegen.js
@@ -56,17 +56,31 @@ function inferEncoding(typeStr) {
 
 // ─── IR construction ─────────────────────────────────────────────────
 
-function buildIR(artifact) {
-    const constructorFields = (artifact.constructorInputs || []).map(p => ({
-        name: p.name, arkType: p.type, encoding: inferEncoding(p.type),
+// The artifact keeps one entry per source parameter, so an array type
+// (pubkey[3]) expands here into the name_0 … name_2 scalars the asm
+// placeholders and the witness stack actually carry.
+function expandFields(name, typeStr, isInjected) {
+    const array = /^(.+)\[(\d+)\]$/.exec(typeStr);
+    if (!array) {
+        return [{ name, arkType: typeStr, encoding: inferEncoding(typeStr), isInjected }];
+    }
+    const [, elementType, length] = array;
+    return Array.from({ length: Number(length) }, (_, index) => ({
+        name: `${name}_${index}`,
+        arkType: elementType,
+        encoding: inferEncoding(elementType),
+        isInjected,
     }));
+}
+
+function buildIR(artifact) {
+    const constructorFields = (artifact.constructorInputs || [])
+        .flatMap(p => expandFields(p.name, p.type, false));
 
     const functions = (artifact.functions || []).map(group => {
         const leaves = (group.leaves || []).map(leaf => {
-            const allFields = (leaf.witness || []).map(w => ({
-                name: w.name, arkType: w.type, encoding: w.encoding,
-                isInjected: w.injected === true,
-            }));
+            const allFields = (leaf.witness || [])
+                .flatMap(w => expandFields(w.name, w.type, w.injected === true));
             return {
                 name: leaf.name,
                 allFields,

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -108,7 +108,7 @@ impl ConcatPass {
                 // The element type decides whether concatenating the loop value
                 // needs an explicit num2bin, so carry it rather than Unknown.
                 let element_type = match iter_type {
-                    ArkType::Array(inner) => *inner,
+                    ArkType::Array(inner, _) => *inner,
                     _ => ArkType::Unknown,
                 };
                 loop_scope.insert(value_var.clone(), element_type);
@@ -151,7 +151,7 @@ impl ConcatPass {
             Expression::ArrayIndex { array, index } => {
                 let (index, _) = self.rewrite_expression_concat(*index, scope);
                 let result_type = match scope.get(&array) {
-                    Some(ArkType::Array(element)) => (**element).clone(),
+                    Some(ArkType::Array(element, _)) => (**element).clone(),
                     _ => ArkType::Unknown,
                 };
                 (

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -148,6 +148,24 @@ impl ConcatPass {
         scope: &Scope,
     ) -> (Expression, ArkType) {
         match expr {
+            Expression::ArrayLiteral(elements) => {
+                let mut element_type = ArkType::Unknown;
+                let rewritten = elements
+                    .into_iter()
+                    .map(|element| {
+                        let (element, t) = self.rewrite_expression_concat(element, scope);
+                        if element_type == ArkType::Unknown {
+                            element_type = t;
+                        }
+                        element
+                    })
+                    .collect::<Vec<_>>();
+                let length = rewritten.len();
+                (
+                    Expression::ArrayLiteral(rewritten),
+                    ArkType::Array(Box::new(element_type), length),
+                )
+            }
             Expression::ArrayIndex { array, index } => {
                 let (index, _) = self.rewrite_expression_concat(*index, scope);
                 let result_type = match scope.get(&array) {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -16,6 +16,8 @@ pub(crate) fn emit_expression_asm(expr: &Expression, asm: &mut Vec<String>) {
             asm.push(format!("<{}>", var));
         }
         Expression::Literal(lit) => push_literal_asm(lit, asm),
+        // Rejected before emission; array declarations emit their elements directly.
+        Expression::ArrayLiteral(_) => {}
         Expression::ArrayIndex { array, index } => {
             if let Expression::Literal(index) = index.as_ref() {
                 asm.push(format!("<{array}[{index}]>"));

--- a/src/compiler/loops.rs
+++ b/src/compiler/loops.rs
@@ -183,6 +183,12 @@ pub(crate) fn substitute_expression(
         Expression::Variable(var) if var == value_var => {
             Expression::Variable(internal_array_binding_name(array_name, &k.to_string()))
         }
+        Expression::ArrayLiteral(elements) => Expression::ArrayLiteral(
+            elements
+                .iter()
+                .map(|element| substitute_expression(element, index_var, value_var, k, array_name))
+                .collect(),
+        ),
         Expression::ArrayIndex { array, index } => Expression::ArrayIndex {
             array: array.clone(),
             index: Box::new(substitute_expression(

--- a/src/compiler/loops.rs
+++ b/src/compiler/loops.rs
@@ -10,14 +10,14 @@ use super::internal_array_binding_name;
 /// - `GroupProperty { group: value_var, property: "sumOutputs" }` → `GroupSum { index: k, source: Outputs }`
 /// - `GroupProperty { group: value_var, property: "sumInputs" }` → `GroupSum { index: k, source: Inputs }`
 /// - `Variable(index_var)` → `Literal(k)`
-/// - `Variable(value_var)` when array_name is Some → its internal array-element binding
+/// - `Variable(value_var)` → its internal array-element binding
 /// - Property-form indexing `arr[index_var]` → the same internal binding
 pub(crate) fn substitute_loop_body(
     body: &[Statement],
     index_var: &str,
     value_var: &str,
     k: usize,
-    array_name: Option<&str>,
+    array_name: &str,
 ) -> Vec<Statement> {
     body.iter()
         .map(|stmt| substitute_statement(stmt, index_var, value_var, k, array_name))
@@ -29,7 +29,7 @@ pub(crate) fn substitute_statement(
     index_var: &str,
     value_var: &str,
     k: usize,
-    array_name: Option<&str>,
+    array_name: &str,
 ) -> Statement {
     match stmt {
         Statement::Require(req) => Statement::Require(substitute_requirement(
@@ -78,7 +78,7 @@ pub(crate) fn substitute_requirement(
     index_var: &str,
     value_var: &str,
     k: usize,
-    array_name: Option<&str>,
+    array_name: &str,
 ) -> Requirement {
     match req {
         Requirement::Expression(expr) => Requirement::Expression(substitute_expression(
@@ -143,15 +143,13 @@ fn substitute_loop_name(
     index_var: &str,
     value_var: &str,
     k: usize,
-    array_name: Option<&str>,
+    array_name: &str,
 ) -> String {
     if name == index_var {
         return k.to_string();
     }
     if name == value_var {
-        return array_name
-            .map(|array| internal_array_binding_name(array, &k.to_string()))
-            .unwrap_or_else(|| k.to_string());
+        return internal_array_binding_name(array_name, &k.to_string());
     }
     if let Some(open) = name.find('[') {
         if name.ends_with(']') {
@@ -160,13 +158,11 @@ fn substitute_loop_name(
                 return internal_array_binding_name(&name[..open], &k.to_string());
             }
             if index == value_var {
-                if let Some(array) = array_name {
-                    return format!(
-                        "{}[{}]",
-                        &name[..open],
-                        internal_array_binding_name(array, &k.to_string())
-                    );
-                }
+                return format!(
+                    "{}[{}]",
+                    &name[..open],
+                    internal_array_binding_name(array_name, &k.to_string())
+                );
             }
         }
     }
@@ -178,18 +174,14 @@ pub(crate) fn substitute_expression(
     index_var: &str,
     value_var: &str,
     k: usize,
-    array_name: Option<&str>,
+    array_name: &str,
 ) -> Expression {
     match expr {
         // Replace index variable with literal k
         Expression::Variable(var) if var == index_var => Expression::Literal(k.to_string()),
         // Replace the value variable with its source-impossible stack binding.
         Expression::Variable(var) if var == value_var => {
-            if let Some(name) = array_name {
-                Expression::Variable(internal_array_binding_name(name, &k.to_string()))
-            } else {
-                Expression::Literal(k.to_string())
-            }
+            Expression::Variable(internal_array_binding_name(array_name, &k.to_string()))
         }
         Expression::ArrayIndex { array, index } => Expression::ArrayIndex {
             array: array.clone(),
@@ -215,12 +207,10 @@ pub(crate) fn substitute_expression(
                         ));
                     }
                     if idx == value_var {
-                        if let Some(array) = array_name {
-                            return Expression::Property(format!(
-                                "{arr_name}[{}]",
-                                internal_array_binding_name(array, &k.to_string())
-                            ));
-                        }
+                        return Expression::Property(format!(
+                            "{arr_name}[{}]",
+                            internal_array_binding_name(array_name, &k.to_string())
+                        ));
                     }
                 }
             }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -56,11 +56,6 @@ enum StackItem {
     Temporary,
 }
 
-/// `tx.assetGroups` carries no declared size, so `for … in tx.assetGroups`
-/// unrolls this many iterations. Ceiling: groups past the third are not
-/// visited; raise this once the VM exposes a group-count bound.
-const ASSET_GROUP_LOOP_ITERATIONS: usize = 3;
-
 // `$` is outside the source identifier grammar, so this namespace cannot collide with user bindings.
 const INTERNAL_ARRAY_BINDING_PREFIX: &str = "$array:";
 const INTERNAL_ARRAY_INDEX_PREFIX: &str = "$array-index:";
@@ -798,16 +793,11 @@ fn generate_asm_from_statements_recursive(
                 iterable,
                 body,
             } => {
-                let array_name = match iterable {
-                    Expression::Property(prop) if prop.trim() == "tx.assetGroups" => None,
-                    Expression::Variable(array_name) => Some(array_name.as_str()),
-                    _ => return Err("unsupported loop iterable".to_string()),
+                let Expression::Variable(array_name) = iterable else {
+                    return Err("unsupported loop iterable".to_string());
                 };
-                let iterations = match array_name {
-                    Some(array) => generator.array_length(array),
-                    None => ASSET_GROUP_LOOP_ITERATIONS,
-                };
-                for k in 0..iterations {
+                let array_name = array_name.as_str();
+                for k in 0..generator.array_length(array_name) {
                     let substituted =
                         substitute_loop_body(body, index_var, value_var, k, array_name);
                     let baseline = generator.stack.clone();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -647,8 +647,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
         }
     }
 
-    // Build constructor inputs (array params expand to indexed scalars).
-    let parameters = expand_abi_params(&contract.parameters);
+    let parameters = contract.parameters.clone();
 
     let mut json = ContractJson {
         name: contract.name.clone(),
@@ -694,9 +693,11 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
     Ok(json)
 }
 
-/// Expand ABI params for emission. Array types (e.g., `pubkey[]`) are flattened
-/// to `name_0`, `name_1`, `name_2`, …; every other param passes through unchanged.
-pub(crate) fn expand_abi_params(params: &[Parameter]) -> Vec<Parameter> {
+/// The placeholder namespace a parameter list emits: array types (e.g.
+/// `pubkey[3]`) flatten to `name_0`, `name_1`, `name_2`; every other param
+/// passes through unchanged. This is the `<name>` namespace in `asm`, not the
+/// artifact ABI, which keeps one entry per source parameter.
+pub(crate) fn expanded_placeholder_params(params: &[Parameter]) -> Vec<Parameter> {
     let mut result = Vec::new();
     for param in params {
         for_each_expanded_param(param, |name, _, param_type| {
@@ -711,21 +712,21 @@ fn covenant_for(
     function: &Function,
     constructor_parameters: &[Parameter],
 ) -> Result<ArkadeCovenant, String> {
-    let inputs = expand_function_inputs(&function.parameters);
+    let inputs = function_inputs(&function.parameters);
     let mut generator = Generator::new(&function.parameters, constructor_parameters);
     generate_asm_from_statements_recursive(&function.statements, &mut generator)?;
     let asm = generator.finish()?;
     Ok(ArkadeCovenant { inputs, asm })
 }
 
-fn expand_function_inputs(params: &[Parameter]) -> Vec<FunctionInput> {
-    let mut inputs = Vec::new();
-    for param in params {
-        for_each_expanded_param(param, |name, _, param_type| {
-            inputs.push(FunctionInput { name, param_type });
-        });
-    }
-    inputs
+fn function_inputs(params: &[Parameter]) -> Vec<FunctionInput> {
+    params
+        .iter()
+        .map(|param| FunctionInput {
+            name: param.name.clone(),
+            param_type: param.param_type.clone(),
+        })
+        .collect()
 }
 
 fn for_each_expanded_param(param: &Parameter, mut f: impl FnMut(String, String, String)) {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -417,6 +417,12 @@ impl Generator {
                     .to_string(),
             );
         }
+        if matches!(expression, Expression::ArrayLiteral(_)) {
+            return Err(
+                "array literals may only initialize an array declaration; composite values are not supported"
+                    .to_string(),
+            );
+        }
         if matches!(
             expression,
             Expression::GroupIOAccess {
@@ -463,6 +469,17 @@ impl Generator {
     }
 
     fn assign(&mut self, name: &str) -> Result<(), String> {
+        if let Some((array, element)) = name.strip_suffix(']').and_then(|n| n.split_once('[')) {
+            if element.parse::<usize>().is_err() {
+                // Writing at a runtime depth needs a write-at-depth opcode
+                // (see docs: OP_PUT); emulating it costs one guarded write per
+                // element. Lift this once the VM provides that primitive.
+                return Err(format!(
+                    "assignment to '{array}' at a runtime index is not supported; use a literal index"
+                ));
+            }
+        }
+        let name = &Self::internal_binding_name(name);
         let index = self
             .binding_index(name)
             .ok_or_else(|| format!("assignment to undeclared binding '{name}'"))?;
@@ -804,10 +821,36 @@ fn generate_asm_from_statements_recursive(
                     }
                 }
             }
-            Statement::LetBinding { name, value, .. } => {
-                generator.emit_expression(value)?;
-                generator.bind_local(name)?;
-            }
+            Statement::LetBinding {
+                name,
+                declared_type,
+                value,
+            } => match (
+                declared_type
+                    .as_deref()
+                    .and_then(crate::models::array_type_parts),
+                value,
+            ) {
+                (Some((_, length)), Expression::ArrayLiteral(elements)) => {
+                    if elements.len() != length {
+                        return Err(format!(
+                            "array '{name}' declares {length} elements but its initializer has {}",
+                            elements.len()
+                        ));
+                    }
+                    // Deepest element last, so element 0 sits closest to the top —
+                    // the layout parameter arrays already have.
+                    for (index, element) in elements.iter().enumerate().rev() {
+                        generator.emit_expression(element)?;
+                        generator
+                            .bind_local(&internal_array_binding_name(name, &index.to_string()))?;
+                    }
+                }
+                _ => {
+                    generator.emit_expression(value)?;
+                    generator.bind_local(name)?;
+                }
+            },
             Statement::VarAssign { name, value } => {
                 generator.emit_expression(value)?;
                 generator.assign(name)?;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -170,6 +170,14 @@ impl Generator {
     }
 
     fn read_binding(&mut self, name: &str) -> Result<(), String> {
+        if let Some(array) = name.trim().strip_suffix(".length") {
+            let length = self.array_length(array);
+            if length == 0 {
+                return Err(format!("'{array}' is not an array; '.length' is undefined"));
+            }
+            self.push_integer_temporary(length);
+            return Ok(());
+        }
         if let Some((array, index)) = name
             .trim()
             .strip_suffix(']')

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,6 +1,6 @@
 use crate::models::{
     ArkadeCovenant, CompilerInfo, ContractJson, Expression, Function, FunctionInput, Parameter,
-    Requirement, Statement, DEFAULT_ARRAY_LENGTH,
+    Requirement, Statement,
 };
 use crate::opcodes::{
     OP_0, OP_1, OP_ADD, OP_BIN2NUM, OP_BOOLAND, OP_CAT, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG,
@@ -56,6 +56,11 @@ enum StackItem {
     Temporary,
 }
 
+/// `tx.assetGroups` carries no declared size, so `for … in tx.assetGroups`
+/// unrolls this many iterations. Ceiling: groups past the third are not
+/// visited; raise this once the VM exposes a group-count bound.
+const ASSET_GROUP_LOOP_ITERATIONS: usize = 3;
+
 // `$` is outside the source identifier grammar, so this namespace cannot collide with user bindings.
 const INTERNAL_ARRAY_BINDING_PREFIX: &str = "$array:";
 const INTERNAL_ARRAY_INDEX_PREFIX: &str = "$array-index:";
@@ -97,7 +102,7 @@ impl Generator {
                 expanded_placeholders.push(format!("<{placeholder}>"));
                 constructor_bindings.push((placeholder, binding_name));
             });
-            if parameter.param_type.ends_with("[]") {
+            if crate::models::array_type_parts(&parameter.param_type).is_some() {
                 constructor_array_expansions.push((
                     format!("<{}>", parameter.name),
                     expanded_placeholders.join(","),
@@ -138,6 +143,17 @@ impl Generator {
         self.stack.iter().position(
             |item| matches!(item, StackItem::Binding { name: binding, .. } if binding == name),
         )
+    }
+
+    /// Element count of an array binding, read off the symbolic stack: its
+    /// elements are bound as `$array:name:0 … $array:name:N-1`.
+    fn array_length(&self, array: &str) -> usize {
+        (0..)
+            .take_while(|i| {
+                self.binding_index(&internal_array_binding_name(array, &i.to_string()))
+                    .is_some()
+            })
+            .count()
     }
 
     fn internal_binding_name(name: &str) -> String {
@@ -209,7 +225,7 @@ impl Generator {
 
         self.push_integer_temporary(0);
         self.apply(OP_PICK, 1, 1)?;
-        self.push_integer_temporary(DEFAULT_ARRAY_LENGTH);
+        self.push_integer_temporary(self.array_length(array));
         self.apply(OP_LESSTHAN, 2, 1)?;
         self.apply(OP_VERIFY, 1, 0)?;
 
@@ -693,8 +709,8 @@ fn expand_function_inputs(params: &[Parameter]) -> Vec<FunctionInput> {
 }
 
 fn for_each_expanded_param(param: &Parameter, mut f: impl FnMut(String, String, String)) {
-    if let Some(base_type) = param.param_type.strip_suffix("[]") {
-        for i in 0..DEFAULT_ARRAY_LENGTH {
+    if let Some((base_type, length)) = crate::models::array_type_parts(&param.param_type) {
+        for i in 0..length {
             f(
                 format!("{}_{}", param.name, i),
                 internal_array_binding_name(&param.name, &i.to_string()),
@@ -762,7 +778,11 @@ fn generate_asm_from_statements_recursive(
                     Expression::Variable(array_name) => Some(array_name.as_str()),
                     _ => return Err("unsupported loop iterable".to_string()),
                 };
-                for k in 0..DEFAULT_ARRAY_LENGTH {
+                let iterations = match array_name {
+                    Some(array) => generator.array_length(array),
+                    None => ASSET_GROUP_LOOP_ITERATIONS,
+                };
+                for k in 0..iterations {
                     let substituted =
                         substitute_loop_body(body, index_var, value_var, k, array_name);
                     let baseline = generator.stack.clone();

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -436,8 +436,9 @@ pub fn emit_leaf_asm(c: &Closure, ts_name: &str, binding: &Binding) -> Vec<Strin
     asm
 }
 
-/// Derive the leaf witness array from the tapscript inputs, with the same array
-/// expansion behavior as covenant function inputs (DEFAULT_ARRAY_LENGTH).
+/// Derive the leaf witness from the tapscript inputs: one entry per source
+/// input, array types carrying their size. Clients expand an array entry into
+/// its `name_0 … name_{N-1}` stack items.
 pub fn leaf_witness(ts: &NamedTapscript) -> Vec<WitnessElement> {
     let mut out = Vec::new();
     let injected = injected_signature_names(ts);
@@ -462,25 +463,12 @@ fn injected_signature_names(ts: &NamedTapscript) -> std::collections::HashSet<St
 }
 
 fn push_witness_param(p: &Parameter, injected: bool, out: &mut Vec<WitnessElement>) {
-    if let Some((base, length)) = crate::models::array_type_parts(&p.param_type) {
-        let t = ArkType::parse(base);
-        for i in 0..length {
-            out.push(WitnessElement {
-                name: format!("{}_{}", p.name, i),
-                elem_type: base.to_string(),
-                encoding: t.encoding().to_string(),
-                injected,
-            });
-        }
-    } else {
-        let t = ArkType::parse(&p.param_type);
-        out.push(WitnessElement {
-            name: p.name.clone(),
-            elem_type: p.param_type.clone(),
-            encoding: t.encoding().to_string(),
-            injected,
-        });
-    }
+    out.push(WitnessElement {
+        name: p.name.clone(),
+        elem_type: p.param_type.clone(),
+        encoding: ArkType::parse(&p.param_type).encoding().to_string(),
+        injected,
+    });
 }
 
 /// Build the unified `functions[]` ABI: one group per covenant function plus

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -462,9 +462,9 @@ fn injected_signature_names(ts: &NamedTapscript) -> std::collections::HashSet<St
 }
 
 fn push_witness_param(p: &Parameter, injected: bool, out: &mut Vec<WitnessElement>) {
-    if let Some(base) = p.param_type.strip_suffix("[]") {
+    if let Some((base, length)) = crate::models::array_type_parts(&p.param_type) {
         let t = ArkType::parse(base);
-        for i in 0..crate::models::DEFAULT_ARRAY_LENGTH {
+        for i in 0..length {
             out.push(WitnessElement {
                 name: format!("{}_{}", p.name, i),
                 elem_type: base.to_string(),

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -436,9 +436,8 @@ pub fn emit_leaf_asm(c: &Closure, ts_name: &str, binding: &Binding) -> Vec<Strin
     asm
 }
 
-/// Derive the leaf witness from the tapscript inputs: one entry per source
-/// input, array types carrying their size. Clients expand an array entry into
-/// its `name_0 … name_{N-1}` stack items.
+/// Derive the leaf witness from the tapscript inputs, one entry per input.
+/// Tapscript inputs are scalars; the validator rejects array types here.
 pub fn leaf_witness(ts: &NamedTapscript) -> Vec<WitnessElement> {
     let mut out = Vec::new();
     let injected = injected_signature_names(ts);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ pub mod wasm;
 
 pub use models::{
     Contract, ContractJson, Expression, Function, Parameter, Requirement, WitnessElement,
-    DEFAULT_ARRAY_LENGTH,
 };
 pub use typechecker::{ArkType, TypeError};
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,19 +4,15 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-/// The number of elements that array-typed parameters (e.g. `pubkey[]`) are
-/// flattened into throughout the pipeline.
+/// Split a declared type string into element type and length when it is an
+/// array type (`"pubkey[3]"` → `("pubkey", 3)`), otherwise `None`.
 ///
-/// This single constant governs:
-/// - Constructor / function input flattening in the compiler
-/// - Witness schema generation (`pubkey_0 … pubkey_N`)
-/// - Compile-time loop unrolling (`for (k, v) in arr`)
-/// - Scope expansion in the type checker
-///
-/// Raising this value increases the size of every compiled tapscript that
-/// uses array parameters; lower it to tighten script sizes when contracts
-/// only need fewer elements.
-pub const DEFAULT_ARRAY_LENGTH: usize = 3;
+/// Array lengths are static and always present: the grammar has no unsized
+/// array type.
+pub fn array_type_parts(declared_type: &str) -> Option<(&str, usize)> {
+    let (element, length) = declared_type.strip_suffix(']')?.split_once('[')?;
+    Some((element, length.parse().ok()?))
+}
 
 // JSON output structures.
 // These represent the compiled contract in a serializable format.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -351,6 +351,8 @@ pub enum Expression {
     Literal(String),
     /// Property access (e.g., tx.time)
     Property(String),
+    /// Array literal; only valid as the initializer of an array declaration.
+    ArrayLiteral(Vec<Expression>),
     /// Array element selected by an integer expression.
     ArrayIndex {
         array: String,

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -206,6 +206,11 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
                 index: Box::new(parse_general_expression(index)?),
             })
         }
+        Rule::array_literal => Ok(Expression::ArrayLiteral(
+            pair.into_inner()
+                .map(parse_general_expression)
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
         Rule::array_length_access => {
             let array = pair
                 .into_inner()

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -206,6 +206,15 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
                 index: Box::new(parse_general_expression(index)?),
             })
         }
+        Rule::array_length_access => {
+            let array = pair
+                .into_inner()
+                .next()
+                .ok_or("Missing array name")?
+                .as_str()
+                .to_string();
+            Ok(Expression::Property(format!("{array}.length")))
+        }
         Rule::tx_property_access => parse_tx_property_to_expr(pair),
         Rule::this_property_access => Ok(Expression::Property(pair.as_str().to_string())),
         Rule::check_sig => {

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -25,9 +25,10 @@ parameter = { data_type ~ identifier }
 
 // Supported data types - atomic rule to prevent partial matches
 // Note: longer types must come before shorter prefixes (bytes32/bytes20 before bytes)
-// Array types use [] suffix (e.g., pubkey[], signature[])
+// Array types carry a static size (e.g., pubkey[3], signature[5])
 base_type = @{ "pubkey" | "signature" | "bytes32" | "bytes20" | "bytes" | "asset" | "int" | "bool" }
-data_type = { base_type ~ ("[]")? }
+array_size = @{ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+data_type = { base_type ~ ("[" ~ array_size ~ "]")? }
 
 // Function definition. A `tapscript` modifier selects an L1 tapleaf body
 // (require-only); otherwise it is an ordinary covenant function body.

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -77,7 +77,7 @@ let_binding = {
 // Variable assignment (reassignment without let keyword)
 // Must check for = but not == or >= or <=
 var_assign = {
-    identifier ~ "=" ~ !("=") ~ general_expression ~ ";"
+    (array_index_access | identifier) ~ "=" ~ !("=") ~ general_expression ~ ";"
 }
 
 // Require statement
@@ -168,6 +168,7 @@ primary_expr = {
     constructor |
     function_call |
     array_index_access |
+    array_literal |
     bool_literal |
     number_literal |
     identifier
@@ -443,9 +444,9 @@ method_arg = {
     number_literal | identifier
 }
 
-// Array literal
+// Array literal — initializes a local array declaration
 array_literal = {
-    "[" ~ complex_expression ~ ("," ~ complex_expression)* ~ "]"
+    "[" ~ general_expression ~ ("," ~ general_expression)* ~ "]"
 }
 
 // Function call

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -161,6 +161,7 @@ primary_expr = {
     output_introspection |
     tx_introspection |
     group_control_is |
+    array_length_access |
     identifier_property_access |
     tx_property_access |
     this_property_access |
@@ -171,6 +172,9 @@ primary_expr = {
     number_literal |
     identifier
 }
+
+// Static array length: arr.length — folded to a literal at compile time
+array_length_access = { identifier ~ "." ~ "length" ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Array indexing: identifier[integer expression]
 array_index_access = {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -266,12 +266,11 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
         }
         Rule::variable_declaration => {
             let mut inner = pair.into_inner();
-            let declared_type = inner
-                .next()
-                .ok_or_else(|| "Parse error: Missing variable type".to_string())?
-                .as_str()
-                .trim()
-                .to_string();
+            let declared_type = parse_data_type(
+                inner
+                    .next()
+                    .ok_or_else(|| "Parse error: Missing variable type".to_string())?,
+            );
             let name = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing variable name".to_string())?
@@ -315,6 +314,19 @@ fn parse_block(pair: Pair<Rule>) -> Result<Vec<Statement>, String> {
     Ok(statements)
 }
 
+/// Canonical declared-type text: `pubkey`, or `pubkey[3]` for array types.
+pub(crate) fn parse_data_type(type_pair: Pair<Rule>) -> String {
+    let text = type_pair.as_str().trim().to_string();
+    let mut inner = type_pair.into_inner();
+    let Some(base) = inner.next() else {
+        return text;
+    };
+    match inner.next() {
+        Some(size) => format!("{}[{}]", base.as_str(), size.as_str()),
+        None => base.as_str().to_string(),
+    }
+}
+
 /// Parse parameter list from contracts or functions
 pub(crate) fn parse_parameters(params: Pair<Rule>) -> Result<Vec<Parameter>, String> {
     let mut parameters = Vec::new();
@@ -322,21 +334,7 @@ pub(crate) fn parse_parameters(params: Pair<Rule>) -> Result<Vec<Parameter>, Str
         if param_pair.as_rule() == Rule::parameter {
             let mut param_inner = param_pair.into_inner();
             let param_type = match param_inner.next() {
-                Some(type_pair) => {
-                    // Extract the base type and check for an array suffix.
-                    let type_text = type_pair.as_str().trim();
-                    if type_text.ends_with("[]") {
-                        type_text.to_string()
-                    } else {
-                        // Parse inner to get just the base type
-                        let mut type_inner = type_pair.into_inner();
-                        if let Some(base) = type_inner.next() {
-                            base.as_str().to_string()
-                        } else {
-                            type_text.to_string()
-                        }
-                    }
-                }
+                Some(type_pair) => parse_data_type(type_pair),
                 None => return Err("Parameter is missing data type".to_string()),
             };
             let param_name = match param_inner.next() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -197,7 +197,8 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
                 .next()
                 .ok_or_else(|| "Parse error: Missing variable name in assignment".to_string())?
                 .as_str()
-                .to_string();
+                .split_whitespace()
+                .collect::<String>();
             let value_pair = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing value in assignment".to_string())?;

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -9,7 +9,7 @@
 ///   decides how to surface them)
 use std::collections::HashMap;
 
-use crate::models::{Contract, Expression, Function, Requirement, Statement, DEFAULT_ARRAY_LENGTH};
+use crate::models::{Contract, Expression, Function, Requirement, Statement};
 
 // ─── Type Enum ────────────────────────────────────────────────────────────────
 
@@ -41,18 +41,18 @@ pub enum ArkType {
     // ── Internal / introspection types ─────────────────────────────────────
 
     // ── Composite ──────────────────────────────────────────────────────────
-    /// Homogeneous array (e.g., `pubkey[]`)
-    Array(Box<ArkType>),
+    /// Homogeneous fixed-size array (e.g., `pubkey[3]`)
+    Array(Box<ArkType>, usize),
 
     /// Type could not be resolved (variable not in scope, etc.)
     Unknown,
 }
 
 impl ArkType {
-    /// Parse from a grammar `data_type` string (e.g., `"pubkey"`, `"bytes32[]"`).
+    /// Parse from a grammar `data_type` string (e.g., `"pubkey"`, `"bytes32[4]"`).
     pub fn parse(s: &str) -> ArkType {
-        if let Some(inner) = s.strip_suffix("[]") {
-            return ArkType::Array(Box::new(ArkType::parse(inner)));
+        if let Some((element, length)) = crate::models::array_type_parts(s) {
+            return ArkType::Array(Box::new(ArkType::parse(element)), length);
         }
         match s {
             "pubkey" => ArkType::Pubkey,
@@ -81,7 +81,7 @@ impl ArkType {
             ArkType::Int => "scriptnum",
             ArkType::Bool => "scriptnum",
             ArkType::Asset => "raw-32",
-            ArkType::Array(_) => "array",
+            ArkType::Array(..) => "array",
             ArkType::Unknown => "unknown",
         }
     }
@@ -97,7 +97,7 @@ impl ArkType {
             ArkType::Int => "int".to_string(),
             ArkType::Bool => "bool".to_string(),
             ArkType::Asset => "asset".to_string(),
-            ArkType::Array(inner) => format!("{}[]", inner.as_str()),
+            ArkType::Array(inner, length) => format!("{}[{length}]", inner.as_str()),
             ArkType::Unknown => "unknown".to_string(),
         }
     }
@@ -127,13 +127,14 @@ pub type Scope = HashMap<String, ArkType>;
 pub fn build_scope(params: &[crate::models::Parameter]) -> Scope {
     let mut scope = Scope::new();
     for p in params {
-        if let Some(base) = p.param_type.strip_suffix("[]") {
+        if let Some((base, length)) = crate::models::array_type_parts(&p.param_type) {
             let elem_type = ArkType::parse(base);
-            // Register the bare name as the array type, plus each indexed
-            // element. The count must match
-            // DEFAULT_ARRAY_LENGTH so the type checker and compiler agree.
-            scope.insert(p.name.clone(), ArkType::Array(Box::new(elem_type.clone())));
-            for i in 0..DEFAULT_ARRAY_LENGTH {
+            // Register the bare name as the array type, plus each indexed element.
+            scope.insert(
+                p.name.clone(),
+                ArkType::Array(Box::new(elem_type.clone()), length),
+            );
+            for i in 0..length {
                 scope.insert(format!("{}[{}]", p.name, i), elem_type.clone());
             }
         } else {
@@ -435,7 +436,7 @@ fn check_comparison(
     if left_type == ArkType::Unknown || right_type == ArkType::Unknown {
         return;
     }
-    if matches!(left_type, ArkType::Array(_)) || matches!(right_type, ArkType::Array(_)) {
+    if matches!(left_type, ArkType::Array(..)) || matches!(right_type, ArkType::Array(..)) {
         errors.push(TypeError::new(format!(
             "fn {}: array comparison '{}' is not supported",
             fn_name, op
@@ -504,7 +505,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
         Expression::Literal(value) if matches!(value.as_str(), "true" | "false") => ArkType::Bool,
         Expression::Literal(_) => ArkType::Int,
         Expression::ArrayIndex { array, .. } => match scope.get(array) {
-            Some(ArkType::Array(element)) => (**element).clone(),
+            Some(ArkType::Array(element, _)) => (**element).clone(),
             _ => ArkType::Unknown,
         },
         Expression::Property(property) => scope
@@ -516,7 +517,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
                     return None;
                 }
                 match scope.get(array)? {
-                    ArkType::Array(element) => Some((**element).clone()),
+                    ArkType::Array(element, _) => Some((**element).clone()),
                     _ => None,
                 }
             })

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -207,6 +207,11 @@ fn check_statement(
                 .map(ArkType::parse)
                 .unwrap_or(inferred);
             // Seed the scope so downstream uses of `name` get the inferred type.
+            if let ArkType::Array(element, length) = &t {
+                for i in 0..*length {
+                    scope.insert(format!("{name}[{i}]"), (**element).clone());
+                }
+            }
             scope.insert(name.clone(), t);
         }
         Statement::VarAssign { name, value } => {
@@ -504,6 +509,15 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
             .unwrap_or(ArkType::Unknown),
         Expression::Literal(value) if matches!(value.as_str(), "true" | "false") => ArkType::Bool,
         Expression::Literal(_) => ArkType::Int,
+        Expression::ArrayLiteral(elements) => ArkType::Array(
+            Box::new(
+                elements
+                    .first()
+                    .map(|element| infer_type(element, scope))
+                    .unwrap_or(ArkType::Unknown),
+            ),
+            elements.len(),
+        ),
         Expression::ArrayIndex { array, .. } => match scope.get(array) {
             Some(ArkType::Array(element, _)) => (**element).clone(),
             _ => ArkType::Unknown,

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -512,6 +512,10 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
             .get(property.trim())
             .cloned()
             .or_else(|| {
+                let array = property.trim().strip_suffix(".length")?;
+                matches!(scope.get(array)?, ArkType::Array(..)).then_some(ArkType::Int)
+            })
+            .or_else(|| {
                 let (array, index) = property.strip_suffix(']')?.split_once('[')?;
                 if index.parse::<usize>().is_ok() {
                     return None;

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1423,7 +1423,7 @@ fn walk_scope(
 /// still collide here (e.g. `int[] xs` vs `int xs_0`).
 fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     // Constructor params expanded exactly as the emitter expands them (array flattening).
-    let ctor_expanded = crate::compiler::expand_abi_params(&contract.parameters);
+    let ctor_expanded = crate::compiler::expanded_placeholder_params(&contract.parameters);
 
     for func in contract.functions.iter().filter(|f| !f.is_internal) {
         let mut seen: HashSet<String> = HashSet::new();
@@ -1437,7 +1437,7 @@ fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssu
             );
         }
 
-        for p in crate::compiler::expand_abi_params(&func.parameters) {
+        for p in crate::compiler::expanded_placeholder_params(&func.parameters) {
             record_name(
                 p.name,
                 &format!("function '{}'", func.name),
@@ -1457,7 +1457,7 @@ fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssu
                 issues,
             );
         }
-        for p in crate::compiler::expand_abi_params(&tapscript.inputs) {
+        for p in crate::compiler::expanded_placeholder_params(&tapscript.inputs) {
             record_name(
                 p.name,
                 &format!("tapscript '{}'", tapscript.name),
@@ -1510,12 +1510,15 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
                     group.name
                 )));
             }
-            let expected_prologue = output
-                .parameters
-                .iter()
-                .rev()
-                .map(|parameter| format!("<{}>", parameter.name))
-                .collect::<Vec<_>>();
+            // The ABI keeps one entry per source parameter; the prologue pushes
+            // one placeholder per array element, so compare against the
+            // flattened namespace.
+            let expected_prologue =
+                crate::compiler::expanded_placeholder_params(&output.parameters)
+                    .iter()
+                    .rev()
+                    .map(|parameter| format!("<{}>", parameter.name))
+                    .collect::<Vec<_>>();
             if !arkade.asm.starts_with(&expected_prologue) {
                 issues.push(ValidationIssue::error(format!(
                     "group '{}' arkade covenant has an invalid constructor prologue",

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -494,16 +494,17 @@ fn insert_parameters(
     source: BindingSource,
 ) {
     for parameter in parameters {
-        if let Some(element_type) = parameter.param_type.strip_suffix("[]") {
+        if let Some((element_type, length)) = crate::models::array_type_parts(&parameter.param_type)
+        {
             let element_type = ArkType::parse(element_type);
             frame.insert(
                 parameter.name.clone(),
                 BindingInfo {
-                    binding_type: ArkType::Array(Box::new(element_type.clone())),
+                    binding_type: ArkType::Array(Box::new(element_type.clone()), length),
                     source,
                 },
             );
-            for index in 0..crate::models::DEFAULT_ARRAY_LENGTH {
+            for index in 0..length {
                 frame.insert(
                     format!("{}[{}]", parameter.name, index),
                     BindingInfo {
@@ -690,7 +691,7 @@ fn validate_binding_statements(
                 let element_type = match iterable {
                     Expression::Variable(name) => match find_binding(scopes, name) {
                         Some(BindingInfo {
-                            binding_type: ArkType::Array(element),
+                            binding_type: ArkType::Array(element, _),
                             ..
                         }) => (**element).clone(),
                         Some(binding) => {
@@ -912,7 +913,7 @@ fn validate_binding_expression(
     if value_position
         && matches!(
             resolved_expression_type(expression, scopes),
-            ArkType::Array(_)
+            ArkType::Array(..)
         )
     {
         issues.push(ValidationIssue::error(format!(
@@ -993,18 +994,22 @@ fn validate_binding_expression(
             validate_named_binding(name, None, "binding", function_name, scopes, issues);
         }
         Expression::ArrayIndex { array, index } => {
+            let mut length = None;
             match find_binding(scopes, array) {
                 None => issues.push(ValidationIssue::error(format!(
                     "function '{}': array '{}' is undefined",
                     function_name, array
                 ))),
-                Some(binding) if !matches!(binding.binding_type, ArkType::Array(_)) => {
+                Some(BindingInfo {
+                    binding_type: ArkType::Array(_, declared_length),
+                    ..
+                }) => length = Some(*declared_length),
+                Some(_) => {
                     issues.push(ValidationIssue::error(format!(
                         "function '{}': binding '{}' is not an array",
                         function_name, array
                     )));
                 }
-                Some(_) => {}
             }
             let index_type = resolved_expression_type(index, scopes);
             if !matches!(index_type, ArkType::Int | ArkType::Unknown) {
@@ -1014,14 +1019,11 @@ fn validate_binding_expression(
                     index_type.as_str()
                 )));
             }
-            if let Expression::Literal(index) = index.as_ref() {
-                if index
-                    .parse::<usize>()
-                    .map_or(true, |index| index >= crate::models::DEFAULT_ARRAY_LENGTH)
-                {
+            if let (Expression::Literal(index), Some(length)) = (index.as_ref(), length) {
+                if index.parse::<usize>().map_or(true, |i| i >= length) {
                     issues.push(ValidationIssue::error(format!(
-                        "function '{}': array index '{}' is out of range",
-                        function_name, index
+                        "function '{}': array index '{}' is out of range for '{}[{}]'",
+                        function_name, index, array, length
                     )));
                 }
             }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -192,6 +192,13 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
                     ts.name, p.name
                 )));
             }
+            if crate::models::array_type_parts(&p.param_type).is_some() {
+                issues.push(ValidationIssue::error(format!(
+                    "tapscript '{}' input '{}' has array type '{}'; array witnesses are not \
+                     supported in tapscript functions",
+                    ts.name, p.name, p.param_type
+                )));
+            }
         }
         // Duplicate input names within a tapscript.
         let mut seen = std::collections::HashSet::new();

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -371,6 +371,8 @@ fn child_exprs(expr: &Expression) -> Vec<&Expression> {
 
         Expression::ArrayIndex { index, .. } => vec![index],
 
+        Expression::ArrayLiteral(elements) => elements.iter().collect(),
+
         Expression::AssetLookup {
             index,
             asset_txid,
@@ -597,7 +599,22 @@ fn validate_binding_statements(
                 declared_type,
                 value,
             } => {
-                validate_binding_expression(value, function_name, scopes, issues, true);
+                // Array literals are the one composite value allowed in a value
+                // position, and only here; validate their elements instead.
+                match value {
+                    Expression::ArrayLiteral(elements) => {
+                        for element in elements {
+                            validate_binding_expression(
+                                element,
+                                function_name,
+                                scopes,
+                                issues,
+                                true,
+                            );
+                        }
+                    }
+                    _ => validate_binding_expression(value, function_name, scopes, issues, true),
+                }
                 let inferred = resolved_expression_type(value, scopes);
                 let binding_type = declared_type
                     .as_deref()
@@ -615,16 +632,38 @@ fn validate_binding_statements(
                         inferred.as_str()
                     )));
                 }
-                scopes
+                if matches!(value, Expression::ArrayLiteral(_))
+                    && declared_type
+                        .as_deref()
+                        .and_then(crate::models::array_type_parts)
+                        .is_none()
+                {
+                    issues.push(ValidationIssue::error(format!(
+                        "function '{}': array literal needs a declared array type, as in 'int[2] {} = …'",
+                        function_name, name
+                    )));
+                }
+                let frame = scopes
                     .last_mut()
-                    .expect("binding validation always has a scope")
-                    .insert(
-                        name.clone(),
-                        BindingInfo {
-                            binding_type,
-                            source: BindingSource::Local,
-                        },
-                    );
+                    .expect("binding validation always has a scope");
+                if let ArkType::Array(element, length) = &binding_type {
+                    for index in 0..*length {
+                        frame.insert(
+                            format!("{name}[{index}]"),
+                            BindingInfo {
+                                binding_type: (**element).clone(),
+                                source: BindingSource::Local,
+                            },
+                        );
+                    }
+                }
+                frame.insert(
+                    name.clone(),
+                    BindingInfo {
+                        binding_type,
+                        source: BindingSource::Local,
+                    },
+                );
             }
             Statement::VarAssign { name, value } => {
                 validate_binding_expression(value, function_name, scopes, issues, true);

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -627,6 +627,27 @@ fn validate_binding_statements(
                     .as_deref()
                     .map(ArkType::parse)
                     .unwrap_or_else(|| inferred.clone());
+                // The inferred array type only carries the first element's type,
+                // so check every element against the declared element type.
+                if let (Expression::ArrayLiteral(elements), ArkType::Array(element_type, _)) =
+                    (value, &binding_type)
+                {
+                    for (index, element) in elements.iter().enumerate() {
+                        let actual = resolved_expression_type(element, scopes);
+                        if actual != ArkType::Unknown
+                            && !binding_types_compatible(element_type, &actual)
+                        {
+                            issues.push(ValidationIssue::error(format!(
+                                "function '{}': element {} of array '{}' has type '{}', expected '{}'",
+                                function_name,
+                                index,
+                                name,
+                                actual.as_str(),
+                                element_type.as_str()
+                            )));
+                        }
+                    }
+                }
                 if declared_type.is_some()
                     && inferred != ArkType::Unknown
                     && !binding_types_compatible(&binding_type, &inferred)

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -751,7 +751,13 @@ fn validate_binding_statements(
                         }
                     },
                     Expression::Property(property) if property.trim() == "tx.assetGroups" => {
-                        ArkType::Int
+                        issues.push(ValidationIssue::error(format!(
+                            "function '{}': cannot iterate 'tx.assetGroups'; the group count is \
+                             not known at compile time. Iterate a declared array of group \
+                             indices instead",
+                            function_name
+                        )));
+                        ArkType::Unknown
                     }
                     _ => {
                         issues.push(ValidationIssue::error(format!(

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1031,6 +1031,18 @@ fn validate_binding_expression(
         Expression::Property(name) if name.contains('[') => {
             validate_named_binding(name, None, "binding", function_name, scopes, issues);
         }
+        Expression::Property(name) if name.ends_with(".length") => {
+            let array = name.trim_end_matches(".length");
+            if !matches!(
+                find_binding(scopes, array).map(|binding| &binding.binding_type),
+                Some(ArkType::Array(..))
+            ) {
+                issues.push(ValidationIssue::error(format!(
+                    "function '{}': '{}' is not an array; '.length' is undefined",
+                    function_name, array
+                )));
+            }
+        }
         Expression::GroupProperty { group, .. } | Expression::GroupControlIs { group, .. }
             if group.parse::<usize>().is_err() =>
         {

--- a/tests/e2e/contracts/static_arrays.ark
+++ b/tests/e2e/contracts/static_arrays.ark
@@ -1,0 +1,38 @@
+// Static array coverage for the emulator VM: sized constructor and function
+// arrays, literal and runtime indexing, per-array loop unrolling, `.length`,
+// and a local array with one element reassigned.
+
+contract StaticArrays(
+  int[4] weights,
+  pubkey owner
+) {
+  function spend(
+    int index,
+    int scaleIndex,
+    int expected,
+    int[5] samples,
+    signature ownerSig
+  ) {
+    require(weights.length + samples.length == 9, "declared sizes");
+
+    int[3] scale = [1, 2, 3];
+    scale[1] = 10;
+
+    int total = (samples[index] * scale[scaleIndex]) + scale[0];
+
+    for (i, weight) in weights {
+      total = total + (weight * (i + 1));
+    }
+
+    for (j, sample) in samples {
+      if (sample > 0) {
+        total = total + (sample * (j + 1));
+      } else {
+        total = total - scale[2];
+      }
+    }
+
+    require(total == expected, "unexpected total");
+    require(checkSig(ownerSig, owner));
+  }
+}

--- a/tests/e2e/contracts/symbolic_stack.ark
+++ b/tests/e2e/contracts/symbolic_stack.ark
@@ -10,7 +10,7 @@ contract SymbolicStackStress(
     int carry,
     int selector,
     int expected,
-    int[] values,
+    int[3] values,
     signature ownerSig,
     pubkey attestor,
     signature attestSig,

--- a/tests/e2e/static_arrays_test.go
+++ b/tests/e2e/static_arrays_test.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+)
+
+// Mirrors contracts/static_arrays.ark, computed independently of the compiler.
+// scale is [1, 2, 3] with element 1 reassigned to 10.
+func expectedTotal(weights [4]int64, samples [5]int64, index, scaleIndex int64) int64 {
+	scale := [3]int64{1, 10, 3}
+	total := samples[index]*scale[scaleIndex] + scale[0]
+	for i, weight := range weights {
+		total += weight * int64(i+1)
+	}
+	for j, sample := range samples {
+		if sample > 0 {
+			total += sample * int64(j+1)
+		} else {
+			total -= 3
+		}
+	}
+	return total
+}
+
+func TestStaticArrays(t *testing.T) {
+	contract := compileArtifact(t, "contracts/static_arrays.ark")
+	serverKey := fixedPrivateKey(1)
+	emulatorKey := fixedPrivateKey(2)
+	ownerKey := fixedPrivateKey(4)
+
+	// The ABI keeps one entry per source parameter, sized.
+	if got := contract.ConstructorInputs[0]; got.Name != "weights" || got.Type != "int[4]" {
+		t.Fatalf("constructor input 0 = %+v, want weights int[4]", got)
+	}
+	group := covenantGroup(t, contract, "spend")
+	if got := group.Arkade.Inputs[3]; got.Name != "samples" || got.Type != "int[5]" {
+		t.Fatalf("covenant input 3 = %+v, want samples int[5]", got)
+	}
+
+	weights := [4]int64{2, 3, 5, 7}
+	// Constructor arrays expand into one placeholder per element.
+	constructorValues := map[string][]byte{
+		"owner": schnorr.SerializePubKey(ownerKey.PubKey()),
+	}
+	for i, weight := range weights {
+		constructorValues[fmt.Sprintf("weights_%d", i)] = scriptInt(t, weight)
+	}
+	arrays := instantiateGroup(
+		t, contract, "spend", constructorValues, serverKey.PubKey(), emulatorKey.PubKey(),
+	)
+
+	testCases := []struct {
+		name       string
+		index      int64
+		scaleIndex int64
+		samples    [5]int64
+		total      int64
+		wantErr    string
+	}{
+		// scaleIndex indexes the local array at runtime, so these also pin the
+		// order its elements are pushed in.
+		{name: "first element", index: 0, scaleIndex: 0, samples: [5]int64{4, 6, 8, 1, 2}},
+		{name: "middle element", index: 2, scaleIndex: 1, samples: [5]int64{5, -1, 7, 0, 9}},
+		{name: "last element", index: 4, scaleIndex: 2, samples: [5]int64{1, 2, 3, 4, 5}},
+		{
+			name:    "index past the declared size is rejected",
+			index:   5,
+			samples: [5]int64{1, 2, 3, 4, 5},
+			wantErr: "OP_VERIFY failed",
+		},
+		{
+			// A negative index isolates the lower bound check: without it,
+			// OP_PICK would fail on the negative depth rather than OP_VERIFY.
+			name:    "negative index fails the bound check",
+			index:   -1,
+			samples: [5]int64{1, 2, 3, 4, 5},
+			wantErr: "OP_VERIFY failed",
+		},
+		{
+			name:       "local array index past its declared size is rejected",
+			index:      1,
+			scaleIndex: 3,
+			samples:    [5]int64{1, 2, 3, 4, 5},
+			wantErr:    "OP_VERIFY failed",
+		},
+		{
+			name:    "wrong total is rejected",
+			index:   1,
+			samples: [5]int64{1, 2, 3, 4, 5},
+			total:   1,
+			wantErr: "OP_VERIFY failed",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			total := testCase.total
+			if total == 0 {
+				index := testCase.index
+				if index < 0 || index >= int64(len(testCase.samples)) {
+					index = 0
+				}
+				scaleIndex := testCase.scaleIndex
+				if scaleIndex < 0 || scaleIndex > 2 {
+					scaleIndex = 0
+				}
+				total = expectedTotal(weights, testCase.samples, index, scaleIndex)
+			}
+
+			values := map[string][]byte{
+				"index":      scriptInt(t, testCase.index),
+				"scaleIndex": scriptInt(t, testCase.scaleIndex),
+				"expected":   scriptInt(t, total),
+				"ownerSig":   nil,
+			}
+			for i, sample := range testCase.samples {
+				values[fmt.Sprintf("samples_%d", i)] = scriptInt(t, sample)
+			}
+
+			deployment := fundingTx(arrays.pkScript, 10_000)
+			unsigned := spendingPSBTWithWitness(
+				t, deployment, arrays, 10_000, arrays.pkScript,
+				covenantWitness(t, group, values),
+			)
+			values["ownerSig"] = signArkadeSighash(t, unsigned, 0, ownerKey)
+			signed := spendingPSBTWithWitness(
+				t, deployment, arrays, 10_000, arrays.pkScript,
+				covenantWitness(t, group, values),
+			)
+
+			requireVMResult(t, signed, emulatorKey.PubKey(), testCase.wantErr)
+		})
+	}
+}

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -22,9 +22,15 @@ import (
 )
 
 type artifact struct {
-	Name      string          `json:"contractName"`
-	Functions []functionGroup `json:"functions"`
-	Warnings  []string        `json:"warnings"`
+	Name              string          `json:"contractName"`
+	ConstructorInputs []abiInput      `json:"constructorInputs"`
+	Functions         []functionGroup `json:"functions"`
+	Warnings          []string        `json:"warnings"`
+}
+
+type abiInput struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type functionGroup struct {
@@ -34,7 +40,8 @@ type functionGroup struct {
 }
 
 type assembly struct {
-	ASM []string `json:"asm"`
+	Inputs []abiInput `json:"inputs"`
+	ASM    []string   `json:"asm"`
 }
 
 type leafArtifact struct {
@@ -105,16 +112,7 @@ func instantiateGroup(
 ) instantiatedGroup {
 	t.Helper()
 
-	var group *functionGroup
-	for i := range contract.Functions {
-		if contract.Functions[i].Name == name {
-			group = &contract.Functions[i]
-			break
-		}
-	}
-	if group == nil || group.Arkade == nil {
-		t.Fatalf("%s.%s covenant not found", contract.Name, name)
-	}
+	group := covenantGroup(t, contract, name)
 
 	var leaf *leafArtifact
 	for i := range group.Leaves {
@@ -144,6 +142,71 @@ func instantiateGroup(
 		pkScript:      pkScript,
 		tapLeafScript: tapLeafScript,
 	}
+}
+
+func covenantGroup(t *testing.T, contract artifact, name string) *functionGroup {
+	t.Helper()
+
+	for i := range contract.Functions {
+		if contract.Functions[i].Name == name && contract.Functions[i].Arkade != nil {
+			return &contract.Functions[i]
+		}
+	}
+	t.Fatalf("%s.%s covenant not found", contract.Name, name)
+	return nil
+}
+
+// arrayTypeParts splits an ABI array type ("int[5]") into its element type and
+// length; length 0 means the type is not an array.
+func arrayTypeParts(typeStr string) (string, int) {
+	open := strings.IndexByte(typeStr, '[')
+	if open < 0 || !strings.HasSuffix(typeStr, "]") {
+		return typeStr, 0
+	}
+	length, err := strconv.Atoi(typeStr[open+1 : len(typeStr)-1])
+	if err != nil || length <= 0 {
+		return typeStr, 0
+	}
+	return typeStr[:open], length
+}
+
+// expandInput maps one ABI entry to the stack items it contributes, deepest
+// first: an array entry becomes name_{N-1} … name_0, so element 0 ends up
+// closest to the top.
+func expandInput(input abiInput) []string {
+	_, length := arrayTypeParts(input.Type)
+	if length == 0 {
+		return []string{input.Name}
+	}
+	names := make([]string, 0, length)
+	for index := length - 1; index >= 0; index-- {
+		names = append(names, fmt.Sprintf("%s_%d", input.Name, index))
+	}
+	return names
+}
+
+// covenantWitness builds the covenant witness from the ABI alone: inputs in
+// reverse declaration order, array entries expanded per expandInput. This is
+// the client-side convention the artifact documents.
+func covenantWitness(
+	t *testing.T,
+	group *functionGroup,
+	values map[string][]byte,
+) wire.TxWitness {
+	t.Helper()
+
+	inputs := group.Arkade.Inputs
+	witness := make(wire.TxWitness, 0, len(inputs))
+	for i := len(inputs) - 1; i >= 0; i-- {
+		for _, name := range expandInput(inputs[i]) {
+			value, ok := values[name]
+			if !ok {
+				t.Fatalf("missing witness value for covenant input %q", name)
+			}
+			witness = append(witness, value)
+		}
+	}
+	return witness
 }
 
 func assemble(t *testing.T, tokens []string, values map[string][]byte) []byte {

--- a/tests/examples/threshold_oracle.rs
+++ b/tests/examples/threshold_oracle.rs
@@ -51,7 +51,7 @@ fn test_threshold_oracle_has_control_flow() {
 fn test_threshold_oracle_constructor_array_flattening() {
     let output = compile(THRESHOLD_ORACLE_CODE).unwrap();
 
-    // pubkey[] oracles should be flattened to oracles_0, oracles_1, oracles_2
+    // pubkey[3] oracles should be flattened to oracles_0, oracles_1, oracles_2
     // in the constructorInputs (default 3 elements)
     let param_names: Vec<&str> = output.parameters.iter().map(|p| p.name.as_str()).collect();
 
@@ -88,7 +88,7 @@ fn test_threshold_oracle_constructor_array_flattening() {
 fn test_threshold_oracle_witness_array_flattening() {
     let output = compile(THRESHOLD_ORACLE_CODE).unwrap();
 
-    // signature[] oracleSigs should be flattened to oracleSigs_0, oracleSigs_1, oracleSigs_2
+    // signature[3] oracleSigs should be flattened to oracleSigs_0, oracleSigs_1, oracleSigs_2
     // in the arkade covenant inputs (function parameters going into the covenant)
     let input_names = arkade_inputs(&output, "attest");
 

--- a/tests/examples/threshold_oracle.rs
+++ b/tests/examples/threshold_oracle.rs
@@ -45,80 +45,50 @@ fn test_threshold_oracle_has_control_flow() {
     assert!(!tokens.is_empty(), "Assembly should not be empty");
 }
 
-// ─── Array ABI Flattening ──────────────────────────────────────────────────────
+// ─── Array ABI Grouping ────────────────────────────────────────────────────────
 
 #[test]
-fn test_threshold_oracle_constructor_array_flattening() {
+fn test_threshold_oracle_constructor_array_is_one_grouped_input() {
     let output = compile(THRESHOLD_ORACLE_CODE).unwrap();
 
-    // pubkey[3] oracles should be flattened to oracles_0, oracles_1, oracles_2
-    // in the constructorInputs (default 3 elements)
+    let oracles = output
+        .parameters
+        .iter()
+        .find(|p| p.name == "oracles")
+        .expect("constructorInputs keeps one entry per source parameter");
+    assert_eq!(oracles.param_type, "pubkey[3]");
+
     let param_names: Vec<&str> = output.parameters.iter().map(|p| p.name.as_str()).collect();
-
     assert!(
-        param_names.contains(&"oracles_0"),
-        "Missing oracles_0 in constructor params. Got: {:?}",
-        param_names
-    );
-    assert!(
-        param_names.contains(&"oracles_1"),
-        "Missing oracles_1 in constructor params. Got: {:?}",
-        param_names
-    );
-    assert!(
-        param_names.contains(&"oracles_2"),
-        "Missing oracles_2 in constructor params. Got: {:?}",
-        param_names
+        !param_names.iter().any(|name| name.starts_with("oracles_")),
+        "array elements must not appear as separate inputs. Got: {param_names:?}"
     );
 
-    // Should NOT contain the original array name
-    assert!(
-        !param_names.contains(&"oracles"),
-        "Should not contain unflatten array 'oracles' in params. Got: {:?}",
-        param_names
-    );
-
-    // Each flattened element should have type 'pubkey'
-    let oracles_0 = output.parameters.iter().find(|p| p.name == "oracles_0");
-    assert!(oracles_0.is_some(), "oracles_0 not found");
-    assert_eq!(oracles_0.unwrap().param_type, "pubkey");
+    // The asm prologue still pushes one placeholder per element.
+    let asm = crate::common::arkade_asm(&output, "attest");
+    for placeholder in ["<oracles_0>", "<oracles_1>", "<oracles_2>"] {
+        assert!(asm.contains(placeholder), "missing {placeholder} in: {asm}");
+    }
 }
 
 #[test]
-fn test_threshold_oracle_witness_array_flattening() {
+fn test_threshold_oracle_covenant_array_input_is_one_grouped_input() {
     let output = compile(THRESHOLD_ORACLE_CODE).unwrap();
 
-    // signature[3] oracleSigs should be flattened to oracleSigs_0, oracleSigs_1, oracleSigs_2
-    // in the arkade covenant inputs (function parameters going into the covenant)
     let input_names = arkade_inputs(&output, "attest");
-
     assert!(
         input_names.contains(&"recipientScriptPubKey".to_string()),
-        "Missing recipientScriptPubKey in covenant inputs. Got: {:?}",
-        input_names
-    );
-
-    assert!(
-        input_names.contains(&"oracleSigs_0".to_string()),
-        "Missing oracleSigs_0 in covenant inputs. Got: {:?}",
-        input_names
+        "Missing recipientScriptPubKey in covenant inputs. Got: {input_names:?}"
     );
     assert!(
-        input_names.contains(&"oracleSigs_1".to_string()),
-        "Missing oracleSigs_1 in covenant inputs. Got: {:?}",
-        input_names
+        input_names.contains(&"oracleSigs".to_string()),
+        "covenant inputs keep one entry per source parameter. Got: {input_names:?}"
     );
     assert!(
-        input_names.contains(&"oracleSigs_2".to_string()),
-        "Missing oracleSigs_2 in covenant inputs. Got: {:?}",
-        input_names
-    );
-
-    // Should NOT contain the original array name
-    assert!(
-        !input_names.contains(&"oracleSigs".to_string()),
-        "Should not contain unflatten array 'oracleSigs' in inputs. Got: {:?}",
-        input_names
+        !input_names
+            .iter()
+            .any(|name| name.starts_with("oracleSigs_")),
+        "array elements must not appear as separate inputs. Got: {input_names:?}"
     );
 }
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -28,6 +28,8 @@ mod no_shadowing;
 mod opcode_functions;
 #[path = "features/packet_primitives.rs"]
 mod packet_primitives;
+#[path = "features/static_arrays.rs"]
+mod static_arrays;
 #[path = "features/symbolic_stack.rs"]
 mod symbolic_stack;
 #[path = "features/tapscript_abi.rs"]

--- a/tests/features/asset_id_explicit.rs
+++ b/tests/features/asset_id_explicit.rs
@@ -286,7 +286,7 @@ fn rejects_bad_gidx_in_if_condition_predicate() {
 fn accepts_loop_index_as_gidx() {
     // The loop index variable is statically Int, so it is a valid gidx operand.
     let src = "contract C(bytes32 fooTxid, pubkey pk) {
-            function f(signature sig, signature[] sigs) {
+            function f(signature sig, signature[3] sigs) {
                 for (i, s) in sigs {
                     require(tx.outputs[i].assets.lookup(fooTxid, i) >= 1);
                 }

--- a/tests/features/beacon.rs
+++ b/tests/features/beacon.rs
@@ -3,24 +3,24 @@ use arkade_compiler::opcodes::{
     OP_CHECKSIG, OP_INSPECTASSETGROUPSUM, OP_INSPECTINASSETLOOKUP, OP_INSPECTOUTPUTSCRIPTPUBKEY,
 };
 
-// Loop-unrolling primitive test over tx.assetGroups.
+// Loop-unrolling primitive test over a declared array of asset group indices.
 const BEACON_LOOP_CODE: &str = r#"
 contract PriceBeacon(
   bytes32 ctrlAssetIdTxid, int ctrlAssetIdGidx,
   pubkey oraclePk,
-  int numGroups
+  int[3] watchedGroups
 ) {
   function passthrough() {
-    require(tx.outputs[0].scriptPubKey == new PriceBeacon(ctrlAssetIdTxid, ctrlAssetIdGidx, oraclePk, numGroups), "broken");
+    require(tx.outputs[0].scriptPubKey == new PriceBeacon(ctrlAssetIdTxid, ctrlAssetIdGidx, oraclePk, watchedGroups), "broken");
 
-    for (k, group) in tx.assetGroups {
+    for (k, group) in watchedGroups {
       require(group.sumOutputs >= group.sumInputs, "drained");
     }
   }
 
   function update(signature oracleSig) {
     require(tx.inputs[0].assets.lookup(ctrlAssetIdTxid, ctrlAssetIdGidx) > 0, "no ctrl");
-    require(tx.outputs[0].scriptPubKey == new PriceBeacon(ctrlAssetIdTxid, ctrlAssetIdGidx, oraclePk, numGroups), "broken");
+    require(tx.outputs[0].scriptPubKey == new PriceBeacon(ctrlAssetIdTxid, ctrlAssetIdGidx, oraclePk, watchedGroups), "broken");
     require(checkSig(oracleSig, oraclePk), "bad sig");
   }
 }

--- a/tests/features/concat_op.rs
+++ b/tests/features/concat_op.rs
@@ -77,7 +77,7 @@ contract IntMath(int a, int b) {
 fn test_loop_body_substitutes_index_through_byte_ops() {
     let code = r#"
 contract LoopHash(bytes32 tag) {
-  function check(int[] prices) {
+  function check(int[3] prices) {
     for (i, p) in prices {
       let m = sha256(tag + num2bin(p, 8));
       require(m == tag);

--- a/tests/features/contract_import_instantiation.rs
+++ b/tests/features/contract_import_instantiation.rs
@@ -434,7 +434,7 @@ fn test_array_constructor_arg_is_flattened() {
     let code = r#"
 import "threshold_oracle.ark";
 
-contract Forwarder(pubkey[] owners) {
+contract Forwarder(pubkey[3] owners) {
   function forward() {
     require(tx.outputs[0].scriptPubKey == new ThresholdOracle(owners));
   }

--- a/tests/features/general_comparisons.rs
+++ b/tests/features/general_comparisons.rs
@@ -342,7 +342,7 @@ fn mismatched_comparisons_warn() {
 fn direct_array_equality_is_rejected() {
     let error = compile(
         "contract Invalid() {
-            function compare(int[] left, int[] right) {
+            function compare(int[3] left, int[3] right) {
                 require(left == right);
             }
         }",

--- a/tests/features/no_shadowing.rs
+++ b/tests/features/no_shadowing.rs
@@ -55,8 +55,8 @@ contract Demo(int amount) {
 fn allows_reassignment_of_local() {
     // `int valid = 0;` then `valid = valid + 1;` — the documented pattern.
     let src = r#"
-contract Demo(pubkey[] ks) {
-  function f(signature[] sigs, bytes32 msg) {
+contract Demo(pubkey[3] ks) {
+  function f(signature[3] sigs, bytes32 msg) {
     int valid = 0;
     for (i, s) in sigs {
       if (checkSigFromStack(s, ks[i], msg)) {
@@ -117,8 +117,8 @@ contract Demo(int limit) {
 #[test]
 fn rejects_inner_loop_var_shadowing_outer_loop_var() {
     let src = r#"
-contract Demo(pubkey[] ks) {
-  function f(signature[] sigs, bytes32 msg) {
+contract Demo(pubkey[3] ks) {
+  function f(signature[3] sigs, bytes32 msg) {
     for (i, s) in sigs {
       for (i, t) in sigs {
         require(checkSigFromStack(s, ks[i], msg));
@@ -141,7 +141,7 @@ contract Demo(pubkey[] ks) {
 fn rejects_loop_var_shadowing_constructor_param() {
     let src = r#"
 contract Demo(int i) {
-  function f(signature[] sigs, pubkey[] ks, bytes32 msg) {
+  function f(signature[3] sigs, pubkey[3] ks, bytes32 msg) {
     for (i, s) in sigs {
       require(checkSigFromStack(s, ks[i], msg));
     }
@@ -160,8 +160,8 @@ contract Demo(int i) {
 #[test]
 fn rejects_identical_loop_variables() {
     let src = r#"
-contract Demo(pubkey[] ks) {
-  function f(signature[] sigs, bytes32 msg) {
+contract Demo(pubkey[3] ks) {
+  function f(signature[3] sigs, bytes32 msg) {
     for (x, x) in sigs {
       require(checkSigFromStack(x, ks[0], msg));
     }
@@ -176,9 +176,9 @@ contract Demo(pubkey[] ks) {
 
 #[test]
 fn rejects_array_element_colliding_with_scalar_param() {
-    // Constructor `int[] xs` -> xs_0, xs_1, xs_2 ; function `int xs_0` -> xs_0.
+    // Constructor `int[3] xs` -> xs_0, xs_1, xs_2 ; function `int xs_0` -> xs_0.
     let src = r#"
-contract Demo(int[] xs) {
+contract Demo(int[3] xs) {
   function f(int xs_0) {
     require(xs_0 >= 1);
   }
@@ -197,7 +197,7 @@ contract Demo(int[] xs) {
 fn flattened_abi_names_do_not_alias_array_elements() {
     let cases = [
         r#"
-contract Demo(int[] xs) {
+contract Demo(int[3] xs) {
   function f() {
     require(xs_0 >= 1);
   }
@@ -205,14 +205,14 @@ contract Demo(int[] xs) {
 "#,
         r#"
 contract Demo() {
-  function f(int[] xs) {
+  function f(int[3] xs) {
     xs_0 = 5;
     require(xs[0] >= 1);
   }
 }
 "#,
         r#"
-contract Demo(pubkey[] keys) {
+contract Demo(pubkey[3] keys) {
   function f(signature sig, bytes32 msg) {
     require(checkSigFromStack(sig, keys_0, msg));
   }
@@ -234,7 +234,7 @@ contract Demo(pubkey[] keys) {
 #[test]
 fn source_bindings_can_reuse_flattened_abi_names() {
     let source = r#"
-contract Demo(int[] xs) {
+contract Demo(int[3] xs) {
   function f() {
     let xs_0 = 1;
     require(xs[0] >= xs_0);
@@ -254,7 +254,7 @@ contract Demo(int[] xs) {
 fn rejects_tapscript_array_expansion_collisions() {
     let cases = [
         r#"
-contract Demo(pubkey[] owners) {
+contract Demo(pubkey[3] owners) {
   function leaf(signature sig, pubkey owners_0) tapscript {
     require(checkSig(sig, owners_0));
   }
@@ -262,7 +262,7 @@ contract Demo(pubkey[] owners) {
 "#,
         r#"
 contract Demo(pubkey owner) {
-  function leaf(signature[] sigs, signature sigs_0) tapscript {
+  function leaf(signature[3] sigs, signature sigs_0) tapscript {
     require(checkSig(sigs_0, owner));
   }
 }
@@ -284,8 +284,8 @@ contract Demo(pubkey owner) {
 fn accepts_sibling_scope_reuse() {
     // let x in both branches; the same loop vars in two separate loops.
     let src = r#"
-contract Demo(pubkey[] ks) {
-  function f(signature[] sigs, bytes32 msg, int flag) {
+contract Demo(pubkey[3] ks) {
+  function f(signature[3] sigs, bytes32 msg, int flag) {
     if (flag >= 1) {
       int x = 1;
       require(x >= 1);

--- a/tests/features/no_shadowing.rs
+++ b/tests/features/no_shadowing.rs
@@ -252,7 +252,9 @@ contract Demo(int[3] xs) {
 
 #[test]
 fn rejects_tapscript_array_expansion_collisions() {
-    let cases = [
+    // Tapscript inputs cannot be arrays, so the collision can only come from a
+    // constructor array expanding onto a declared tapscript input name.
+    let error = compile(
         r#"
 contract Demo(pubkey[3] owners) {
   function leaf(signature sig, pubkey owners_0) tapscript {
@@ -260,24 +262,13 @@ contract Demo(pubkey[3] owners) {
   }
 }
 "#,
-        r#"
-contract Demo(pubkey owner) {
-  function leaf(signature[3] sigs, signature sigs_0) tapscript {
-    require(checkSig(sigs_0, owner));
-  }
-}
-"#,
-    ];
-
-    for source in cases {
-        let error = compile(source)
-            .expect_err("expanded tapscript names must not collide")
-            .to_string();
-        assert!(
-            error.contains("collide in the emitted namespace"),
-            "unexpected error: {error}"
-        );
-    }
+    )
+    .expect_err("expanded tapscript names must not collide")
+    .to_string();
+    assert!(
+        error.contains("collide in the emitted namespace"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]

--- a/tests/features/opcode_functions.rs
+++ b/tests/features/opcode_functions.rs
@@ -170,7 +170,7 @@ fn test_unary_minus_negates() {
 fn test_unary_minus_substitutes_loop_index() {
     let code = r#"
         contract LoopNeg(pubkey owner) {
-            function f(int[] amounts) {
+            function f(int[3] amounts) {
                 for (i, amt) in amounts {
                     let d = -i;
                     require(d <= 0);

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -1,5 +1,5 @@
 use arkade_compiler::compile;
-use arkade_compiler::opcodes::{OP_ADD, OP_CHECKSIGFROMSTACK, OP_LESSTHAN};
+use arkade_compiler::opcodes::{OP_ADD, OP_CHECKSIGFROMSTACK, OP_DROP, OP_LESSTHAN, OP_ROLL};
 
 fn contains_tokens(asm: &[String], expected: &[&str]) -> bool {
     asm.windows(expected.len()).any(|window| {
@@ -174,4 +174,109 @@ contract Scalar(int limit) {
     .to_string();
 
     assert!(error.contains(".length"), "unexpected error: {error}");
+}
+
+#[test]
+fn local_arrays_bind_one_element_per_declared_slot() {
+    let output = compile(
+        r#"
+contract Local(int limit) {
+    function spend(int amount, int index) {
+        int[3] weights = [1, 2, 5];
+        require(amount * weights[index] >= limit + weights.length);
+    }
+}
+"#,
+    )
+    .expect("local array must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        contains_tokens(&asm, &["5", "2", "1"]),
+        "elements are pushed deepest-last so element 0 sits closest to the top: {asm:?}"
+    );
+    assert!(
+        contains_tokens(&asm, &["OP_3", OP_LESSTHAN]),
+        "runtime index into a local array is bounded by its declared size: {asm:?}"
+    );
+}
+
+#[test]
+fn local_array_elements_are_assignable_at_a_literal_index() {
+    let output = compile(
+        r#"
+contract Local() {
+    function spend(int amount) {
+        int[2] weights = [1, 2];
+        weights[0] = 4;
+        require(amount >= weights[0]);
+    }
+}
+"#,
+    )
+    .expect("element assignment must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        contains_tokens(&asm, &["4", "OP_1", OP_ROLL, OP_DROP]),
+        "assignment overwrites the element in place: {asm:?}"
+    );
+}
+
+#[test]
+fn assignment_at_a_runtime_index_is_rejected() {
+    let error = compile(
+        r#"
+contract Local() {
+    function spend(int amount, int index) {
+        int[2] weights = [1, 2];
+        weights[index] = 4;
+        require(amount >= weights[0]);
+    }
+}
+"#,
+    )
+    .expect_err("runtime-index assignment must be rejected")
+    .to_string();
+
+    assert!(error.contains("runtime index"), "unexpected error: {error}");
+}
+
+#[test]
+fn array_literal_size_must_match_the_declaration() {
+    let error = compile(
+        r#"
+contract Local() {
+    function spend(int amount) {
+        int[3] weights = [1, 2];
+        require(amount >= weights[0]);
+    }
+}
+"#,
+    )
+    .expect_err("element count mismatch must be rejected")
+    .to_string();
+
+    assert!(
+        error.contains("int[3]") && error.contains("int[2]"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn array_literals_are_rejected_outside_array_declarations() {
+    let error = compile(
+        r#"
+contract Local() {
+    function spend(int amount) {
+        let weights = [1, 2];
+        require(amount >= weights);
+    }
+}
+"#,
+    )
+    .expect_err("array literal outside an array declaration must be rejected")
+    .to_string();
+
+    assert!(error.contains("array literal"), "unexpected error: {error}");
 }

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -280,3 +280,25 @@ contract Local() {
 
     assert!(error.contains("array literal"), "unexpected error: {error}");
 }
+
+#[test]
+fn iterating_tx_asset_groups_is_rejected() {
+    let error = compile(
+        r#"
+contract Groups() {
+    function spend() {
+        for (k, group) in tx.assetGroups {
+            require(group.sumOutputs >= group.sumInputs, "drained");
+        }
+    }
+}
+"#,
+    )
+    .expect_err("the asset group count is not known at compile time")
+    .to_string();
+
+    assert!(
+        error.contains("cannot iterate 'tx.assetGroups'"),
+        "unexpected error: {error}"
+    );
+}

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -1,5 +1,7 @@
 use arkade_compiler::compile;
-use arkade_compiler::opcodes::{OP_ADD, OP_CHECKSIGFROMSTACK, OP_DROP, OP_LESSTHAN, OP_ROLL};
+use arkade_compiler::opcodes::{
+    OP_ADD, OP_CAT, OP_CHECKSIGFROMSTACK, OP_DROP, OP_LESSTHAN, OP_ROLL, OP_SWAP,
+};
 
 fn contains_tokens(asm: &[String], expected: &[&str]) -> bool {
     asm.windows(expected.len()).any(|window| {
@@ -324,5 +326,100 @@ contract Demo(pubkey owner) {
     assert!(
         error.contains("array witnesses are not supported"),
         "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn array_literal_elements_are_substituted_inside_loops() {
+    let output = compile(
+        r#"
+contract Local(int limit) {
+    function spend(int[2] xs) {
+        for (i, v) in xs {
+            int[2] pair = [v, i];
+            require(pair[0] + pair[1] >= limit);
+        }
+    }
+}
+"#,
+    )
+    .expect("loop variables inside an array literal must be unrolled");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        asm.iter().all(|token| !token.contains("$array:")),
+        "internal bindings must not leak: {asm:?}"
+    );
+}
+
+#[test]
+fn array_literal_elements_are_rewritten_by_the_concat_pass() {
+    let output = compile(
+        r#"
+contract Parts(bytes32 a, bytes32 b, bytes expected) {
+    function spend(int amount) {
+        bytes[2] parts = [a + b, a];
+        require(parts[0] == expected);
+        require(amount > 0);
+    }
+}
+"#,
+    )
+    .expect("byte concatenation inside an array literal must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        asm.iter().any(|token| token == OP_CAT),
+        "adding two byte operands must emit {OP_CAT}, not arithmetic: {asm:?}"
+    );
+    assert!(
+        !asm.iter().any(|token| token == OP_ADD),
+        "byte concatenation must not emit {OP_ADD}: {asm:?}"
+    );
+}
+
+#[test]
+fn array_literal_element_types_must_match_the_declared_element_type() {
+    let error = compile(
+        r#"
+contract Local(bytes32 h) {
+    function spend(int amount, bytes32 other) {
+        bytes32[2] xs = [h, 5];
+        require(xs[1] == other);
+        require(amount > 0);
+    }
+}
+"#,
+    )
+    .expect_err("a heterogeneous array literal must be rejected")
+    .to_string();
+
+    assert!(
+        error.contains("element 1 of array 'xs' has type 'int', expected 'bytes32'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn local_array_elements_are_assignable_at_a_nonzero_literal_index() {
+    let output = compile(
+        r#"
+contract Local() {
+    function spend(int amount) {
+        int[3] weights = [1, 2, 3];
+        weights[1] = 9;
+        require(amount >= (weights[0] + weights[1]) + weights[2]);
+    }
+}
+"#,
+    )
+    .expect("element assignment at a non-zero index must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    // Index 0 sits directly under the pushed value (depth 1, no walk-back);
+    // index 1 is one deeper and must be swapped back into place.
+    assert!(
+        contains_tokens(&asm, &["9", "OP_2", OP_ROLL, OP_DROP, OP_SWAP]),
+        "the write must roll the element at its own depth, not index 0's: {asm:?}"
     );
 }

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -302,3 +302,27 @@ contract Groups() {
         "unexpected error: {error}"
     );
 }
+
+#[test]
+fn array_inputs_are_rejected_in_tapscript_functions() {
+    let error = compile(
+        r#"
+contract Demo(pubkey owner) {
+    function spend(signature sig) {
+        require(checkSig(sig, owner));
+    }
+
+    function leaf(signature sig, signature[3] extras) tapscript {
+        require(checkSig(sig, owner));
+    }
+}
+"#,
+    )
+    .expect_err("array witnesses are not supported in tapscript functions")
+    .to_string();
+
+    assert!(
+        error.contains("array witnesses are not supported"),
+        "unexpected error: {error}"
+    );
+}

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -1,5 +1,5 @@
 use arkade_compiler::compile;
-use arkade_compiler::opcodes::{OP_CHECKSIGFROMSTACK, OP_LESSTHAN};
+use arkade_compiler::opcodes::{OP_ADD, OP_CHECKSIGFROMSTACK, OP_LESSTHAN};
 
 fn contains_tokens(asm: &[String], expected: &[&str]) -> bool {
     asm.windows(expected.len()).any(|window| {
@@ -137,4 +137,41 @@ contract Unsized(pubkey[] owners) {
         error.to_lowercase().contains("parse"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn array_length_folds_to_a_literal() {
+    let output = compile(
+        r#"
+contract Quorum(pubkey[5] oracles) {
+    function spend(int[4] weights, int total) {
+        require(total >= oracles.length + weights.length);
+    }
+}
+"#,
+    )
+    .expect("arr.length must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        contains_tokens(&asm, &["OP_5", "OP_4", OP_ADD]),
+        "each .length folds to its declared size: {asm:?}"
+    );
+}
+
+#[test]
+fn length_on_a_non_array_is_rejected() {
+    let error = compile(
+        r#"
+contract Scalar(int limit) {
+    function spend(int amount) {
+        require(amount >= limit.length);
+    }
+}
+"#,
+    )
+    .expect_err("'.length' on a scalar must be rejected")
+    .to_string();
+
+    assert!(error.contains(".length"), "unexpected error: {error}");
 }

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -29,15 +29,15 @@ contract Sized(pubkey[2] owners) {
             .iter()
             .map(|p| (p.name.as_str(), p.param_type.as_str()))
             .collect::<Vec<_>>(),
-        vec![("owners_0", "pubkey"), ("owners_1", "pubkey")],
-        "constructor arrays flatten to one scalar input per declared element"
+        vec![("owners", "pubkey[2]")],
+        "constructor inputs keep one entry per source parameter, sized"
     );
 
     let inputs = crate::common::arkade_inputs(&output, "spend");
     assert_eq!(
         inputs,
-        vec!["sigs_0", "sigs_1", "sigs_2", "sigs_3", "msg"],
-        "function arrays expand to one input per declared element"
+        vec!["sigs", "msg"],
+        "covenant inputs keep one entry per source parameter"
     );
 
     let asm = crate::common::arkade_asm(&output, "spend");

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -1,0 +1,140 @@
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{OP_CHECKSIGFROMSTACK, OP_LESSTHAN};
+
+fn contains_tokens(asm: &[String], expected: &[&str]) -> bool {
+    asm.windows(expected.len()).any(|window| {
+        window
+            .iter()
+            .map(String::as_str)
+            .eq(expected.iter().copied())
+    })
+}
+
+#[test]
+fn declared_sizes_drive_input_expansion_per_array() {
+    let output = compile(
+        r#"
+contract Sized(pubkey[2] owners) {
+    function spend(signature[4] sigs, bytes32 msg) {
+        require(checkSigFromStack(sigs[0], owners[1], msg));
+    }
+}
+"#,
+    )
+    .expect("sized arrays must compile");
+
+    assert_eq!(
+        output
+            .parameters
+            .iter()
+            .map(|p| (p.name.as_str(), p.param_type.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("owners_0", "pubkey"), ("owners_1", "pubkey")],
+        "constructor arrays flatten to one scalar input per declared element"
+    );
+
+    let inputs = crate::common::arkade_inputs(&output, "spend");
+    assert_eq!(
+        inputs,
+        vec!["sigs_0", "sigs_1", "sigs_2", "sigs_3", "msg"],
+        "function arrays expand to one input per declared element"
+    );
+
+    let asm = crate::common::arkade_asm(&output, "spend");
+    for placeholder in ["<owners_0>", "<owners_1>"] {
+        assert!(
+            asm.contains(placeholder),
+            "constructor array expands to its declared size: {asm}"
+        );
+    }
+    assert!(
+        !asm.contains("<owners_2>"),
+        "constructor array must not expand past its declared size: {asm}"
+    );
+}
+
+#[test]
+fn loops_unroll_once_per_declared_element() {
+    let output = compile(
+        r#"
+contract Quorum(pubkey[5] oracles) {
+    function attest(signature[5] sigs, bytes32 msg) {
+        int valid = 0;
+        for (i, sig) in sigs {
+            if (checkSigFromStack(sig, oracles[i], msg)) {
+                valid = valid + 1;
+            }
+        }
+        require(valid >= 3);
+    }
+}
+"#,
+    )
+    .expect("loop over a sized array must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "attest");
+    assert_eq!(
+        asm.iter()
+            .filter(|token| token.as_str() == OP_CHECKSIGFROMSTACK)
+            .count(),
+        5,
+        "loop unrolls once per declared element"
+    );
+}
+
+#[test]
+fn runtime_index_bound_check_uses_the_arrays_own_size() {
+    let output = compile(
+        r#"
+contract Bounds() {
+    function spend(int[7] values, int index) {
+        require(values[index] >= 0);
+    }
+}
+"#,
+    )
+    .expect("runtime index must compile");
+
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        contains_tokens(&asm, &["OP_7", OP_LESSTHAN]),
+        "bound check must compare against the declared size: {asm:?}"
+    );
+}
+
+#[test]
+fn literal_index_past_the_declared_size_is_rejected() {
+    let error = compile(
+        r#"
+contract Bounds() {
+    function spend(int[2] values, int expected) {
+        require(values[2] == expected);
+    }
+}
+"#,
+    )
+    .expect_err("index at the declared size must be rejected")
+    .to_string();
+
+    assert!(error.contains("out of range"), "unexpected error: {error}");
+}
+
+#[test]
+fn unsized_array_types_are_rejected() {
+    let error = compile(
+        r#"
+contract Unsized(pubkey[] owners) {
+    function spend(signature sig) {
+        require(checkSig(sig, owners[0]));
+    }
+}
+"#,
+    )
+    .expect_err("unsized array types must be rejected")
+    .to_string();
+
+    assert!(
+        error.to_lowercase().contains("parse"),
+        "unexpected error: {error}"
+    );
+}

--- a/tests/features/symbolic_stack.rs
+++ b/tests/features/symbolic_stack.rs
@@ -133,7 +133,7 @@ fn array_loop_values_remain_runtime_group_indices() {
     let covenant = covenant(
         r#"
 contract GroupIndices() {
-    function spend(int[] groups) {
+    function spend(int[3] groups) {
         let total = 0;
         for (i, group) in groups {
             total = total + group.sumInputs + i;
@@ -165,7 +165,7 @@ fn runtime_array_indices_are_bounded_and_pick_by_computed_depth() {
     let covenant = covenant(
         r#"
 contract RuntimeIndex() {
-    function spend(int[] values, int index) {
+    function spend(int[3] values, int index) {
         require(values[index] >= 0);
     }
 }
@@ -207,7 +207,7 @@ fn array_index_accepts_integer_expressions() {
     let covenant = covenant(
         r#"
 contract ExpressionIndex() {
-    function spend(int[] values, int x, int y) {
+    function spend(int[3] values, int x, int y) {
         require(values[x * y + 3] >= 0);
     }
 }
@@ -228,7 +228,7 @@ fn literal_array_indices_remain_static() {
     let covenant = covenant(
         r#"
 contract StaticIndex() {
-    function spend(int[] values, int expected) {
+    function spend(int[3] values, int expected) {
         require(values[2] == expected);
     }
 }
@@ -247,7 +247,7 @@ contract StaticIndex() {
 fn leading_zero_array_indices_are_rejected() {
     let source = r#"
 contract StaticIndex() {
-    function spend(int[] values, int expected) {
+    function spend(int[3] values, int expected) {
         require(values[01] == expected);
     }
 }
@@ -260,7 +260,7 @@ contract StaticIndex() {
 fn runtime_array_indices_work_in_named_crypto_operands_and_loop_values() {
     let cases = [
         r#"
-contract RuntimeIndex(pubkey[] keys) {
+contract RuntimeIndex(pubkey[3] keys) {
     function spend(signature sig, bytes32 msg, int index) {
         require(checkSigFromStack(sig, keys[index], msg));
     }
@@ -268,7 +268,7 @@ contract RuntimeIndex(pubkey[] keys) {
 "#,
         r#"
 contract LoopValueIndex() {
-    function spend(int[] indices, int[] values) {
+    function spend(int[3] indices, int[3] values) {
         for (i, index) in indices {
             require(values[index] >= 0);
         }
@@ -286,7 +286,7 @@ contract LoopValueIndex() {
 fn runtime_array_index_must_be_an_integer() {
     let source = r#"
 contract RuntimeIndex() {
-    function spend(int[] values, bytes index) {
+    function spend(int[3] values, bytes index) {
         require(values[index] >= 0);
     }
 }


### PR DESCRIPTION
Arrays were fixed at three elements by a single compile-wide constant (`DEFAULT_ARRAY_LENGTH`). This replaces that with sCrypt-style static arrays: the size is part of the type and every layer reads it from the declaration.

```
contract Quorum(pubkey[5] oracles) {
  function attest(signature[5] sigs, bytes32 msg, int index) {
    int[3] weights = [1, 2, 5];
    weights[0] = 4;

    for (i, sig) in sigs { ... }          // unrolls 5x
    require(checkSigFromStack(sigs[index], oracles[index], msg));  // bound-checked against 5
    require(total >= oracles.length);     // folds to 5
  }
}
```

## What changed

- **`T[N]` is the only array form.** Bare `T[]` no longer parses; `T[0]` and `T[01]` are parse errors. `DEFAULT_ARRAY_LENGTH` is deleted.
- **`arr.length`** folds to the declared size at compile time.
- **Local arrays**: `int[3] xs = [1, 2, 3];` with element assignment at a literal index. Elements bind exactly like parameter arrays, so indexing, loops and `.length` treat them identically.
- **Artifact ABI groups arrays.** `constructorInputs`, `arkade.inputs` and leaf `witness` keep one entry per source parameter, carrying the size: `{ "name": "oracles", "type": "pubkey[3]" }`.
- **Arrays are covenant-only.** Constructor and covenant function parameters take arrays; `tapscript` function inputs must be scalars, so no tapleaf witness carries an array for now.
- **`for … in tx.assetGroups` is rejected.** The group count is not known at compile time, so the old fixed unroll silently checked only the first three groups.

Rejected with a message: bare `T[]`, zero or leading-zero sizes, an array input on a `tapscript` function, a literal index at or past the declared size, an initializer whose element count or type does not match, an array literal without a declared array type, and `xs[i] = v` at a runtime index.

## Notes for review

**The compiler derives array lengths from the symbolic stack.** `Generator::array_length` counts the contiguous `$array:name:i` bindings already tracked there, so no new state was needed for the bound check or the unroll count, and local arrays work through the same path as parameters.

**The ABI and the script now speak two representations.** The artifact groups arrays; `asm` keeps per-element placeholders (`<oracles_0>`). `validate_output` derives the expected constructor prologue by flattening `constructorInputs`, so a mismatch between the two fails the build. Consumers expand: `arkade-bindgen` (`fields_from_ark_type`) and `playground/codegen.js` (`expandFields`). Without that expansion, `Encoding::from_ark_type("pubkey[3]")` would have fallen through to `Unknown` and generated `[]byte` fields for a pubkey — silently wrong stubs, hence the new `test_ir_expands_grouped_array_fields`.

**Runtime-index assignment (`xs[i] = v`) is deferred, not forgotten.** The VM has `OP_PICK` (read at a runtime depth) but no inverse, so every write is emulated — `Generator::assign` costs `O(depth)` opcodes today for *every* assignment. Emulating a dynamic array write on the current opcode set costs `N` guarded writes. The design doc writes up an `OP_PUT` proposal (dual of `OP_PICK`, O(1) interpreter cost, constant `-2` stack effect) that would make it ~11 opcodes and collapse `assign` to two. Note the `0 <= i < N` check stays the compiler's job either way: `OP_PUT` can only bound-check against the whole stack, while an array occupies a subrange, so a witness-supplied index could otherwise overwrite a neighbouring binding.

## Testing

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` pass at each of the six commits. `./playground/build.sh` succeeds.

New e2e (`sh scripts/e2e.sh`): `tests/e2e/contracts/static_arrays.ark` runs an `int[4]` constructor array, an `int[5]` function array and a local `int[3]` through the Arkade VM, with runtime indexing into both a parameter and a local array, and rejection cases for negative, past-the-end and local out-of-range indices. The harness builds the witness from the ABI (`covenantWitness`/`expandInput`), so it exercises the documented client-side expansion rather than assuming an order.

Two things worth knowing about that e2e, from mutation-checking it:

- Reversing the local-array push order initially *passed*, because flipping the order flips the binding names too and literal indexing stays correct by name. Only a runtime index into a local array depends on that layout, so the contract now does one; the mutation fails the suite.
- An off-by-one in the runtime bound value still passes the e2e — an over-long guard lets the read succeed and the later total check trips the same `OP_VERIFY failed`. That case is pinned by the unit test `runtime_index_bound_check_uses_the_arrays_own_size`, which asserts the exact emitted length.

## Migration

Every `T[]` declaration needs a size; `[3]` preserves current behaviour. Clients expand a grouped array entry into `name_0 … name_{N-1}` in index order (witness order is reverse declaration order, element 0 closest to the top).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fixed-size arrays with indexing, `.length`, literals, assignments, and loop iteration.
  * Preserved grouped array inputs in contract interfaces while expanding elements for execution.
  * Added validation for array sizes, bounds, and invalid array usage.
  * Added end-to-end coverage for static-array contracts and transaction scenarios.

* **Documentation**
  * Documented array behavior, stack ordering, serialization, and constructor handling.
  * Updated the threshold oracle example to use fixed-size arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
