### PR TITLE
Add custom struct types

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,20 @@ contract Vault(Policy policy) {
 
 Struct literals require an explicit type and every named field exactly once. Scalar leaves may be read and assigned, while whole-struct assignment and comparison are unsupported. Structs can contain scalar arrays, but arrays of structs and struct-valued `tapscript` inputs are not supported.
 
+Fixed-width builtins that return multiple stack items expose native result structs. Their types and fields are `AssetId { bytes32 txid; int gidx; }`, `Outpoint { bytes32 txid; int vout; }`, and `ECPoint { int x; int y; }`. The type may be explicit or inferred with `let`:
+
+```solidity
+let assetId = tx.outputs[0].assets[0].assetId;
+Outpoint previous = tx.inputs[0].outpoint;
+ECPoint sum = ecAdd(x1, y1, x2, y2, curveId);
+
+require(assetId.gidx >= 0);
+require(previous.txid == expectedTxid);
+require(sum.x >= 0);
+```
+
+`AssetId` is returned by indexed asset and asset-group `.assetId` access, `Outpoint` by input `.outpoint` access, and `ECPoint` by `ecAdd` and `ecMul`. Native result structs are local values; whole-struct comparison remains unsupported.
+
 ### Contract Structure
 
 An Arkade Language file may start with zero or more `import` declarations, followed by a `contract` declaration:

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ contract FujiSafe(
 - `bool`: Boolean value
 - `asset`: Asset identifier (for asset-aware contracts)
 
-Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles_0 … oracles_4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally. Arrays are allowed in constructor and covenant function parameters; `tapscript` function inputs must be scalars.
+Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles.0` … `oracles.4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally. Arrays are allowed in constructor and covenant function parameters; `tapscript` function inputs must be scalars.
 
 Named structs are declared before the contract. Their scalar leaves occupy separate stack items and may include nested structs or fixed arrays of scalar types:
 
@@ -470,9 +470,9 @@ Arkade Language compiles to Arkade Script and produces a JSON artifact for use w
 
 `constructorInputs`, `arkade.inputs` and each leaf's `witness` describe the source ABI: one entry per source parameter, in declaration order. They do not describe the physical VM stack order.
 
-An array parameter stays one entry carrying its size in the type (`{ "name": "oracles", "type": "pubkey[3]" }`). Each array element is a separate stack item and a separate `<name_i>` placeholder, so clients expand an array entry into `name_0 … name_{N-1}` in index order.
+An array parameter stays one entry carrying its size in the type (`{ "name": "oracles", "type": "pubkey[3]" }`). Each array element is a separate stack item and a separate `<name.i>` placeholder, so clients expand an array entry into `name.0` … `name.{N-1}` in index order.
 
-A struct parameter also stays grouped under its named type. Clients use the artifact's `structs` declarations to flatten its scalar leaves recursively in field declaration order. For example, `Policy policy` above expands to `policy_primary_key`, `policy_primary_weight`, `policy_limits_0`, and `policy_limits_1`.
+A struct parameter also stays grouped under its named type. Clients use the artifact's `structs` declarations to flatten its scalar leaves recursively in field declaration order. For example, `Policy policy` above expands to `policy.primary.key`, `policy.primary.weight`, `policy.limits.0`, and `policy.limits.1`. Period-separated path segments are unambiguous because source identifiers cannot contain periods.
 
 Clients serialize covenant function inputs in reverse `arkade.inputs` order. For example, source inputs `[amount, sig]` produce the physical bottom-to-top witness `[sig, amount]`.
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,33 @@ contract FujiSafe(
 
 Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles_0 … oracles_4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally. Arrays are allowed in constructor and covenant function parameters; `tapscript` function inputs must be scalars.
 
+Named structs are declared before the contract. Their scalar leaves occupy separate stack items and may include nested structs or fixed arrays of scalar types:
+
+```solidity
+struct Signer {
+  pubkey key;
+  int weight;
+}
+
+struct Policy {
+  Signer primary;
+  int[2] limits;
+}
+
+contract Vault(Policy policy) {
+  function spend(int expected) {
+    Policy local = {
+      primary: { key: policy.primary.key, weight: expected },
+      limits: [1, 2]
+    };
+    local.primary.weight = local.limits[1];
+    require(local.primary.weight == expected);
+  }
+}
+```
+
+Struct literals require an explicit type and every named field exactly once. Scalar leaves may be read and assigned, while whole-struct assignment and comparison are unsupported. Structs can contain scalar arrays, but arrays of structs and struct-valued `tapscript` inputs are not supported.
+
 ### Contract Structure
 
 An Arkade Language file may start with zero or more `import` declarations, followed by a `contract` declaration:
@@ -431,6 +458,7 @@ Arkade Language compiles to Arkade Script and produces a JSON artifact for use w
 |-----------------------|-------------------------------------------------------------------------------------------|
 | `contractName`        | Contract identifier                                                                       |
 | `constructorInputs`   | Constructor parameters in source declaration order, one entry per parameter               |
+| `structs`             | User-defined struct layouts in source declaration order                                   |
 | `functions`           | Spend groups: `{ name, arkade?, leaves[] }`                                               |
 | `arkade`              | Optional emulator-run covenant `{ inputs, asm }`                                          |
 | `arkade.inputs`       | Function parameters in source declaration order, one entry per parameter                  |
@@ -443,6 +471,8 @@ Arkade Language compiles to Arkade Script and produces a JSON artifact for use w
 `constructorInputs`, `arkade.inputs` and each leaf's `witness` describe the source ABI: one entry per source parameter, in declaration order. They do not describe the physical VM stack order.
 
 An array parameter stays one entry carrying its size in the type (`{ "name": "oracles", "type": "pubkey[3]" }`). Each array element is a separate stack item and a separate `<name_i>` placeholder, so clients expand an array entry into `name_0 … name_{N-1}` in index order.
+
+A struct parameter also stays grouped under its named type. Clients use the artifact's `structs` declarations to flatten its scalar leaves recursively in field declaration order. For example, `Policy policy` above expands to `policy_primary_key`, `policy_primary_weight`, `policy_limits_0`, and `policy_limits_1`.
 
 Clients serialize covenant function inputs in reverse `arkade.inputs` order. For example, source inputs `[amount, sig]` produce the physical bottom-to-top witness `[sig, amount]`.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ require(previous.txid == expectedTxid);
 require(sum.x >= 0);
 ```
 
-`AssetId` is returned by indexed asset and asset-group `.assetId` access, `Outpoint` by input `.outpoint` access, and `ECPoint` by `ecAdd` and `ecMul`. Native result structs are local values; whole-struct comparison remains unsupported.
+`AssetId` is returned by indexed asset and asset-group `.assetId` access, `Outpoint` by input `.outpoint` access, and `ECPoint` by `ecAdd` and `ecMul`. They are also valid constructor and covenant function parameter types, flattening to their scalar leaves like any other struct; whole-struct comparison remains unsupported. Because their layouts are fixed, they are not repeated in the artifact's `structs` list.
 
 ### Contract Structure
 

--- a/arkade-bindgen/src/ir.rs
+++ b/arkade-bindgen/src/ir.rs
@@ -65,7 +65,7 @@ impl Encoding {
 /// A typed field in the IR (constructor param, covenant input, or witness element).
 #[derive(Debug, Clone)]
 pub struct Field {
-    /// Field name as it appears in the artifact (camelCase).
+    /// Scalar placeholder name as it appears in the artifact.
     pub name: String,
     /// Arkade Script type string (e.g., "pubkey", "signature").
     pub ark_type: String,

--- a/arkade-bindgen/src/ir.rs
+++ b/arkade-bindgen/src/ir.rs
@@ -133,22 +133,32 @@ pub struct ContractIR {
 
 /// Expand one artifact entry into generated fields.
 ///
-/// The artifact keeps one entry per source parameter, so an array type
-/// (`pubkey[3]`) becomes the `name_0 … name_2` scalars the covenant asm and the
-/// witness stack actually carry.
-fn fields_from_ark_type(name: &str, ark_type: &str, is_injected: bool) -> Vec<Field> {
-    let field = |name: String, ark_type: &str| Field {
-        name,
-        ark_type: ark_type.to_string(),
-        encoding: Encoding::from_ark_type(ark_type),
-        is_injected,
-    };
-    match arkade_compiler::models::array_type_parts(ark_type) {
-        Some((element, length)) => (0..length)
-            .map(|index| field(format!("{name}_{index}"), element))
-            .collect(),
-        None => vec![field(name.to_string(), ark_type)],
-    }
+/// The artifact keeps one entry per source parameter, so arrays and structs
+/// expand into the scalar fields the covenant asm and witness stack carry.
+fn fields_from_ark_type(
+    name: &str,
+    ark_type: &str,
+    is_injected: bool,
+    structs: &[arkade_compiler::StructDefinition],
+) -> Result<Vec<Field>, String> {
+    arkade_compiler::models::flatten_parameter(
+        &arkade_compiler::Parameter {
+            name: name.to_string(),
+            param_type: ark_type.to_string(),
+        },
+        structs,
+    )
+    .map(|leaves| {
+        leaves
+            .into_iter()
+            .map(|leaf| Field {
+                name: leaf.emitted_name,
+                encoding: Encoding::from_ark_type(&leaf.leaf_type),
+                ark_type: leaf.leaf_type,
+                is_injected,
+            })
+            .collect()
+    })
 }
 
 /// Build an IR from a compiled contract artifact.
@@ -156,37 +166,72 @@ pub fn build_ir(artifact: &ContractJson) -> Result<ContractIR, String> {
     let constructor_fields = artifact
         .parameters
         .iter()
-        .flat_map(|p| fields_from_ark_type(&p.name, &p.param_type, false))
+        .map(|p| fields_from_ark_type(&p.name, &p.param_type, false, &artifact.structs))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
         .collect();
 
     let groups = artifact
         .functions
         .iter()
-        .map(|group| GroupIR {
-            name: group.name.clone(),
-            covenant: group.arkade.as_ref().map(|cov| CovenantIR {
-                inputs: cov
-                    .inputs
-                    .iter()
-                    .flat_map(|i| fields_from_ark_type(&i.name, &i.param_type, false))
-                    .collect(),
-                asm: cov.asm.clone(),
-            }),
-            leaves: group
+        .map(|group| {
+            let covenant = group
+                .arkade
+                .as_ref()
+                .map(|cov| -> Result<CovenantIR, String> {
+                    Ok(CovenantIR {
+                        inputs: cov
+                            .inputs
+                            .iter()
+                            .map(|input| {
+                                fields_from_ark_type(
+                                    &input.name,
+                                    &input.param_type,
+                                    false,
+                                    &artifact.structs,
+                                )
+                            })
+                            .collect::<Result<Vec<_>, String>>()?
+                            .into_iter()
+                            .flatten()
+                            .collect(),
+                        asm: cov.asm.clone(),
+                    })
+                })
+                .transpose()?;
+            let leaves = group
                 .leaves
                 .iter()
-                .map(|leaf| LeafIR {
-                    name: leaf.name.clone(),
-                    witness_fields: leaf
-                        .witness
-                        .iter()
-                        .flat_map(|w| fields_from_ark_type(&w.name, &w.elem_type, w.injected))
-                        .collect(),
-                    asm: leaf.asm.clone(),
+                .map(|leaf| {
+                    Ok(LeafIR {
+                        name: leaf.name.clone(),
+                        witness_fields: leaf
+                            .witness
+                            .iter()
+                            .map(|witness| {
+                                fields_from_ark_type(
+                                    &witness.name,
+                                    &witness.elem_type,
+                                    witness.injected,
+                                    &artifact.structs,
+                                )
+                            })
+                            .collect::<Result<Vec<_>, String>>()?
+                            .into_iter()
+                            .flatten()
+                            .collect(),
+                        asm: leaf.asm.clone(),
+                    })
                 })
-                .collect(),
+                .collect::<Result<Vec<_>, String>>()?;
+            Ok(GroupIR {
+                name: group.name.clone(),
+                covenant,
+                leaves,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, String>>()?;
 
     Ok(ContractIR {
         name: artifact.name.clone(),

--- a/arkade-bindgen/src/ir.rs
+++ b/arkade-bindgen/src/ir.rs
@@ -65,7 +65,7 @@ impl Encoding {
 /// A typed field in the IR (constructor param, covenant input, or witness element).
 #[derive(Debug, Clone)]
 pub struct Field {
-    /// Scalar placeholder name as it appears in the artifact.
+    /// Flattened scalar path used by assembly placeholders and witness entries.
     pub name: String,
     /// Arkade Script type string (e.g., "pubkey", "signature").
     pub ark_type: String,

--- a/arkade-bindgen/src/naming.rs
+++ b/arkade-bindgen/src/naming.rs
@@ -52,6 +52,25 @@ pub fn to_camel_case(s: &str) -> String {
     format!("{}{}", first, chars.collect::<String>())
 }
 
+/// Convert a placeholder path to an exported Go field name without losing
+/// the distinction between path separators and source underscores.
+pub fn to_go_field_name(s: &str) -> String {
+    if !s.contains('.') {
+        return to_pascal_case(s);
+    }
+
+    let mut result = String::new();
+    for (index, ch) in s.chars().enumerate() {
+        match ch {
+            '.' => result.push_str("_D"),
+            '_' => result.push_str("_U"),
+            ch if index == 0 => result.push(ch.to_ascii_uppercase()),
+            ch => result.push(ch),
+        }
+    }
+    result
+}
+
 /// Convert a string to snake_case.
 ///
 /// - "receiverSig" → "receiver_sig"
@@ -121,6 +140,13 @@ mod tests {
         assert_eq!(to_pascal_case("non_interactive_swap"), "NonInteractiveSwap");
         assert_eq!(to_pascal_case("htlc"), "Htlc");
         assert_eq!(to_pascal_case("sender"), "Sender");
+    }
+
+    #[test]
+    fn test_to_go_field_name_preserves_dotted_paths() {
+        assert_eq!(to_go_field_name("value.a_b"), "Value_Da_Ub");
+        assert_eq!(to_go_field_name("value.a.b"), "Value_Da_Db");
+        assert_eq!(to_go_field_name("values.0"), "Values_D0");
     }
 
     #[test]

--- a/arkade-bindgen/src/naming.rs
+++ b/arkade-bindgen/src/naming.rs
@@ -53,7 +53,7 @@ pub fn to_camel_case(s: &str) -> String {
 }
 
 /// Convert a placeholder path to an exported Go field name without losing
-/// the distinction between path separators and source underscores.
+/// path separators, source underscores, or initial-letter case.
 pub fn to_go_field_name(s: &str) -> String {
     if !s.contains('.') {
         return to_pascal_case(s);
@@ -64,6 +64,10 @@ pub fn to_go_field_name(s: &str) -> String {
         match ch {
             '.' => result.push_str("_D"),
             '_' => result.push_str("_U"),
+            ch if index == 0 && ch.is_ascii_uppercase() => {
+                result.push(ch);
+                result.push_str("_C");
+            }
             ch if index == 0 => result.push(ch.to_ascii_uppercase()),
             ch => result.push(ch),
         }
@@ -147,6 +151,7 @@ mod tests {
         assert_eq!(to_go_field_name("value.a_b"), "Value_Da_Ub");
         assert_eq!(to_go_field_name("value.a.b"), "Value_Da_Db");
         assert_eq!(to_go_field_name("values.0"), "Values_D0");
+        assert_ne!(to_go_field_name("value.a"), to_go_field_name("Value.a"));
     }
 
     #[test]

--- a/arkade-bindgen/src/targets/go.rs
+++ b/arkade-bindgen/src/targets/go.rs
@@ -1,5 +1,5 @@
 use crate::ir::{ContractIR, Encoding, Field, GroupIR, LeafIR};
-use crate::naming::{to_camel_case, to_pascal_case, to_snake_case};
+use crate::naming::{to_camel_case, to_go_field_name, to_pascal_case, to_snake_case};
 use crate::targets::{CodegenOptions, CodegenTarget, GeneratedFile};
 
 pub struct GoTarget;
@@ -61,7 +61,7 @@ fn encoding_const(encoding: &Encoding) -> &'static str {
 
 /// How to convert a Go typed field value to []byte for the witness builder.
 fn value_expr(field: &Field, prefix: &str) -> String {
-    let go_name = to_pascal_case(&field.name);
+    let go_name = to_go_field_name(&field.name);
     match field.encoding {
         Encoding::ScriptNum => {
             if field.ark_type == "bool" {
@@ -126,7 +126,7 @@ fn generate_go(ir: &ContractIR, options: &CodegenOptions) -> String {
     for field in &ir.constructor_fields {
         out.push_str(&format!(
             "\t{} {} // {} ({})\n",
-            to_pascal_case(&field.name),
+            to_go_field_name(&field.name),
             go_type_for_field(field),
             field.ark_type,
             field.encoding.as_str(),
@@ -219,7 +219,7 @@ fn emit_witness_struct(out: &mut String, ir: &ContractIR, group: &GroupIR, leaf:
     for field in leaf.user_fields() {
         out.push_str(&format!(
             "\t{} {} // {} ({})\n",
-            to_pascal_case(&field.name),
+            to_go_field_name(&field.name),
             go_type_for_field(field),
             field.ark_type,
             field.encoding.as_str(),
@@ -228,7 +228,7 @@ fn emit_witness_struct(out: &mut String, ir: &ContractIR, group: &GroupIR, leaf:
     for field in leaf.witness_fields.iter().filter(|f| f.is_injected) {
         out.push_str(&format!(
             "\t// {} injected by Arkade\n",
-            to_pascal_case(&field.name)
+            to_go_field_name(&field.name)
         ));
     }
     out.push_str("}\n\n");

--- a/arkade-bindgen/src/targets/typescript.rs
+++ b/arkade-bindgen/src/targets/typescript.rs
@@ -45,6 +45,7 @@ fn sdk_type_alias(encoding: &Encoding) -> Option<&'static str> {
 }
 
 fn field_name(name: &str) -> String {
+    // Flat dotted paths stay verbatim so they cannot collide with underscored names.
     if name.contains('.') {
         format!("\"{name}\"")
     } else {

--- a/arkade-bindgen/src/targets/typescript.rs
+++ b/arkade-bindgen/src/targets/typescript.rs
@@ -44,6 +44,14 @@ fn sdk_type_alias(encoding: &Encoding) -> Option<&'static str> {
     }
 }
 
+fn field_name(name: &str) -> String {
+    if name.contains('.') {
+        format!("\"{name}\"")
+    } else {
+        to_camel_case(name)
+    }
+}
+
 /// Witness interface name for a leaf. Collapses the redundant name when a group
 /// has a single leaf sharing its name (e.g. `HTLCClaimWitness`, not
 /// `HTLCClaimClaimWitness`).
@@ -133,7 +141,7 @@ fn generate_typescript(ir: &ContractIR, options: &CodegenOptions) -> String {
             "  /** {} ({}) */\n  {}: {};\n",
             field.ark_type,
             field.encoding.as_str(),
-            to_camel_case(&field.name),
+            field_name(&field.name),
             field_ts_type(field),
         ));
     }
@@ -195,7 +203,7 @@ fn emit_witness_interface(out: &mut String, ir: &ContractIR, group: &GroupIR, le
             "  /** {} ({}) */\n  {}: {};\n",
             field.ark_type,
             field.encoding.as_str(),
-            to_camel_case(&field.name),
+            field_name(&field.name),
             field_ts_type(field),
         ));
     }

--- a/arkade-bindgen/tests/go_test.rs
+++ b/arkade-bindgen/tests/go_test.rs
@@ -106,3 +106,26 @@ fn test_go_fixed_array_types() {
     assert!(code.contains("PreimageHash [20]byte")); // bytes20
     assert!(code.contains("RefundTime int64")); // int
 }
+
+#[test]
+fn test_go_dotted_fields_remain_distinct() {
+    let artifact = arkade_compiler::compile(
+        r#"
+struct Inner { int b; }
+struct Ambiguous { int a_b; Inner a; }
+contract C(Ambiguous value) {
+    function spend() { require(true); }
+}
+"#,
+    )
+    .unwrap();
+    let json = serde_json::to_string(&artifact).unwrap();
+    let code = generate_from_str(&json, Target::Go, &Options::default())
+        .unwrap()
+        .content;
+
+    assert!(code.contains("Value_Da_Ub int64"));
+    assert!(code.contains("Value_Da_Db int64"));
+    assert!(code.contains("Name: \"value.a_b\""));
+    assert!(code.contains("Name: \"value.a.b\""));
+}

--- a/arkade-bindgen/tests/go_test.rs
+++ b/arkade-bindgen/tests/go_test.rs
@@ -129,3 +129,23 @@ contract C(Ambiguous value) {
     assert!(code.contains("Name: \"value.a_b\""));
     assert!(code.contains("Name: \"value.a.b\""));
 }
+
+#[test]
+fn test_go_dotted_fields_preserve_initial_case() {
+    let artifact = arkade_compiler::compile(
+        r#"
+struct Value { int a; }
+contract C(Value value, Value Value) {
+    function spend() { require(true); }
+}
+"#,
+    )
+    .unwrap();
+    let json = serde_json::to_string(&artifact).unwrap();
+    let code = generate_from_str(&json, Target::Go, &Options::default())
+        .unwrap()
+        .content;
+
+    assert!(code.contains("Value_Da int64"));
+    assert!(code.contains("V_Calue_Da int64"));
+}

--- a/arkade-bindgen/tests/ir_test.rs
+++ b/arkade-bindgen/tests/ir_test.rs
@@ -162,3 +162,67 @@ fn test_ir_expands_grouped_array_fields() {
         .iter()
         .all(|f| f.encoding == Encoding::Schnorr64));
 }
+
+#[test]
+fn test_ir_expands_nested_struct_fields() {
+    let artifact = r#"{
+        "contractName": "Vault",
+        "structs": [
+            {
+                "name": "Signer",
+                "fields": [
+                    { "name": "key", "type": "pubkey" },
+                    { "name": "weight", "type": "int" }
+                ]
+            },
+            {
+                "name": "Policy",
+                "fields": [
+                    { "name": "primary", "type": "Signer" },
+                    { "name": "limits", "type": "int[2]" }
+                ]
+            }
+        ],
+        "constructorInputs": [{ "name": "policy", "type": "Policy" }],
+        "functions": [{
+            "name": "spend",
+            "arkade": {
+                "inputs": [{ "name": "candidate", "type": "Policy" }],
+                "asm": ["<policy_limits_1>", "<policy_limits_0>", "<policy_primary_weight>", "<policy_primary_key>", "OP_1"]
+            },
+            "leaves": [{ "name": "spend", "witness": [], "asm": ["OP_1"] }]
+        }]
+    }"#;
+
+    let ir = build_ir(&load_artifact_str(artifact).unwrap()).unwrap();
+    let constructor = ir
+        .constructor_fields
+        .iter()
+        .map(|field| (field.name.as_str(), &field.encoding))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        constructor,
+        [
+            ("policy_primary_key", &Encoding::Compressed33),
+            ("policy_primary_weight", &Encoding::ScriptNum),
+            ("policy_limits_0", &Encoding::ScriptNum),
+            ("policy_limits_1", &Encoding::ScriptNum),
+        ]
+    );
+    assert_eq!(
+        ir.groups[0]
+            .covenant
+            .as_ref()
+            .unwrap()
+            .inputs
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "candidate_primary_key",
+            "candidate_primary_weight",
+            "candidate_limits_0",
+            "candidate_limits_1",
+        ]
+    );
+}

--- a/arkade-bindgen/tests/ir_test.rs
+++ b/arkade-bindgen/tests/ir_test.rs
@@ -117,7 +117,7 @@ fn test_ir_expands_grouped_array_fields() {
             "name": "attest",
             "arkade": {
                 "inputs": [{ "name": "sigs", "type": "signature[2]" }],
-                "asm": ["<oracles_2>", "<oracles_1>", "<oracles_0>", "OP_1"]
+                "asm": ["<oracles.2>", "<oracles.1>", "<oracles.0>", "OP_1"]
             },
             "leaves": [{
                 "name": "attest",
@@ -134,7 +134,7 @@ fn test_ir_expands_grouped_array_fields() {
         .iter()
         .map(|f| f.name.as_str())
         .collect();
-    assert_eq!(names, ["oracles_0", "oracles_1", "oracles_2"]);
+    assert_eq!(names, ["oracles.0", "oracles.1", "oracles.2"]);
     assert!(ir
         .constructor_fields
         .iter()
@@ -149,14 +149,14 @@ fn test_ir_expands_grouped_array_fields() {
         .iter()
         .map(|f| f.name.as_str())
         .collect();
-    assert_eq!(inputs, ["sigs_0", "sigs_1"]);
+    assert_eq!(inputs, ["sigs.0", "sigs.1"]);
 
     let witness: Vec<&str> = group.leaves[0]
         .witness_fields
         .iter()
         .map(|f| f.name.as_str())
         .collect();
-    assert_eq!(witness, ["sigs_0", "sigs_1"]);
+    assert_eq!(witness, ["sigs.0", "sigs.1"]);
     assert!(group.leaves[0]
         .witness_fields
         .iter()
@@ -188,7 +188,7 @@ fn test_ir_expands_nested_struct_fields() {
             "name": "spend",
             "arkade": {
                 "inputs": [{ "name": "candidate", "type": "Policy" }],
-                "asm": ["<policy_limits_1>", "<policy_limits_0>", "<policy_primary_weight>", "<policy_primary_key>", "OP_1"]
+                "asm": ["<policy.limits.1>", "<policy.limits.0>", "<policy.primary.weight>", "<policy.primary.key>", "OP_1"]
             },
             "leaves": [{ "name": "spend", "witness": [], "asm": ["OP_1"] }]
         }]
@@ -203,10 +203,10 @@ fn test_ir_expands_nested_struct_fields() {
     assert_eq!(
         constructor,
         [
-            ("policy_primary_key", &Encoding::Compressed33),
-            ("policy_primary_weight", &Encoding::ScriptNum),
-            ("policy_limits_0", &Encoding::ScriptNum),
-            ("policy_limits_1", &Encoding::ScriptNum),
+            ("policy.primary.key", &Encoding::Compressed33),
+            ("policy.primary.weight", &Encoding::ScriptNum),
+            ("policy.limits.0", &Encoding::ScriptNum),
+            ("policy.limits.1", &Encoding::ScriptNum),
         ]
     );
     assert_eq!(
@@ -219,10 +219,10 @@ fn test_ir_expands_nested_struct_fields() {
             .map(|field| field.name.as_str())
             .collect::<Vec<_>>(),
         [
-            "candidate_primary_key",
-            "candidate_primary_weight",
-            "candidate_limits_0",
-            "candidate_limits_1",
+            "candidate.primary.key",
+            "candidate.primary.weight",
+            "candidate.limits.0",
+            "candidate.limits.1",
         ]
     );
 }

--- a/arkade-bindgen/tests/typescript_test.rs
+++ b/arkade-bindgen/tests/typescript_test.rs
@@ -103,3 +103,24 @@ fn test_typescript_group_order_preserved() {
     assert!(claim < refund);
     assert!(refund < uni);
 }
+
+#[test]
+fn test_typescript_dotted_fields_remain_distinct() {
+    let artifact = arkade_compiler::compile(
+        r#"
+struct Inner { int b; }
+struct Ambiguous { int a_b; Inner a; }
+contract C(Ambiguous value) {
+    function spend() { require(true); }
+}
+"#,
+    )
+    .unwrap();
+    let json = serde_json::to_string(&artifact).unwrap();
+    let code = generate_from_str(&json, Target::TypeScript, &Options::default())
+        .unwrap()
+        .content;
+
+    assert!(code.contains("\"value.a_b\": bigint;"));
+    assert!(code.contains("\"value.a.b\": bigint;"));
+}

--- a/examples/struct_vault/struct_vault.ark
+++ b/examples/struct_vault/struct_vault.ark
@@ -1,0 +1,37 @@
+struct Signer {
+  pubkey key;
+  int weight;
+}
+
+struct Policy {
+  Signer primary;
+  int[2] limits;
+  int exitDelay;
+}
+
+contract StructVault(Policy policy) {
+  function update(Policy next, signature sig, bytes32 message) {
+    require(checkSigFromStack(sig, policy.primary.key, message));
+
+    int total = 0;
+    for (i, limit) in next.limits {
+      total = total + limit;
+    }
+    require(total >= policy.primary.weight);
+
+    Policy local = {
+      primary: {
+        key: next.primary.key,
+        weight: total
+      },
+      limits: [next.limits[0], next.limits[1]],
+      exitDelay: policy.exitDelay
+    };
+    require(local.primary.weight == total);
+  }
+
+  function unilateral(signature sig) tapscript {
+    require(older(policy.exitDelay));
+    require(checkSig(sig, policy.primary.key));
+  }
+}

--- a/playground/arkade-language.js
+++ b/playground/arkade-language.js
@@ -5,7 +5,7 @@ const arkadeMonarch = {
     defaultToken: 'invalid',
 
     keywords: [
-        'contract', 'function', 'tapscript', 'require', 'if', 'else',
+        'contract', 'struct', 'function', 'tapscript', 'require', 'if', 'else',
         'for', 'in', 'let', 'internal', 'new'
     ],
 
@@ -36,7 +36,7 @@ const arkadeMonarch = {
             [/\s+/, 'white'],
 
             // Keywords
-            [/\b(contract|function|tapscript|require|if|else|for|in|let|internal|new)\b/, 'keyword'],
+            [/\b(contract|struct|function|tapscript|require|if|else|for|in|let|internal|new)\b/, 'keyword'],
 
             // Types
             [/\b(pubkey|signature|bytes32|bytes20|bytes|asset|int|bool)\b/, 'type'],
@@ -130,6 +130,7 @@ const arkadeTheme = {
 const arkadeCompletions = [
     // Keywords
     { label: 'contract', kind: 'Keyword', insertText: 'contract ${1:Name}(${2:params}) {\n\t$0\n}', insertTextRules: 4 },
+    { label: 'struct', kind: 'Keyword', insertText: 'struct ${1:Name} {\n\t${2:int} ${3:field};\n}', insertTextRules: 4 },
     { label: 'function', kind: 'Keyword', insertText: 'function ${1:name}(${2:params}) {\n\t$0\n}', insertTextRules: 4 },
     { label: 'require', kind: 'Keyword', insertText: 'require(${1:condition});', insertTextRules: 4 },
     { label: 'tapscript', kind: 'Keyword', insertText: 'tapscript {\n\t$0\n}', insertTextRules: 4 },

--- a/playground/codegen.js
+++ b/playground/codegen.js
@@ -43,6 +43,19 @@ function toSnakeCase(s) {
     return splitWords(s).map(w => w.toLowerCase()).join('_');
 }
 
+function toGoFieldName(s) {
+    if (!s.includes('.')) return toPascalCase(s);
+    return [...s].map((ch, index) => {
+        if (ch === '.') return '_D';
+        if (ch === '_') return '_U';
+        return index === 0 ? ch.toUpperCase() : ch;
+    }).join('');
+}
+
+function tsFieldName(s) {
+    return s.includes('.') ? JSON.stringify(s) : toCamelCase(s);
+}
+
 // ─── Encoding inference ──────────────────────────────────────────────
 
 function inferEncoding(typeStr) {
@@ -63,13 +76,13 @@ function expandFields(name, typeStr, isInjected, structs = []) {
     if (array) {
         const [, elementType, length] = array;
         return Array.from({ length: Number(length) }, (_, index) =>
-            expandFields(`${name}_${index}`, elementType, isInjected, structs)
+            expandFields(`${name}.${index}`, elementType, isInjected, structs)
         ).flat();
     }
     const definition = structs.find(definition => definition.name === typeStr);
     if (definition) {
         return definition.fields.flatMap(field =>
-            expandFields(`${name}_${field.name}`, field.type, isInjected, structs)
+            expandFields(`${name}.${field.name}`, field.type, isInjected, structs)
         );
     }
     return [{ name, arkType: typeStr, encoding: inferEncoding(typeStr), isInjected }];
@@ -147,7 +160,7 @@ function generateTypeScript(ir) {
     out += `/** Constructor parameters for ${ir.name} */\n`;
     out += `export interface ${ir.name}Params {\n`;
     for (const f of ir.constructorFields) {
-        out += `  /** ${f.arkType} (${f.encoding}) */\n  ${toCamelCase(f.name)}: ${tsTypeForField(f)};\n`;
+        out += `  /** ${f.arkType} (${f.encoding}) */\n  ${tsFieldName(f.name)}: ${tsTypeForField(f)};\n`;
     }
     out += `}\n\n`;
 
@@ -159,7 +172,7 @@ function generateTypeScript(ir) {
             out += `/** Witness for ${ir.name}.${func.name} leaf "${leaf.name}" */\n`;
             out += `export interface ${ifaceName} {\n`;
             for (const f of leaf.userFields) {
-                out += `  /** ${f.arkType} (${f.encoding}) */\n  ${toCamelCase(f.name)}: ${tsTypeForField(f)};\n`;
+                out += `  /** ${f.arkType} (${f.encoding}) */\n  ${tsFieldName(f.name)}: ${tsTypeForField(f)};\n`;
             }
             const injected = leaf.allFields.filter(f => f.isInjected).map(f => f.name).join(', ');
             if (injected) out += `  // ${injected} injected by Arkade infrastructure\n`;
@@ -222,7 +235,7 @@ const ENCODING_CONST = {
 };
 
 function goValueExpr(field, prefix) {
-    const goName = toPascalCase(field.name);
+    const goName = toGoFieldName(field.name);
     if (field.encoding === 'scriptnum') {
         return field.arkType === 'bool'
             ? `ark.EncodeBool(${prefix}.${goName})`
@@ -247,7 +260,7 @@ function generateGo(ir) {
     out += `// ${ir.name}Params holds constructor parameters for the ${ir.name} contract.\n`;
     out += `type ${ir.name}Params struct {\n`;
     for (const f of ir.constructorFields) {
-        out += `\t${toPascalCase(f.name)} ${goTypeForField(f)} // ${f.arkType} (${f.encoding})\n`;
+        out += `\t${toGoFieldName(f.name)} ${goTypeForField(f)} // ${f.arkType} (${f.encoding})\n`;
     }
     out += `}\n\n`;
 
@@ -259,9 +272,9 @@ function generateGo(ir) {
             out += `// ${structName} holds witness data for ${ir.name}.${func.name} leaf "${leaf.name}".\n`;
             out += `type ${structName} struct {\n`;
             for (const f of leaf.userFields) {
-                out += `\t${toPascalCase(f.name)} ${goTypeForField(f)} // ${f.arkType} (${f.encoding})\n`;
+                out += `\t${toGoFieldName(f.name)} ${goTypeForField(f)} // ${f.arkType} (${f.encoding})\n`;
             }
-            const injected = leaf.allFields.filter(f => f.isInjected).map(f => toPascalCase(f.name)).join(', ');
+            const injected = leaf.allFields.filter(f => f.isInjected).map(f => toGoFieldName(f.name)).join(', ');
             if (injected) out += `\t// ${injected} injected by Arkade infrastructure\n`;
             out += `}\n\n`;
         }

--- a/playground/codegen.js
+++ b/playground/codegen.js
@@ -48,6 +48,7 @@ function toGoFieldName(s) {
     return [...s].map((ch, index) => {
         if (ch === '.') return '_D';
         if (ch === '_') return '_U';
+        if (index === 0 && ch >= 'A' && ch <= 'Z') return `${ch}_C`;
         return index === 0 ? ch.toUpperCase() : ch;
     }).join('');
 }
@@ -79,7 +80,13 @@ function expandFields(name, typeStr, isInjected, structs = []) {
             expandFields(`${name}.${index}`, elementType, isInjected, structs)
         ).flat();
     }
-    const definition = structs.find(definition => definition.name === typeStr);
+    const nativeFields = {
+        AssetId: [{ name: 'txid', type: 'bytes32' }, { name: 'gidx', type: 'int' }],
+        Outpoint: [{ name: 'txid', type: 'bytes32' }, { name: 'vout', type: 'int' }],
+        ECPoint: [{ name: 'x', type: 'int' }, { name: 'y', type: 'int' }],
+    };
+    const definition = structs.find(definition => definition.name === typeStr)
+        || (nativeFields[typeStr] && { fields: nativeFields[typeStr] });
     if (definition) {
         return definition.fields.flatMap(field =>
             expandFields(`${name}.${field.name}`, field.type, isInjected, structs)

--- a/playground/codegen.js
+++ b/playground/codegen.js
@@ -56,31 +56,34 @@ function inferEncoding(typeStr) {
 
 // ─── IR construction ─────────────────────────────────────────────────
 
-// The artifact keeps one entry per source parameter, so an array type
-// (pubkey[3]) expands here into the name_0 … name_2 scalars the asm
-// placeholders and the witness stack actually carry.
-function expandFields(name, typeStr, isInjected) {
+// The artifact keeps one entry per source parameter. Expand arrays and structs
+// into the scalar fields the asm placeholders and witness stack carry.
+function expandFields(name, typeStr, isInjected, structs = []) {
     const array = /^(.+)\[(\d+)\]$/.exec(typeStr);
-    if (!array) {
-        return [{ name, arkType: typeStr, encoding: inferEncoding(typeStr), isInjected }];
+    if (array) {
+        const [, elementType, length] = array;
+        return Array.from({ length: Number(length) }, (_, index) =>
+            expandFields(`${name}_${index}`, elementType, isInjected, structs)
+        ).flat();
     }
-    const [, elementType, length] = array;
-    return Array.from({ length: Number(length) }, (_, index) => ({
-        name: `${name}_${index}`,
-        arkType: elementType,
-        encoding: inferEncoding(elementType),
-        isInjected,
-    }));
+    const definition = structs.find(definition => definition.name === typeStr);
+    if (definition) {
+        return definition.fields.flatMap(field =>
+            expandFields(`${name}_${field.name}`, field.type, isInjected, structs)
+        );
+    }
+    return [{ name, arkType: typeStr, encoding: inferEncoding(typeStr), isInjected }];
 }
 
 function buildIR(artifact) {
+    const structs = artifact.structs || [];
     const constructorFields = (artifact.constructorInputs || [])
-        .flatMap(p => expandFields(p.name, p.type, false));
+        .flatMap(p => expandFields(p.name, p.type, false, structs));
 
     const functions = (artifact.functions || []).map(group => {
         const leaves = (group.leaves || []).map(leaf => {
             const allFields = (leaf.witness || [])
-                .flatMap(w => expandFields(w.name, w.type, w.injected === true));
+                .flatMap(w => expandFields(w.name, w.type, w.injected === true, structs));
             return {
                 name: leaf.name,
                 allFields,

--- a/playground/main.js
+++ b/playground/main.js
@@ -47,6 +47,7 @@ const examples = {
     single_sig: { name: 'SingleSig', code: contracts.single_sig },
     htlc: { name: 'HTLC', code: contracts.htlc },
     fuji_safe: { name: 'FujiSafe', code: contracts.fuji_safe },
+    struct_vault: { name: 'StructVault', code: contracts.struct_vault },
     swap: { name: 'NonInteractiveSwap', code: contracts.non_interactive_swap },
 };
 

--- a/src/compiler/asset.rs
+++ b/src/compiler/asset.rs
@@ -150,10 +150,6 @@ pub(crate) fn emit_asset_at_asm(
     match property {
         "assetId" => {
             // Drop the amount, keep the canonical Asset ID (asset_txid, asset_gidx).
-            // TODO(asset-id-struct): this intentionally leaves TWO stack items, so
-            // `.assetId` needs a composite `AssetId` struct return type before it
-            // can be destructured (.txid/.gidx) or compared safely. Deferred to a
-            // separate PR.
             asm.push(OP_DROP.to_string());
         }
         "amount" => {
@@ -214,11 +210,7 @@ pub(crate) fn emit_group_property_asm(group: &str, property: &str, asm: &mut Vec
             asm.push(OP_INSPECTASSETGROUPMETADATAHASH.to_string());
         }
         "assetId" => {
-            // Returns the canonical Asset ID (asset_txid, asset_gidx) — TWO stack items.
-            // TODO(asset-id-struct): like asset_at `.assetId`, this needs a composite
-            // `AssetId` struct return type before it can be destructured (.txid/.gidx)
-            // or compared with `==` (a single OP_EQUAL only sees the top item, the
-            // gidx). Deferred to a separate PR.
+            // Returns the canonical Asset ID (asset_txid, asset_gidx).
             asm.push(format!("<{}>", group));
             asm.push(OP_INSPECTASSETGROUPASSETID.to_string());
         }

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -70,25 +70,13 @@ impl ConcatPass {
                     scope,
                 );
                 *value = new_expr;
-                if let Some(declared_type) = declared_type {
-                    scope.extend(crate::typechecker::build_scope_with_structs(
-                        &[Parameter {
-                            name: name.clone(),
-                            param_type: declared_type.clone(),
-                        }],
-                        &self.structs,
-                    ));
-                } else if matches!(t, ArkType::Struct(_)) {
-                    scope.extend(crate::typechecker::build_scope_with_structs(
-                        &[Parameter {
-                            name: name.clone(),
-                            param_type: t.as_str(),
-                        }],
-                        &self.structs,
-                    ));
-                } else {
-                    scope.insert(name.clone(), t);
-                }
+                crate::typechecker::bind_local_type(
+                    scope,
+                    name,
+                    declared_type.as_deref(),
+                    t,
+                    &self.structs,
+                );
             }
             Statement::VarAssign { name, value } => {
                 let (new_expr, t) = self.rewrite_expression_concat(

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -78,6 +78,14 @@ impl ConcatPass {
                         }],
                         &self.structs,
                     ));
+                } else if matches!(t, ArkType::Struct(_)) {
+                    scope.extend(crate::typechecker::build_scope_with_structs(
+                        &[Parameter {
+                            name: name.clone(),
+                            param_type: t.as_str(),
+                        }],
+                        &self.structs,
+                    ));
                 } else {
                     scope.insert(name.clone(), t);
                 }

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -25,10 +25,14 @@ fn is_numeric(t: &ArkType) -> bool {
 #[derive(Default)]
 struct ConcatPass {
     errors: Vec<String>,
+    structs: Vec<crate::models::StructDefinition>,
 }
 
 pub(crate) fn rewrite_concat_ops(contract: &mut crate::models::Contract) -> Result<(), String> {
-    let mut pass = ConcatPass::default();
+    let mut pass = ConcatPass {
+        structs: contract.structs.clone(),
+        ..ConcatPass::default()
+    };
     let constructor_scope =
         crate::typechecker::build_scope_with_structs(&contract.parameters, &contract.structs);
     for function in &mut contract.functions {
@@ -66,10 +70,17 @@ impl ConcatPass {
                     scope,
                 );
                 *value = new_expr;
-                scope.insert(
-                    name.clone(),
-                    declared_type.as_deref().map(ArkType::parse).unwrap_or(t),
-                );
+                if let Some(declared_type) = declared_type {
+                    scope.extend(crate::typechecker::build_scope_with_structs(
+                        &[Parameter {
+                            name: name.clone(),
+                            param_type: declared_type.clone(),
+                        }],
+                        &self.structs,
+                    ));
+                } else {
+                    scope.insert(name.clone(), t);
+                }
             }
             Statement::VarAssign { name, value } => {
                 let (new_expr, t) = self.rewrite_expression_concat(
@@ -170,6 +181,15 @@ impl ConcatPass {
                     ArkType::Array(Box::new(element_type), length),
                 )
             }
+            Expression::StructLiteral(fields) => (
+                Expression::StructLiteral(
+                    fields
+                        .into_iter()
+                        .map(|(name, value)| (name, self.rewrite_expression_concat(value, scope).0))
+                        .collect(),
+                ),
+                ArkType::Unknown,
+            ),
             Expression::ArrayIndex { array, index } => {
                 let (index, _) = self.rewrite_expression_concat(*index, scope);
                 let result_type = match scope.get(&array) {

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -29,10 +29,14 @@ struct ConcatPass {
 
 pub(crate) fn rewrite_concat_ops(contract: &mut crate::models::Contract) -> Result<(), String> {
     let mut pass = ConcatPass::default();
-    let constructor_scope = crate::typechecker::build_scope(&contract.parameters);
+    let constructor_scope =
+        crate::typechecker::build_scope_with_structs(&contract.parameters, &contract.structs);
     for function in &mut contract.functions {
         let mut scope = constructor_scope.clone();
-        scope.extend(crate::typechecker::build_scope(&function.parameters));
+        scope.extend(crate::typechecker::build_scope_with_structs(
+            &function.parameters,
+            &contract.structs,
+        ));
         pass.rewrite_statements_concat(&mut function.statements, &mut scope);
     }
     if pass.errors.is_empty() {

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -18,6 +18,8 @@ pub(crate) fn emit_expression_asm(expr: &Expression, asm: &mut Vec<String>) {
         Expression::Literal(lit) => push_literal_asm(lit, asm),
         // Rejected before emission; array declarations emit their elements directly.
         Expression::ArrayLiteral(_) => {}
+        // Rejected before emission; typed struct declarations emit scalar leaves directly.
+        Expression::StructLiteral(_) => {}
         Expression::ArrayIndex { array, index } => {
             if let Expression::Literal(index) = index.as_ref() {
                 asm.push(format!("<{array}[{index}]>"));

--- a/src/compiler/loops.rs
+++ b/src/compiler/loops.rs
@@ -189,6 +189,17 @@ pub(crate) fn substitute_expression(
                 .map(|element| substitute_expression(element, index_var, value_var, k, array_name))
                 .collect(),
         ),
+        Expression::StructLiteral(fields) => Expression::StructLiteral(
+            fields
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.clone(),
+                        substitute_expression(value, index_var, value_var, k, array_name),
+                    )
+                })
+                .collect(),
+        ),
         Expression::ArrayIndex { array, index } => Expression::ArrayIndex {
             array: array.clone(),
             index: Box::new(substitute_expression(

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -467,8 +467,8 @@ impl Generator {
     ) -> Result<(), String> {
         let fields = crate::models::builtin_struct_fields(declared_type)
             .ok_or_else(|| format!("unknown native struct type '{declared_type}'"))?;
-        // Native multi-item opcodes currently all return two leaves. Replace
-        // this swap with a general reversal when a wider result is introduced.
+        // Native expressions push fields in declaration order, first deepest.
+        // Replace this swap with a general reversal when a wider result is introduced.
         if fields.len() != 2 {
             return Err(format!(
                 "native struct '{declared_type}' has unsupported width {}",
@@ -873,9 +873,14 @@ fn generate_asm_from_statements_recursive(
                         &generator.structs,
                         &mut leaves,
                     )?;
-                    for (access_name, expression) in leaves.into_iter().rev() {
-                        generator.emit_expression(&expression)?;
-                        generator.bind_local(&Generator::internal_binding_name(&access_name))?;
+                    for (access_name, leaf_type, expression) in leaves.into_iter().rev() {
+                        if crate::models::is_builtin_struct(&leaf_type) {
+                            generator.bind_native_struct(&access_name, &leaf_type, &expression)?;
+                        } else {
+                            generator.emit_expression(&expression)?;
+                            generator
+                                .bind_local(&Generator::internal_binding_name(&access_name))?;
+                        }
                     }
                 }
                 (declared_type, value)
@@ -930,7 +935,7 @@ fn collect_struct_literal_leaves(
     declared_type: &str,
     value: &Expression,
     structs: &[crate::models::StructDefinition],
-    leaves: &mut Vec<(String, Expression)>,
+    leaves: &mut Vec<(String, String, Expression)>,
 ) -> Result<(), String> {
     if let Some((element_type, length)) = crate::models::array_type_parts(declared_type) {
         let Expression::ArrayLiteral(elements) = value else {
@@ -948,12 +953,28 @@ fn collect_struct_literal_leaves(
             if !crate::models::is_builtin_type(element_type) {
                 return Err("arrays of structs are not supported".to_string());
             }
-            leaves.push((format!("{access_name}[{index}]"), element.clone()));
+            leaves.push((
+                format!("{access_name}[{index}]"),
+                element_type.to_string(),
+                element.clone(),
+            ));
         }
         return Ok(());
     }
     if crate::models::is_builtin_type(declared_type) {
-        leaves.push((access_name.to_string(), value.clone()));
+        leaves.push((
+            access_name.to_string(),
+            declared_type.to_string(),
+            value.clone(),
+        ));
+        return Ok(());
+    }
+    if crate::models::is_builtin_struct(declared_type) {
+        leaves.push((
+            access_name.to_string(),
+            declared_type.to_string(),
+            value.clone(),
+        ));
         return Ok(());
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -655,6 +655,8 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
         Err(e) => return Err(format!("Parse error: {}", e)),
     };
 
+    typechecker::resolve_group_properties(&mut contract);
+
     // ── Semantic validation ────────────────────────────────────────────────
     // Catch errors the PEG grammar cannot express (duplicate names, missing
     // timelocks, etc.) before we attempt code generation.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -70,6 +70,7 @@ struct Generator {
     scopes: Vec<usize>,
     alt_depth: usize,
     constructor_array_expansions: Vec<(String, String)>,
+    structs: Vec<crate::models::StructDefinition>,
 }
 
 impl Generator {
@@ -124,6 +125,7 @@ impl Generator {
             scopes: Vec::new(),
             alt_depth: 0,
             constructor_array_expansions,
+            structs: structs.to_vec(),
         })
     }
 
@@ -421,6 +423,12 @@ impl Generator {
         if matches!(expression, Expression::ArrayLiteral(_)) {
             return Err(
                 "array literals may only initialize an array declaration; composite values are not supported"
+                    .to_string(),
+            );
+        }
+        if matches!(expression, Expression::StructLiteral(_)) {
+            return Err(
+                "struct literals may only initialize a typed struct declaration; composite values are not supported"
                     .to_string(),
             );
         }
@@ -822,13 +830,31 @@ fn generate_asm_from_statements_recursive(
                 name,
                 declared_type,
                 value,
-            } => match (
-                declared_type
-                    .as_deref()
-                    .and_then(crate::models::array_type_parts),
-                value,
-            ) {
-                (Some((_, length)), Expression::ArrayLiteral(elements)) => {
+            } => match (declared_type.as_deref(), value) {
+                (Some(declared_type), Expression::StructLiteral(_))
+                    if generator
+                        .structs
+                        .iter()
+                        .any(|definition| definition.name == declared_type) =>
+                {
+                    let mut leaves = Vec::new();
+                    collect_struct_literal_leaves(
+                        name,
+                        declared_type,
+                        value,
+                        &generator.structs,
+                        &mut leaves,
+                    )?;
+                    for (access_name, expression) in leaves.into_iter().rev() {
+                        generator.emit_expression(&expression)?;
+                        generator.bind_local(&Generator::internal_binding_name(&access_name))?;
+                    }
+                }
+                (Some(declared_type), Expression::ArrayLiteral(elements))
+                    if crate::models::array_type_parts(declared_type).is_some() =>
+                {
+                    let (_, length) = crate::models::array_type_parts(declared_type)
+                        .expect("matched an array type");
                     if elements.len() != length {
                         return Err(format!(
                             "array '{name}' declares {length} elements but its initializer has {}",
@@ -854,6 +880,74 @@ fn generate_asm_from_statements_recursive(
             }
         }
         generator.assert_statement_boundary()?;
+    }
+    Ok(())
+}
+
+fn collect_struct_literal_leaves(
+    access_name: &str,
+    declared_type: &str,
+    value: &Expression,
+    structs: &[crate::models::StructDefinition],
+    leaves: &mut Vec<(String, Expression)>,
+) -> Result<(), String> {
+    if let Some((element_type, length)) = crate::models::array_type_parts(declared_type) {
+        let Expression::ArrayLiteral(elements) = value else {
+            return Err(format!(
+                "field '{access_name}' must be initialized with an array literal"
+            ));
+        };
+        if elements.len() != length {
+            return Err(format!(
+                "array field '{access_name}' declares {length} elements but its initializer has {}",
+                elements.len()
+            ));
+        }
+        for (index, element) in elements.iter().enumerate() {
+            if !crate::models::is_builtin_type(element_type) {
+                return Err("arrays of structs are not supported".to_string());
+            }
+            leaves.push((format!("{access_name}[{index}]"), element.clone()));
+        }
+        return Ok(());
+    }
+    if crate::models::is_builtin_type(declared_type) {
+        leaves.push((access_name.to_string(), value.clone()));
+        return Ok(());
+    }
+
+    let definition = structs
+        .iter()
+        .find(|definition| definition.name == declared_type)
+        .ok_or_else(|| format!("unknown struct type '{declared_type}'"))?;
+    let Expression::StructLiteral(fields) = value else {
+        return Err(format!(
+            "struct field '{access_name}' must be initialized with a struct literal"
+        ));
+    };
+    for field in &definition.fields {
+        let matches = fields
+            .iter()
+            .filter(|(name, _)| name == &field.name)
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            return Err(format!(
+                "struct literal for '{access_name}' must initialize field '{}' exactly once",
+                field.name
+            ));
+        }
+        collect_struct_literal_leaves(
+            &format!("{access_name}.{}", field.name),
+            &field.param_type,
+            &matches[0].1,
+            structs,
+            leaves,
+        )?;
+    }
+    if fields.len() != definition.fields.len() {
+        return Err(format!(
+            "struct literal for '{access_name}' has unknown or duplicate fields"
+        ));
     }
     Ok(())
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -408,18 +408,6 @@ impl Generator {
     }
 
     fn emit_expression(&mut self, expression: &Expression) -> Result<(), String> {
-        if matches!(
-            expression,
-            Expression::CurrentInput(Some(property)) if property == "outpoint"
-        ) || matches!(
-            expression,
-            Expression::InputIntrospection { property, .. } if property == "outpoint"
-        ) {
-            return Err(
-                "outpoint inspection produces 2 stack items; composite values are not supported"
-                    .to_string(),
-            );
-        }
         if matches!(expression, Expression::ArrayLiteral(_)) {
             return Err(
                 "array literals may only initialize an array declaration; composite values are not supported"
@@ -444,19 +432,57 @@ impl Generator {
                     .to_string(),
             );
         }
+        self.emit_expression_items(expression, 1)
+    }
+
+    fn emit_expression_items(
+        &mut self,
+        expression: &Expression,
+        expected: usize,
+    ) -> Result<(), String> {
         let before = self.stack.len();
         let mut raw = Vec::new();
         emit_expression_asm(expression, &mut raw);
         for token in raw {
             self.lower_raw_token(&token)?;
         }
-        if self.stack.len() != before + 1
-            || !matches!(self.stack.last(), Some(StackItem::Temporary))
+        if self.stack.len() != before + expected
+            || self.stack[before..]
+                .iter()
+                .any(|item| !matches!(item, StackItem::Temporary))
         {
             return Err(format!(
-                "expression produces {} stack items; exactly one is required",
-                self.stack.len().saturating_sub(before)
+                "expression produces {} stack items; exactly {expected} required",
+                self.stack.len().saturating_sub(before),
             ));
+        }
+        Ok(())
+    }
+
+    fn bind_native_struct(
+        &mut self,
+        name: &str,
+        declared_type: &str,
+        expression: &Expression,
+    ) -> Result<(), String> {
+        let fields = crate::models::builtin_struct_fields(declared_type)
+            .ok_or_else(|| format!("unknown native struct type '{declared_type}'"))?;
+        // Native multi-item opcodes currently all return two leaves. Replace
+        // this swap with a general reversal when a wider result is introduced.
+        if fields.len() != 2 {
+            return Err(format!(
+                "native struct '{declared_type}' has unsupported width {}",
+                fields.len()
+            ));
+        }
+        self.emit_expression_items(expression, fields.len())?;
+        self.swap()?;
+        let start = self.stack.len() - fields.len();
+        for ((field, _), item) in fields.iter().rev().zip(&mut self.stack[start..]) {
+            *item = StackItem::Binding {
+                name: Self::internal_binding_name(&format!("{name}.{field}")),
+                kind: BindingKind::Local,
+            };
         }
         Ok(())
     }
@@ -849,6 +875,19 @@ fn generate_asm_from_statements_recursive(
                         generator.emit_expression(&expression)?;
                         generator.bind_local(&Generator::internal_binding_name(&access_name))?;
                     }
+                }
+                (declared_type, value)
+                    if crate::models::expression_result_struct(value).is_some() =>
+                {
+                    let result_type = crate::models::expression_result_struct(value)
+                        .expect("matched a native struct result");
+                    if declared_type.is_some_and(|declared| declared != result_type) {
+                        return Err(format!(
+                            "binding '{name}' declares type '{}' but initializer has type '{result_type}'",
+                            declared_type.expect("checked as some"),
+                        ));
+                    }
+                    generator.bind_native_struct(name, result_type, value)?;
                 }
                 (Some(declared_type), Expression::ArrayLiteral(elements))
                     if crate::models::array_type_parts(declared_type).is_some() =>

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -173,7 +173,11 @@ impl Generator {
     }
 
     fn read_binding(&mut self, name: &str) -> Result<(), String> {
-        if let Some(array) = name.trim().strip_suffix(".length") {
+        // A field named `length` outranks synthetic array length.
+        let is_binding = self
+            .binding_index(&Self::internal_binding_name(name))
+            .is_some();
+        if let Some(array) = name.trim().strip_suffix(".length").filter(|_| !is_binding) {
             let length = self.array_length(array);
             if length == 0 {
                 return Err(format!("'{array}' is not an array; '.length' is undefined"));

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -651,6 +651,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
 
     let mut json = ContractJson {
         name: contract.name.clone(),
+        structs: contract.structs.clone(),
         parameters,
         functions: Vec::new(),
         source: Some(strip_comments(source_code)),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -709,7 +709,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
 }
 
 /// The placeholder namespace a parameter list emits: array types (e.g.
-/// `pubkey[3]`) flatten to `name_0`, `name_1`, `name_2`; every other param
+/// `pubkey[3]`) flatten to `name.0`, `name.1`, `name.2`; every other param
 /// passes through unchanged. This is the `<name>` namespace in `asm`, not the
 /// artifact ABI, which keeps one entry per source parameter.
 pub(crate) fn expanded_placeholder_params(

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -73,12 +73,16 @@ struct Generator {
 }
 
 impl Generator {
-    fn new(function_parameters: &[Parameter], constructor_parameters: &[Parameter]) -> Self {
+    fn new(
+        function_parameters: &[Parameter],
+        constructor_parameters: &[Parameter],
+        structs: &[crate::models::StructDefinition],
+    ) -> Result<Self, String> {
         let mut function_bindings = Vec::new();
         for parameter in function_parameters {
-            for_each_expanded_param(parameter, |_, binding_name, _| {
+            for_each_expanded_param(parameter, structs, |_, binding_name, _| {
                 function_bindings.push(binding_name);
-            });
+            })?;
         }
         let mut stack = function_bindings
             .into_iter()
@@ -93,11 +97,13 @@ impl Generator {
         let mut constructor_array_expansions = Vec::new();
         for parameter in constructor_parameters {
             let mut expanded_placeholders = Vec::new();
-            for_each_expanded_param(parameter, |placeholder, binding_name, _| {
+            for_each_expanded_param(parameter, structs, |placeholder, binding_name, _| {
                 expanded_placeholders.push(format!("<{placeholder}>"));
                 constructor_bindings.push((placeholder, binding_name));
-            });
-            if crate::models::array_type_parts(&parameter.param_type).is_some() {
+            })?;
+            if expanded_placeholders.len() != 1
+                || expanded_placeholders[0] != format!("<{}>", parameter.name)
+            {
                 constructor_array_expansions.push((
                     format!("<{}>", parameter.name),
                     expanded_placeholders.join(","),
@@ -112,13 +118,13 @@ impl Generator {
                 kind: BindingKind::Constructor,
             });
         }
-        Self {
+        Ok(Self {
             asm,
             stack,
             scopes: Vec::new(),
             alt_depth: 0,
             constructor_array_expansions,
-        }
+        })
     }
 
     fn push_depth(&mut self, depth: usize) {
@@ -669,7 +675,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
     for function in contract.functions.iter().filter(|f| !f.is_internal) {
         covenants.insert(
             function.name.clone(),
-            covenant_for(function, &contract.parameters)?,
+            covenant_for(function, &contract.parameters, &contract.structs)?,
         );
     }
 
@@ -698,23 +704,27 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
 /// `pubkey[3]`) flatten to `name_0`, `name_1`, `name_2`; every other param
 /// passes through unchanged. This is the `<name>` namespace in `asm`, not the
 /// artifact ABI, which keeps one entry per source parameter.
-pub(crate) fn expanded_placeholder_params(params: &[Parameter]) -> Vec<Parameter> {
+pub(crate) fn expanded_placeholder_params(
+    params: &[Parameter],
+    structs: &[crate::models::StructDefinition],
+) -> Result<Vec<Parameter>, String> {
     let mut result = Vec::new();
     for param in params {
-        for_each_expanded_param(param, |name, _, param_type| {
+        for_each_expanded_param(param, structs, |name, _, param_type| {
             result.push(Parameter { name, param_type });
-        });
+        })?;
     }
-    result
+    Ok(result)
 }
 
 /// Build an `ArkadeCovenant` for a non-internal function.
 fn covenant_for(
     function: &Function,
     constructor_parameters: &[Parameter],
+    structs: &[crate::models::StructDefinition],
 ) -> Result<ArkadeCovenant, String> {
     let inputs = function_inputs(&function.parameters);
-    let mut generator = Generator::new(&function.parameters, constructor_parameters);
+    let mut generator = Generator::new(&function.parameters, constructor_parameters, structs)?;
     generate_asm_from_statements_recursive(&function.statements, &mut generator)?;
     let asm = generator.finish()?;
     Ok(ArkadeCovenant { inputs, asm })
@@ -730,22 +740,16 @@ fn function_inputs(params: &[Parameter]) -> Vec<FunctionInput> {
         .collect()
 }
 
-fn for_each_expanded_param(param: &Parameter, mut f: impl FnMut(String, String, String)) {
-    if let Some((base_type, length)) = crate::models::array_type_parts(&param.param_type) {
-        for i in 0..length {
-            f(
-                format!("{}_{}", param.name, i),
-                internal_array_binding_name(&param.name, &i.to_string()),
-                base_type.to_string(),
-            );
-        }
-    } else {
-        f(
-            param.name.clone(),
-            param.name.clone(),
-            param.param_type.clone(),
-        );
+fn for_each_expanded_param(
+    param: &Parameter,
+    structs: &[crate::models::StructDefinition],
+    mut f: impl FnMut(String, String, String),
+) -> Result<(), String> {
+    for leaf in crate::models::flatten_parameter(param, structs)? {
+        let binding_name = Generator::internal_binding_name(&leaf.access_name);
+        f(leaf.emitted_name, binding_name, leaf.leaf_type);
     }
+    Ok(())
 }
 
 /// Recursively generate assembly from statements
@@ -795,8 +799,9 @@ fn generate_asm_from_statements_recursive(
                 iterable,
                 body,
             } => {
-                let Expression::Variable(array_name) = iterable else {
-                    return Err("unsupported loop iterable".to_string());
+                let array_name = match iterable {
+                    Expression::Variable(name) | Expression::Property(name) => name,
+                    _ => return Err("unsupported loop iterable".to_string()),
                 };
                 let array_name = array_name.as_str();
                 for k in 0..generator.array_length(array_name) {
@@ -1018,7 +1023,7 @@ mod symbolic_stack_tests {
                 param_type: "int".to_string(),
             })
             .collect::<Vec<_>>();
-        let mut generator = Generator::new(&inputs, &[]);
+        let mut generator = Generator::new(&inputs, &[], &[]).expect("scalar test inputs");
 
         generator.push_temporary("9");
         generator.assign("d").expect("deep assignment");

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -248,14 +248,13 @@ pub fn validate_arkd_rules(
     c: &Closure,
     min_exit_delay: Option<u64>,
 ) -> Result<(), String> {
+    let constructor_scope =
+        crate::typechecker::build_scope_with_structs(&contract.parameters, &contract.structs);
     // Pubkeys in scope: constructor pubkey params + pubkey tapscript inputs.
     let in_scope = |name: &str| -> bool {
         name == "server"
             || name == "emulator"
-            || contract
-                .parameters
-                .iter()
-                .any(|p| p.name == name && p.param_type == "pubkey")
+            || constructor_scope.get(name) == Some(&ArkType::Pubkey)
             || ts
                 .inputs
                 .iter()
@@ -273,8 +272,7 @@ pub fn validate_arkd_rules(
 
     // Any declared name (constructor param or tapscript input), any type.
     let name_declared = |name: &str| -> bool {
-        contract.parameters.iter().any(|p| p.name == name)
-            || ts.inputs.iter().any(|p| p.name == name)
+        constructor_scope.contains_key(name) || ts.inputs.iter().any(|p| p.name == name)
     };
     // A declared `signature` input.
     let sig_input = |name: &str| -> bool {
@@ -495,10 +493,12 @@ pub fn build_function_groups(
             Binding::Standalone => ts.name.clone(),
         };
 
+        let mut asm = emit_leaf_asm(&closure, &ts.name, &binding);
+        resolve_constructor_field_placeholders(&mut asm, contract)?;
         grouped.entry(group_key).or_default().push(AbiLeaf {
             name: ts.name.clone(),
             witness: leaf_witness(ts),
-            asm: emit_leaf_asm(&closure, &ts.name, &binding),
+            asm,
         });
     }
 
@@ -528,6 +528,33 @@ pub fn build_function_groups(
     }
 
     Ok(groups)
+}
+
+fn resolve_constructor_field_placeholders(
+    asm: &mut [String],
+    contract: &Contract,
+) -> Result<(), String> {
+    let replacements = contract
+        .parameters
+        .iter()
+        .map(|parameter| crate::models::flatten_parameter(parameter, &contract.structs))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .filter(|leaf| leaf.access_name != leaf.emitted_name)
+        .map(|leaf| {
+            (
+                format!("<{}>", leaf.access_name),
+                format!("<{}>", leaf.emitted_name),
+            )
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    for token in asm {
+        if let Some(replacement) = replacements.get(token) {
+            *token = replacement.clone();
+        }
+    }
+    Ok(())
 }
 
 /// The §5.4 default collaborative leaf: checkMultisig([server, tweak(emulator, fn)], …, 2).

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -725,6 +725,7 @@ mod tests {
     fn contract_with(funcs: &[&str], tapscripts: Vec<NamedTapscript>) -> Contract {
         Contract {
             name: "C".into(),
+            structs: vec![],
             parameters: vec![
                 Parameter {
                     name: "owner".into(),

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -270,9 +270,11 @@ pub fn validate_arkd_rules(
         }
     }
 
-    // Any declared name (constructor param or tapscript input), any type.
+    // Any scalar constructor binding or tapscript input.
     let name_declared = |name: &str| -> bool {
-        constructor_scope.contains_key(name) || ts.inputs.iter().any(|p| p.name == name)
+        constructor_scope.get(name).is_some_and(|binding_type| {
+            !matches!(binding_type, ArkType::Struct(_) | ArkType::Array(..))
+        }) || ts.inputs.iter().any(|p| p.name == name)
     };
     // A declared `signature` input.
     let sig_input = |name: &str| -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ mod validator;
 pub mod wasm;
 
 pub use models::{
-    Contract, ContractJson, Expression, Function, Parameter, Requirement, WitnessElement,
+    Contract, ContractJson, Expression, Function, Parameter, Requirement, StructDefinition,
+    WitnessElement,
 };
 pub use typechecker::{ArkType, TypeError};
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -21,6 +21,7 @@ pub fn is_builtin_type(declared_type: &str) -> bool {
     )
 }
 
+/// Native struct fields in source order; producing opcodes push the first field deepest.
 pub fn builtin_struct_fields(
     declared_type: &str,
 ) -> Option<&'static [(&'static str, &'static str)]> {
@@ -110,6 +111,19 @@ fn flatten_type(
             emitted_name: emitted_name.to_string(),
             leaf_type: declared_type.to_string(),
         });
+        return Ok(());
+    }
+    if let Some(fields) = builtin_struct_fields(declared_type) {
+        for (field_name, field_type) in fields {
+            flatten_type(
+                &format!("{access_name}.{field_name}"),
+                &format!("{emitted_name}.{field_name}"),
+                field_type,
+                structs,
+                stack,
+                leaves,
+            )?;
+        }
         return Ok(());
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -45,7 +45,7 @@ pub struct StructDefinition {
 pub struct TypeLeaf {
     /// Source path used by expressions, such as `policy.owner.key`.
     pub access_name: String,
-    /// Artifact and placeholder name, such as `policy_owner_key`.
+    /// Artifact and placeholder name, such as `policy.owner.key`.
     pub emitted_name: String,
     pub leaf_type: String,
 }
@@ -83,7 +83,7 @@ fn flatten_type(
         for index in 0..length {
             leaves.push(TypeLeaf {
                 access_name: format!("{access_name}[{index}]"),
-                emitted_name: format!("{emitted_name}_{index}"),
+                emitted_name: format!("{emitted_name}.{index}"),
                 leaf_type: element_type.to_string(),
             });
         }
@@ -109,7 +109,7 @@ fn flatten_type(
     for field in &definition.fields {
         flatten_type(
             &format!("{access_name}.{}", field.name),
-            &format!("{emitted_name}_{}", field.name),
+            &format!("{emitted_name}.{}", field.name),
             &field.param_type,
             structs,
             stack,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -21,6 +21,21 @@ pub fn is_builtin_type(declared_type: &str) -> bool {
     )
 }
 
+pub fn builtin_struct_fields(
+    declared_type: &str,
+) -> Option<&'static [(&'static str, &'static str)]> {
+    match declared_type {
+        "AssetId" => Some(&[("txid", "bytes32"), ("gidx", "int")]),
+        "Outpoint" => Some(&[("txid", "bytes32"), ("vout", "int")]),
+        "ECPoint" => Some(&[("x", "int"), ("y", "int")]),
+        _ => None,
+    }
+}
+
+pub fn is_builtin_struct(declared_type: &str) -> bool {
+    builtin_struct_fields(declared_type).is_some()
+}
+
 // JSON output structures.
 // These represent the compiled contract in a serializable format.
 /// Parameter in a contract or function
@@ -604,12 +619,7 @@ pub enum Expression {
         modulus: Box<Expression>,
     },
     // ─── Crypto Opcodes ────────────────────────────────────────────────
-    /// EC point addition. Produces x and y as two stack items.
-    ///
-    /// TODO(asset-id-struct): like `group.assetId`, a two-item result has no
-    /// representation — `let` binds one name and `==` would only see y. The
-    /// result is unusable until the composite return type lands; the emission
-    /// is correct and ready for it.
+    /// EC point addition. Produces an `ECPoint`.
     EcAdd {
         x1: Box<Expression>,
         y1: Box<Expression>,
@@ -617,9 +627,7 @@ pub enum Expression {
         y2: Box<Expression>,
         curve_id: Box<Expression>,
     },
-    /// EC scalar multiplication. Produces x and y as two stack items.
-    ///
-    /// TODO(asset-id-struct): same two-item limitation as `EcAdd`.
+    /// EC scalar multiplication. Produces an `ECPoint`.
     EcMul {
         x: Box<Expression>,
         y: Box<Expression>,
@@ -700,4 +708,23 @@ pub enum Expression {
         index: Box<Expression>,
         packet_type: Box<Expression>,
     },
+}
+
+/// Native struct returned by a fixed-width multi-item expression.
+pub fn expression_result_struct(expression: &Expression) -> Option<&'static str> {
+    match expression {
+        Expression::EcAdd { .. } | Expression::EcMul { .. } => Some("ECPoint"),
+        Expression::AssetAt { property, .. } | Expression::GroupProperty { property, .. }
+            if property == "assetId" =>
+        {
+            Some("AssetId")
+        }
+        Expression::CurrentInput(Some(property))
+        | Expression::InputIntrospection { property, .. }
+            if property == "outpoint" =>
+        {
+            Some("Outpoint")
+        }
+        _ => None,
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -451,6 +451,8 @@ pub enum Expression {
     Property(String),
     /// Array literal; only valid as the initializer of an array declaration.
     ArrayLiteral(Vec<Expression>),
+    /// Named struct literal; only valid as the initializer of a typed declaration.
+    StructLiteral(Vec<(String, Expression)>),
     /// Array element selected by an integer expression.
     ArrayIndex {
         array: String,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -14,6 +14,13 @@ pub fn array_type_parts(declared_type: &str) -> Option<(&str, usize)> {
     Some((element, length.parse().ok()?))
 }
 
+pub fn is_builtin_type(declared_type: &str) -> bool {
+    matches!(
+        declared_type,
+        "pubkey" | "signature" | "bytes" | "bytes20" | "bytes32" | "int" | "bool" | "asset"
+    )
+}
+
 // JSON output structures.
 // These represent the compiled contract in a serializable format.
 /// Parameter in a contract or function
@@ -24,6 +31,13 @@ pub struct Parameter {
     /// Parameter type (pubkey, signature, bytes32, int, bool, asset, value)
     #[serde(rename = "type")]
     pub param_type: String,
+}
+
+/// A named, statically laid-out source type.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StructDefinition {
+    pub name: String,
+    pub fields: Vec<Parameter>,
 }
 
 /// Function input parameter
@@ -104,6 +118,8 @@ pub struct AbiFunctionGroup {
 pub struct ContractJson {
     #[serde(rename = "contractName")]
     pub name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub structs: Vec<StructDefinition>,
     #[serde(rename = "constructorInputs")]
     pub parameters: Vec<Parameter>,
     pub functions: Vec<AbiFunctionGroup>,
@@ -132,6 +148,8 @@ pub struct CompilerInfo {
 pub struct Contract {
     /// Contract name
     pub name: String,
+    /// Struct types declared before this contract.
+    pub structs: Vec<StructDefinition>,
     /// Contract parameters
     pub parameters: Vec<Parameter>,
     /// Contract functions

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -40,6 +40,86 @@ pub struct StructDefinition {
     pub fields: Vec<Parameter>,
 }
 
+/// One scalar leaf in a recursively flattened parameter layout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeLeaf {
+    /// Source path used by expressions, such as `policy.owner.key`.
+    pub access_name: String,
+    /// Artifact and placeholder name, such as `policy_owner_key`.
+    pub emitted_name: String,
+    pub leaf_type: String,
+}
+
+pub fn flatten_parameter(
+    parameter: &Parameter,
+    structs: &[StructDefinition],
+) -> Result<Vec<TypeLeaf>, String> {
+    let mut leaves = Vec::new();
+    flatten_type(
+        &parameter.name,
+        &parameter.name,
+        &parameter.param_type,
+        structs,
+        &mut Vec::new(),
+        &mut leaves,
+    )?;
+    Ok(leaves)
+}
+
+fn flatten_type(
+    access_name: &str,
+    emitted_name: &str,
+    declared_type: &str,
+    structs: &[StructDefinition],
+    stack: &mut Vec<String>,
+    leaves: &mut Vec<TypeLeaf>,
+) -> Result<(), String> {
+    if let Some((element_type, length)) = array_type_parts(declared_type) {
+        if !is_builtin_type(element_type) {
+            return Err(format!(
+                "arrays of structs are not supported: '{declared_type}'"
+            ));
+        }
+        for index in 0..length {
+            leaves.push(TypeLeaf {
+                access_name: format!("{access_name}[{index}]"),
+                emitted_name: format!("{emitted_name}_{index}"),
+                leaf_type: element_type.to_string(),
+            });
+        }
+        return Ok(());
+    }
+    if is_builtin_type(declared_type) {
+        leaves.push(TypeLeaf {
+            access_name: access_name.to_string(),
+            emitted_name: emitted_name.to_string(),
+            leaf_type: declared_type.to_string(),
+        });
+        return Ok(());
+    }
+
+    let definition = structs
+        .iter()
+        .find(|definition| definition.name == declared_type)
+        .ok_or_else(|| format!("unknown type '{declared_type}'"))?;
+    if stack.iter().any(|name| name == declared_type) {
+        return Err(format!("recursive struct layout: {declared_type}"));
+    }
+    stack.push(declared_type.to_string());
+    for field in &definition.fields {
+        flatten_type(
+            &format!("{access_name}.{}", field.name),
+            &format!("{emitted_name}_{}", field.name),
+            &field.param_type,
+            structs,
+            stack,
+            leaves,
+        )?;
+    }
+    stack.pop();
+    Ok(())
+}
+
 /// Function input parameter
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FunctionInput {

--- a/src/parser/asset.rs
+++ b/src/parser/asset.rs
@@ -6,20 +6,18 @@ use pest::iterators::Pair;
 
 // ─── Asset Lookup Parsing ──────────────────────────────────────────────────────
 
-/// Parse an asset-id txid operand (a bytes32 identifier).
-pub(crate) fn parse_asset_id_txid(pair: Pair<Rule>) -> Expression {
+pub(crate) fn parse_asset_id_txid(pair: Pair<Rule>) -> Result<Expression, String> {
     match pair.as_rule() {
-        Rule::identifier_property_access => Expression::Property(pair.as_str().to_string()),
-        _ => Expression::Variable(pair.as_str().to_string()),
+        Rule::identifier_property_access => parse_property_access(pair),
+        _ => Ok(Expression::Variable(pair.as_str().to_string())),
     }
 }
 
-/// Parse an asset-id gidx operand (an int identifier or a numeric literal).
-pub(crate) fn parse_asset_id_gidx(pair: Pair<Rule>) -> Expression {
+pub(crate) fn parse_asset_id_gidx(pair: Pair<Rule>) -> Result<Expression, String> {
     match pair.as_rule() {
-        Rule::number_literal => Expression::Literal(pair.as_str().to_string()),
-        Rule::identifier_property_access => Expression::Property(pair.as_str().to_string()),
-        _ => Expression::Variable(pair.as_str().to_string()),
+        Rule::number_literal => Ok(Expression::Literal(pair.as_str().to_string())),
+        Rule::identifier_property_access => parse_property_access(pair),
+        _ => Ok(Expression::Variable(pair.as_str().to_string())),
     }
 }
 
@@ -62,8 +60,8 @@ pub(crate) fn parse_asset_group_id_operands(
     }
 
     Ok((
-        parse_asset_id_txid(txid_pair),
-        parse_asset_id_gidx(gidx_pair),
+        parse_asset_id_txid(txid_pair)?,
+        parse_asset_id_gidx(gidx_pair)?,
     ))
 }
 
@@ -100,8 +98,8 @@ pub(crate) fn parse_asset_lookup_operands(
     };
 
     // Parse the canonical Asset ID operands: txid (bytes32) then gidx (int).
-    let asset_txid = parse_asset_id_txid(inner.next().ok_or("Missing asset txid")?);
-    let asset_gidx = parse_asset_id_gidx(inner.next().ok_or("Missing asset gidx")?);
+    let asset_txid = parse_asset_id_txid(inner.next().ok_or("Missing asset txid")?)?;
+    let asset_gidx = parse_asset_id_gidx(inner.next().ok_or("Missing asset gidx")?)?;
 
     Ok((source, index, asset_txid, asset_gidx))
 }
@@ -224,8 +222,8 @@ pub(crate) fn parse_group_control_is_to_expression(pair: Pair<Rule>) -> Result<E
         .ok_or("Missing group in controlIs")?
         .as_str()
         .to_string();
-    let asset_txid = parse_asset_id_txid(inner.next().ok_or("Missing controlIs txid")?);
-    let asset_gidx = parse_asset_id_gidx(inner.next().ok_or("Missing controlIs gidx")?);
+    let asset_txid = parse_asset_id_txid(inner.next().ok_or("Missing controlIs txid")?)?;
+    let asset_gidx = parse_asset_id_gidx(inner.next().ok_or("Missing controlIs gidx")?)?;
     Ok(Expression::GroupControlIs {
         group,
         asset_txid: Box::new(asset_txid),

--- a/src/parser/asset.rs
+++ b/src/parser/asset.rs
@@ -8,13 +8,17 @@ use pest::iterators::Pair;
 
 /// Parse an asset-id txid operand (a bytes32 identifier).
 pub(crate) fn parse_asset_id_txid(pair: Pair<Rule>) -> Expression {
-    Expression::Variable(pair.as_str().to_string())
+    match pair.as_rule() {
+        Rule::identifier_property_access => Expression::Property(pair.as_str().to_string()),
+        _ => Expression::Variable(pair.as_str().to_string()),
+    }
 }
 
 /// Parse an asset-id gidx operand (an int identifier or a numeric literal).
 pub(crate) fn parse_asset_id_gidx(pair: Pair<Rule>) -> Expression {
     match pair.as_rule() {
         Rule::number_literal => Expression::Literal(pair.as_str().to_string()),
+        Rule::identifier_property_access => Expression::Property(pair.as_str().to_string()),
         _ => Expression::Variable(pair.as_str().to_string()),
     }
 }
@@ -46,9 +50,13 @@ pub(crate) fn parse_asset_group_id_operands(
         .next()
         .ok_or("asset id requires (txid, gidx) operands")?;
 
-    if txid_pair.as_rule() != Rule::identifier
-        || !matches!(gidx_pair.as_rule(), Rule::identifier | Rule::number_literal)
-        || operands.next().is_some()
+    if !matches!(
+        txid_pair.as_rule(),
+        Rule::identifier | Rule::identifier_property_access
+    ) || !matches!(
+        gidx_pair.as_rule(),
+        Rule::identifier | Rule::identifier_property_access | Rule::number_literal
+    ) || operands.next().is_some()
     {
         return Err("asset id requires (txid, gidx) operands".to_string());
     }

--- a/src/parser/comparison.rs
+++ b/src/parser/comparison.rs
@@ -4,7 +4,6 @@ use super::*;
 use crate::models::*;
 use pest::iterators::Pair;
 
-/// Parse tx.time >= variable → After requirement
 pub(crate) fn parse_time_comparison(pair: Pair<Rule>) -> Result<Requirement, String> {
     let mut inner = pair.into_inner();
     let timelock_var = inner.next().ok_or("Missing timelock")?.as_str().to_string();
@@ -32,12 +31,14 @@ pub(crate) fn parse_hash_comparison(pair: Pair<Rule>) -> Result<Requirement, Str
     // and literals surface as `Variable` / `Literal`, while byte-producing
     // primitives (substr/cat/…) and arithmetic surface as their own variants.
     let preimage_expr = parse_additive_expr(preimage_pair)?;
-    let rhs_is_identifier = matches!(rhs_pair.as_rule(), Rule::identifier);
+    let rhs_is_binding = matches!(rhs_pair.as_rule(), Rule::named_binding);
 
-    // Fast path: a bare identifier/literal preimage AND identifier RHS keep the
+    // Fast path: a bare binding/literal preimage and binding RHS keep the
     // structured HashEqual emission (`<preimage> OP_<HASH> <hash> OP_EQUAL`).
-    if rhs_is_identifier {
-        if let Expression::Variable(name) | Expression::Literal(name) = &preimage_expr {
+    if rhs_is_binding {
+        if let Expression::Variable(name) | Expression::Literal(name) | Expression::Property(name) =
+            &preimage_expr
+        {
             return Ok(Requirement::HashEqual {
                 hash_fn,
                 preimage: name.clone(),

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -301,26 +301,7 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
         Rule::asset_count => parse_asset_count_to_expression(pair),
         Rule::asset_at => parse_asset_at_to_expression(pair),
         Rule::group_control_is => parse_group_control_is_to_expression(pair),
-        Rule::identifier_property_access => {
-            let text = pair.as_str().trim().to_string();
-            let mut inner = pair.into_inner().collect::<Vec<_>>();
-            if inner
-                .last()
-                .is_some_and(|part| part.as_rule() == Rule::general_expression)
-            {
-                let index = inner.pop().ok_or("Missing field array index")?;
-                let array = inner
-                    .iter()
-                    .map(|part| part.as_str())
-                    .collect::<Vec<_>>()
-                    .join(".");
-                return Ok(Expression::ArrayIndex {
-                    array,
-                    index: Box::new(parse_general_expression(index)?),
-                });
-            }
-            Ok(Expression::Property(text))
-        }
+        Rule::identifier_property_access => parse_property_access(pair),
         Rule::input_introspection => parse_input_introspection_to_expression(pair),
         Rule::output_introspection => parse_output_introspection_to_expression(pair),
         Rule::tx_introspection => parse_tx_introspection_to_expression(pair),
@@ -385,6 +366,28 @@ pub(crate) fn parse_atom_pair(pair: Pair<Rule>) -> Expression {
     }
 }
 
+pub(crate) fn parse_property_access(pair: Pair<Rule>) -> Result<Expression, String> {
+    let mut inner = pair.into_inner().collect::<Vec<_>>();
+    let index = match inner.last() {
+        Some(part) if part.as_rule() == Rule::general_expression => {
+            Some(inner.pop().ok_or("Missing field array index")?)
+        }
+        _ => None,
+    };
+    let path = inner
+        .iter()
+        .map(|part| part.as_str())
+        .collect::<Vec<_>>()
+        .join(".");
+    match index {
+        Some(index) => Ok(Expression::ArrayIndex {
+            array: path,
+            index: Box::new(parse_general_expression(index)?),
+        }),
+        None => Ok(Expression::Property(path)),
+    }
+}
+
 /// Parse a `byte_value` rule into an Expression. Used wherever the grammar
 /// accepts an arbitrary byte-producing operand (substr/cat/bin2num/size args).
 pub(crate) fn parse_byte_value(pair: Pair<Rule>) -> Result<Expression, String> {
@@ -401,7 +404,14 @@ pub(crate) fn parse_byte_value(pair: Pair<Rule>) -> Result<Expression, String> {
         Rule::output_introspection => parse_output_introspection_to_expression(inner),
         Rule::asset_at => parse_asset_at_to_expression(inner),
         Rule::identifier => Ok(Expression::Variable(inner.as_str().to_string())),
-        Rule::named_binding => Ok(Expression::Property(inner.as_str().to_string())),
+        Rule::named_binding => {
+            let name = inner.as_str().to_string();
+            if name.contains(['.', '[']) {
+                Ok(Expression::Property(name))
+            } else {
+                Ok(Expression::Variable(name))
+            }
+        }
         r => Err(format!("Unsupported byte_value rule: {:?}", r)),
     }
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -211,6 +211,22 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
                 .map(parse_general_expression)
                 .collect::<Result<Vec<_>, _>>()?,
         )),
+        Rule::struct_literal => Ok(Expression::StructLiteral(
+            pair.into_inner()
+                .map(|field| {
+                    let mut field = field.into_inner();
+                    let name = field
+                        .next()
+                        .ok_or("Missing struct literal field name")?
+                        .as_str()
+                        .to_string();
+                    let value = parse_general_expression(
+                        field.next().ok_or("Missing struct literal field value")?,
+                    )?;
+                    Ok((name, value))
+                })
+                .collect::<Result<Vec<_>, String>>()?,
+        )),
         Rule::array_length_access => {
             let array = pair
                 .into_inner()

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -286,19 +286,44 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
         Rule::asset_at => parse_asset_at_to_expression(pair),
         Rule::group_control_is => parse_group_control_is_to_expression(pair),
         Rule::identifier_property_access => {
-            let mut inner = pair.into_inner();
-            Ok(Expression::GroupProperty {
-                group: inner
-                    .next()
-                    .ok_or("Missing group name")?
-                    .as_str()
-                    .to_string(),
-                property: inner
-                    .next()
-                    .ok_or("Missing group property")?
-                    .as_str()
-                    .to_string(),
-            })
+            let text = pair.as_str().trim().to_string();
+            let mut inner = pair.into_inner().collect::<Vec<_>>();
+            if inner
+                .last()
+                .is_some_and(|part| part.as_rule() == Rule::general_expression)
+            {
+                let index = inner.pop().ok_or("Missing field array index")?;
+                let array = inner
+                    .iter()
+                    .map(|part| part.as_str())
+                    .collect::<Vec<_>>()
+                    .join(".");
+                return Ok(Expression::ArrayIndex {
+                    array,
+                    index: Box::new(parse_general_expression(index)?),
+                });
+            }
+            let parts = inner.iter().map(|part| part.as_str()).collect::<Vec<_>>();
+            if parts.len() == 2
+                && matches!(
+                    parts[1],
+                    "numInputs"
+                        | "numOutputs"
+                        | "sumInputs"
+                        | "sumOutputs"
+                        | "delta"
+                        | "hasControl"
+                        | "metadataHash"
+                        | "assetId"
+                        | "isFresh"
+                )
+            {
+                return Ok(Expression::GroupProperty {
+                    group: parts[0].to_string(),
+                    property: parts[1].to_string(),
+                });
+            }
+            Ok(Expression::Property(text))
         }
         Rule::input_introspection => parse_input_introspection_to_expression(pair),
         Rule::output_introspection => parse_output_introspection_to_expression(pair),
@@ -380,6 +405,7 @@ pub(crate) fn parse_byte_value(pair: Pair<Rule>) -> Result<Expression, String> {
         Rule::output_introspection => parse_output_introspection_to_expression(inner),
         Rule::asset_at => parse_asset_at_to_expression(inner),
         Rule::identifier => Ok(Expression::Variable(inner.as_str().to_string())),
+        Rule::named_binding => Ok(Expression::Property(inner.as_str().to_string())),
         r => Err(format!("Unsupported byte_value rule: {:?}", r)),
     }
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -319,26 +319,6 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
                     index: Box::new(parse_general_expression(index)?),
                 });
             }
-            let parts = inner.iter().map(|part| part.as_str()).collect::<Vec<_>>();
-            if parts.len() == 2
-                && matches!(
-                    parts[1],
-                    "numInputs"
-                        | "numOutputs"
-                        | "sumInputs"
-                        | "sumOutputs"
-                        | "delta"
-                        | "hasControl"
-                        | "metadataHash"
-                        | "assetId"
-                        | "isFresh"
-                )
-            {
-                return Ok(Expression::GroupProperty {
-                    group: parts[0].to_string(),
-                    property: parts[1].to_string(),
-                });
-            }
             Ok(Expression::Property(text))
         }
         Rule::input_introspection => parse_input_introspection_to_expression(pair),

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -82,7 +82,7 @@ let_binding = {
 // Variable assignment (reassignment without let keyword)
 // Must check for = but not == or >= or <=
 var_assign = {
-    (array_index_access | identifier) ~ "=" ~ !("=") ~ general_expression ~ ";"
+    (identifier_property_access | array_index_access | identifier) ~ "=" ~ !("=") ~ general_expression ~ ";"
 }
 
 // Require statement
@@ -167,9 +167,9 @@ primary_expr = {
     tx_introspection |
     group_control_is |
     array_length_access |
-    identifier_property_access |
     tx_property_access |
     this_property_access |
+    identifier_property_access |
     constructor |
     function_call |
     array_index_access |
@@ -241,6 +241,8 @@ complex_expression = _{
     tx_property_access |
     this_property_access |
     function_call |
+    identifier_property_access |
+    array_index_access |
     identifier |
     number_literal |
     array_literal
@@ -341,9 +343,9 @@ group_control_is = {
     identifier ~ "." ~ "controlIs" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")"
 }
 
-// Identifier property access: variable.property (e.g., group.sumInputs, tokenGroup.delta)
+// Named field path, optionally ending in an array index.
 identifier_property_access = {
-    identifier ~ "." ~ group_property
+    identifier ~ ("." ~ identifier)+ ~ ("[" ~ general_expression ~ "]")?
 }
 
 // ─── Standard Comparisons ──────────────────────────────────────────────────────
@@ -463,7 +465,7 @@ function_call = {
 
 // Key expression: a bare pubkey identifier (server, emulator, owner, …) or an
 // explicit emulator tweak. Used only inside checkSig/checkMultisig.
-key_expr = { tweak_key | identifier }
+key_expr = { tweak_key | named_binding }
 
 // Explicit emulator tweak: tweak(emulator, funcName)
 tweak_key = { "tweak" ~ "(" ~ identifier ~ "," ~ identifier ~ ")" }
@@ -473,7 +475,7 @@ key_array = { "[" ~ key_expr ~ ("," ~ key_expr)* ~ "]" }
 
 // CheckSig expression — key position accepts a key expression (incl. tweak()).
 check_sig = {
-    "checkSig" ~ "(" ~ identifier ~ "," ~ key_expr ~ ")"
+    "checkSig" ~ "(" ~ named_binding ~ "," ~ key_expr ~ ")"
 }
 
 // CheckSigFromStack expression
@@ -483,7 +485,7 @@ check_sig_from_stack = {
 }
 
 // Signature function argument: identifier or array access
-sig_arg = { named_array_index_access | identifier }
+sig_arg = { named_binding }
 
 // CheckMultisig expression
 check_multisig = { check_threshold_multisig }
@@ -496,7 +498,16 @@ check_threshold_multisig = {
 
 // Array of identifiers
 array = {
-    "[" ~ identifier ~ ("," ~ identifier)* ~ "]"
+    "[" ~ named_binding ~ ("," ~ named_binding)* ~ "]"
+}
+
+// Named operands used by crypto checks. Dynamic indices here remain limited
+// to a single binding because these AST nodes store operand names directly.
+named_binding = @{
+    identifier ~ (
+        ("." ~ identifier)+ ~ ("[" ~ (identifier | number_literal) ~ "]")? |
+        "[" ~ (identifier | number_literal) ~ "]"
+    )?
 }
 
 // SHA256 function. Accepts any additive expression so concatenation chains
@@ -585,7 +596,7 @@ byte_value = {
     input_introspection |
     output_introspection |
     asset_at |
-    identifier
+    named_binding
 }
 
 // Substring extraction: substr(data, offset, size) → OP_SUBSTR

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -181,16 +181,11 @@ primary_expr = {
 }
 
 // Static array length: arr.length — folded to a literal at compile time
-array_length_access = { identifier ~ "." ~ "length" ~ !(ASCII_ALPHANUMERIC | "_") }
+array_length_access = { identifier ~ "." ~ "length" ~ !(ASCII_ALPHANUMERIC | "_" | "[" | ".") }
 
 // Array indexing: identifier[integer expression]
 array_index_access = {
     identifier ~ "[" ~ general_expression ~ "]"
-}
-
-// Named operands are string-backed; widen them to Expression before accepting computed indices.
-named_array_index_access = {
-    identifier ~ "[" ~ (identifier | number_literal) ~ "]"
 }
 
 // Operators
@@ -356,7 +351,7 @@ identifier_property_access = {
 
 // Time comparison (tx.time >= timelock)
 time_comparison = {
-    "tx.time" ~ ">=" ~ identifier
+    "tx.time" ~ ">=" ~ named_binding
 }
 
 // Generalized hash condition function name.
@@ -370,7 +365,7 @@ hash_func = { hash_fn_name ~ "(" ~ additive_expr ~ ")" }
 // that constructions like `sha256(substr(packet, ...)) == substr(other, ...)`
 // — used by the LayerZero scripts — parse natively.
 hash_comparison = {
-    hash_func ~ "==" ~ (substr_func | cat_func | num2bin_func | identifier)
+    hash_func ~ "==" ~ (substr_func | cat_func | num2bin_func | named_binding)
 }
 
 // Constructor expression: new ContractName(args)

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -6,7 +6,13 @@ COMMENT = _{ "//" ~ (!"\n" ~ ANY)* ~ "\n" }
 import_stmt = { "import" ~ string_literal ~ ";" }
 
 // Main entry point - must consume the entire input
-main = { SOI ~ import_stmt* ~ contract ~ EOI }
+main = { SOI ~ import_stmt* ~ struct_definition* ~ contract ~ EOI }
+
+struct_definition = {
+    "struct" ~ identifier ~ "{" ~ struct_field+ ~ "}"
+}
+
+struct_field = { data_type ~ identifier ~ ";" }
 
 // Contract definition
 contract = {
@@ -26,9 +32,8 @@ parameter = { data_type ~ identifier }
 // Supported data types - atomic rule to prevent partial matches
 // Note: longer types must come before shorter prefixes (bytes32/bytes20 before bytes)
 // Array types carry a static size (e.g., pubkey[3], signature[5])
-base_type = @{ "pubkey" | "signature" | "bytes32" | "bytes20" | "bytes" | "asset" | "int" | "bool" }
 array_size = @{ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
-data_type = { base_type ~ ("[" ~ array_size ~ "]")? }
+data_type = { identifier ~ ("[" ~ array_size ~ "]")? }
 
 // Function definition. A `tapscript` modifier selects an L1 tapleaf body
 // (require-only); otherwise it is an ordinary covenant function body.

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -251,17 +251,20 @@ complex_expression = _{
 
 // ─── Asset Lookups ─────────────────────────────────────────────────────────────
 
+asset_id_txid_operand = _{ identifier_property_access | identifier }
+asset_id_gidx_operand = _{ number_literal | identifier_property_access | identifier }
+
 // Asset lookup on inputs/outputs: tx.inputs[i].assets.lookup(txid, gidx)
 // txid is a bytes32 identifier; gidx is an int identifier or a 0..65535 literal.
 asset_lookup = {
     "tx" ~ "." ~ asset_lookup_source ~ array_access ~ "." ~ "assets"
-        ~ "." ~ "lookup" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")"
+        ~ "." ~ "lookup" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")"
 }
 
 // Asset presence predicate: tx.inputs[i].assets.has(txid, gidx) → Bool
 asset_has = {
     "tx" ~ "." ~ asset_lookup_source ~ array_access ~ "." ~ "assets"
-        ~ "." ~ "has" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")"
+        ~ "." ~ "has" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")"
 }
 
 // Asset count: tx.inputs[i].assets.length or tx.outputs[o].assets.length
@@ -323,8 +326,8 @@ output_introspection_property = { "value" | "scriptPubKey" }
 // tx.assetGroups[k].sumInputs, etc.
 asset_group_access = {
     "tx" ~ "." ~ "assetGroups" ~ (
-        "." ~ "find" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")" |
-        "." ~ "has" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")" |
+        "." ~ "find" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")" |
+        "." ~ "has" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")" |
         "." ~ "length" |
         array_access ~ "." ~ group_property
     )
@@ -337,11 +340,11 @@ group_property = @{
     "numInputs" | "numOutputs" | "sumInputs" | "sumOutputs" | "delta" | "hasControl" | "metadataHash" | "assetId" | "isFresh"
 }
 
-// Group control predicates (struct-free, replace the old `.control ==`):
+// Group control predicates compare explicit AssetId components:
 //   group.controlIs(txid, gidx) → Bool (full canonical control Asset ID equality)
 //   group.hasControl            → Bool (handled as a plain group_property)
 group_control_is = {
-    identifier ~ "." ~ "controlIs" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")"
+    identifier ~ "." ~ "controlIs" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")"
 }
 
 // Named field path, optionally ending in an array index.
@@ -393,8 +396,8 @@ tx_property_body = {
     ("input" ~ "." ~ "current" ~ ("." ~ identifier)*) |
     // Asset groups access: find, has, length, or indexed property access
     ("assetGroups" ~ (
-        "." ~ "find" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")" |
-        "." ~ "has" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")" |
+        "." ~ "find" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")" |
+        "." ~ "has" ~ "(" ~ asset_id_txid_operand ~ "," ~ asset_id_gidx_operand ~ ")" |
         "." ~ "length" |
         array_access ~ ("." ~ asset_group_property)?
     )?) |

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -173,6 +173,7 @@ primary_expr = {
     constructor |
     function_call |
     array_index_access |
+    struct_literal |
     array_literal |
     bool_literal |
     number_literal |
@@ -455,6 +456,12 @@ method_arg = {
 array_literal = {
     "[" ~ general_expression ~ ("," ~ general_expression)* ~ "]"
 }
+
+struct_literal = {
+    "{" ~ struct_literal_field ~ ("," ~ struct_literal_field)* ~ "}"
+}
+
+struct_literal_field = { identifier ~ ":" ~ general_expression }
 
 // Function call
 function_call = {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,4 @@
-use crate::models::{Contract, Function, Parameter, Statement};
+use crate::models::{Contract, Function, Parameter, Statement, StructDefinition};
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
 use pest_derive::Parser;
@@ -40,6 +40,7 @@ pub fn parse(source_code: &str) -> Result<Contract, Box<dyn std::error::Error>> 
 fn build_ast(pairs: Pairs<Rule>) -> Result<Contract, String> {
     let mut contract = Contract {
         name: String::new(),
+        structs: Vec::new(),
         parameters: Vec::new(),
         functions: Vec::new(),
         tapscripts: Vec::new(),
@@ -63,6 +64,9 @@ fn build_ast(pairs: Pairs<Rule>) -> Result<Contract, String> {
                         Rule::contract => {
                             parse_contract(&mut contract, inner_pair)?;
                         }
+                        Rule::struct_definition => {
+                            contract.structs.push(parse_struct_definition(inner_pair)?);
+                        }
                         _ => {}
                     }
                 }
@@ -75,6 +79,32 @@ fn build_ast(pairs: Pairs<Rule>) -> Result<Contract, String> {
     }
 
     Ok(contract)
+}
+
+fn parse_struct_definition(pair: Pair<Rule>) -> Result<StructDefinition, String> {
+    let mut inner = pair.into_inner();
+    let name = inner
+        .next()
+        .ok_or_else(|| "Missing struct name".to_string())?
+        .as_str()
+        .to_string();
+    let fields = inner
+        .map(|field| {
+            let mut field = field.into_inner();
+            let param_type = parse_data_type(
+                field
+                    .next()
+                    .ok_or_else(|| format!("struct '{name}' field is missing a type"))?,
+            );
+            let name = field
+                .next()
+                .ok_or_else(|| format!("struct '{name}' field is missing a name"))?
+                .as_str()
+                .to_string();
+            Ok(Parameter { name, param_type })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(StructDefinition { name, fields })
 }
 
 /// Parse a contract definition: name, parameters, and functions

--- a/src/parser/tapscript.rs
+++ b/src/parser/tapscript.rs
@@ -189,7 +189,7 @@ pub(crate) fn parse_tap_multisig(pair: Pair<Rule>) -> Result<crate::models::TapI
 pub(crate) fn parse_key_expr(pair: Pair<Rule>) -> Result<crate::models::KeyExpr, String> {
     use crate::models::KeyExpr;
     match pair.as_rule() {
-        Rule::identifier => Ok(KeyExpr::Ident(pair.as_str().to_string())),
+        Rule::identifier | Rule::named_binding => Ok(KeyExpr::Ident(pair.as_str().to_string())),
         Rule::key_expr => {
             let inner = pair.into_inner().next().ok_or("Empty key expression")?;
             parse_key_expr(inner)

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -212,6 +212,7 @@ fn check_function(
         &mut scope,
         &mut errors,
         &function.name,
+        structs,
     );
     errors
 }
@@ -221,9 +222,10 @@ fn check_statements(
     scope: &mut Scope,
     errors: &mut Vec<TypeError>,
     fn_name: &str,
+    structs: &[crate::models::StructDefinition],
 ) {
     for stmt in stmts {
-        check_statement(stmt, scope, errors, fn_name);
+        check_statement(stmt, scope, errors, fn_name, structs);
     }
 }
 
@@ -232,6 +234,7 @@ fn check_statement(
     scope: &mut Scope,
     errors: &mut Vec<TypeError>,
     fn_name: &str,
+    structs: &[crate::models::StructDefinition],
 ) {
     match stmt {
         Statement::Require(req) => {
@@ -248,13 +251,17 @@ fn check_statement(
                 .as_deref()
                 .map(ArkType::parse)
                 .unwrap_or(inferred);
-            // Seed the scope so downstream uses of `name` get the inferred type.
-            if let ArkType::Array(element, length) = &t {
-                for i in 0..*length {
-                    scope.insert(format!("{name}[{i}]"), (**element).clone());
-                }
+            if let Some(declared_type) = declared_type {
+                scope.extend(build_scope_with_structs(
+                    &[crate::models::Parameter {
+                        name: name.clone(),
+                        param_type: declared_type.clone(),
+                    }],
+                    structs,
+                ));
+            } else {
+                scope.insert(name.clone(), t);
             }
-            scope.insert(name.clone(), t);
         }
         Statement::VarAssign { name, value } => {
             let original_type = scope.get(name.as_str()).cloned();
@@ -297,9 +304,9 @@ fn check_statement(
             }
             // Use cloned child scopes so LetBindings inside branches don't
             // leak into the parent scope.
-            check_statements(then_body, &mut scope.clone(), errors, fn_name);
+            check_statements(then_body, &mut scope.clone(), errors, fn_name, structs);
             if let Some(else_stmts) = else_body {
-                check_statements(else_stmts, &mut scope.clone(), errors, fn_name);
+                check_statements(else_stmts, &mut scope.clone(), errors, fn_name, structs);
             }
         }
         Statement::ForIn {
@@ -313,7 +320,7 @@ fn check_statement(
             let mut loop_scope = scope.clone();
             loop_scope.insert(index_var.clone(), ArkType::Int);
             loop_scope.insert(value_var.clone(), ArkType::Unknown);
-            check_statements(body, &mut loop_scope, errors, fn_name);
+            check_statements(body, &mut loop_scope, errors, fn_name, structs);
         }
     }
 }
@@ -562,6 +569,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
             ),
             elements.len(),
         ),
+        Expression::StructLiteral(_) => ArkType::Unknown,
         Expression::ArrayIndex { array, .. } => match scope.get(array) {
             Some(ArkType::Array(element, _)) => (**element).clone(),
             _ => ArkType::Unknown,

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -129,24 +129,57 @@ impl TypeError {
 
 pub type Scope = HashMap<String, ArkType>;
 
-pub fn build_scope(params: &[crate::models::Parameter]) -> Scope {
+pub fn build_scope_with_structs(
+    params: &[crate::models::Parameter],
+    structs: &[crate::models::StructDefinition],
+) -> Scope {
     let mut scope = Scope::new();
     for p in params {
-        if let Some((base, length)) = crate::models::array_type_parts(&p.param_type) {
-            let elem_type = ArkType::parse(base);
-            // Register the bare name as the array type, plus each indexed element.
-            scope.insert(
-                p.name.clone(),
-                ArkType::Array(Box::new(elem_type.clone()), length),
-            );
-            for i in 0..length {
-                scope.insert(format!("{}[{}]", p.name, i), elem_type.clone());
-            }
-        } else {
-            scope.insert(p.name.clone(), ArkType::parse(&p.param_type));
-        }
+        insert_type_bindings(&mut scope, &p.name, &p.param_type, structs, &mut Vec::new());
     }
     scope
+}
+
+fn insert_type_bindings(
+    scope: &mut Scope,
+    name: &str,
+    declared_type: &str,
+    structs: &[crate::models::StructDefinition],
+    stack: &mut Vec<String>,
+) {
+    if let Some((base, length)) = crate::models::array_type_parts(declared_type) {
+        let element_type = ArkType::parse(base);
+        scope.insert(
+            name.to_string(),
+            ArkType::Array(Box::new(element_type.clone()), length),
+        );
+        for index in 0..length {
+            scope.insert(format!("{name}[{index}]"), element_type.clone());
+        }
+        return;
+    }
+    if let Some(definition) = structs
+        .iter()
+        .find(|definition| definition.name == declared_type)
+    {
+        scope.insert(name.to_string(), ArkType::Struct(declared_type.to_string()));
+        if stack.iter().any(|name| name == declared_type) {
+            return;
+        }
+        stack.push(declared_type.to_string());
+        for field in &definition.fields {
+            insert_type_bindings(
+                scope,
+                &format!("{name}.{}", field.name),
+                &field.param_type,
+                structs,
+                stack,
+            );
+        }
+        stack.pop();
+        return;
+    }
+    scope.insert(name.to_string(), ArkType::parse(declared_type));
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -156,18 +189,22 @@ pub fn build_scope(params: &[crate::models::Parameter]) -> Scope {
 /// Returns all type errors found across all functions.
 /// Currently non-fatal — the compiler emits these as warnings.
 pub fn check_contract(contract: &Contract) -> Vec<TypeError> {
-    let constructor_scope = build_scope(&contract.parameters);
+    let constructor_scope = build_scope_with_structs(&contract.parameters, &contract.structs);
     contract
         .functions
         .iter()
-        .flat_map(|f| check_function(f, &constructor_scope))
+        .flat_map(|f| check_function(f, &constructor_scope, &contract.structs))
         .collect()
 }
 
-fn check_function(function: &Function, constructor_scope: &Scope) -> Vec<TypeError> {
+fn check_function(
+    function: &Function,
+    constructor_scope: &Scope,
+    structs: &[crate::models::StructDefinition],
+) -> Vec<TypeError> {
     let mut scope = constructor_scope.clone();
     // Merge function parameters into scope
-    scope.extend(build_scope(&function.parameters));
+    scope.extend(build_scope_with_structs(&function.parameters, structs));
 
     let mut errors = Vec::new();
     check_statements(
@@ -446,9 +483,11 @@ fn check_comparison(
     if left_type == ArkType::Unknown || right_type == ArkType::Unknown {
         return;
     }
-    if matches!(left_type, ArkType::Array(..)) || matches!(right_type, ArkType::Array(..)) {
+    if matches!(left_type, ArkType::Array(..) | ArkType::Struct(..))
+        || matches!(right_type, ArkType::Array(..) | ArkType::Struct(..))
+    {
         errors.push(TypeError::new(format!(
-            "fn {}: array comparison '{}' is not supported",
+            "fn {}: composite comparison '{}' is not supported",
             fn_name, op
         )));
         return;

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -195,6 +195,306 @@ fn insert_type_bindings(
     scope.insert(name.to_string(), ArkType::parse(declared_type));
 }
 
+pub(crate) fn resolve_group_properties(contract: &mut Contract) {
+    let constructor_scope = build_scope_with_structs(&contract.parameters, &contract.structs);
+    for function in &mut contract.functions {
+        let mut scope = constructor_scope.clone();
+        scope.extend(build_scope_with_structs(
+            &function.parameters,
+            &contract.structs,
+        ));
+        resolve_statements(&mut function.statements, &mut scope, &contract.structs);
+    }
+}
+
+fn resolve_statements(
+    statements: &mut [Statement],
+    scope: &mut Scope,
+    structs: &[crate::models::StructDefinition],
+) {
+    for statement in statements {
+        match statement {
+            Statement::Require(requirement) => match requirement {
+                Requirement::Expression(expression) => resolve_expression(expression, scope),
+                Requirement::Comparison { left, right, .. } => {
+                    resolve_expression(left, scope);
+                    resolve_expression(right, scope);
+                }
+                _ => {}
+            },
+            Statement::LetBinding {
+                name,
+                declared_type,
+                value,
+            } => {
+                resolve_expression(value, scope);
+                let binding_type = declared_type
+                    .as_deref()
+                    .map(ArkType::parse)
+                    .unwrap_or_else(|| infer_type(value, scope));
+                if let Some(declared_type) = declared_type {
+                    scope.extend(build_scope_with_structs(
+                        &[crate::models::Parameter {
+                            name: name.clone(),
+                            param_type: declared_type.clone(),
+                        }],
+                        structs,
+                    ));
+                } else if matches!(binding_type, ArkType::Struct(_)) {
+                    scope.extend(build_scope_with_structs(
+                        &[crate::models::Parameter {
+                            name: name.clone(),
+                            param_type: binding_type.as_str(),
+                        }],
+                        structs,
+                    ));
+                } else {
+                    scope.insert(name.clone(), binding_type);
+                }
+            }
+            Statement::VarAssign { value, .. } => resolve_expression(value, scope),
+            Statement::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                resolve_expression(condition, scope);
+                resolve_statements(then_body, &mut scope.clone(), structs);
+                if let Some(else_body) = else_body {
+                    resolve_statements(else_body, &mut scope.clone(), structs);
+                }
+            }
+            Statement::ForIn {
+                index_var,
+                value_var,
+                iterable,
+                body,
+            } => {
+                resolve_expression(iterable, scope);
+                let element_type = match infer_type(iterable, scope) {
+                    ArkType::Array(element, _) => *element,
+                    _ => ArkType::Unknown,
+                };
+                let mut loop_scope = scope.clone();
+                loop_scope.insert(index_var.clone(), ArkType::Int);
+                loop_scope.insert(value_var.clone(), element_type);
+                resolve_statements(body, &mut loop_scope, structs);
+            }
+        }
+    }
+}
+
+fn resolve_expression(expression: &mut Expression, scope: &Scope) {
+    match expression {
+        Expression::ArrayLiteral(elements)
+        | Expression::ContractInstance { args: elements, .. } => {
+            for element in elements {
+                resolve_expression(element, scope);
+            }
+        }
+        Expression::StructLiteral(fields) => {
+            for (_, value) in fields {
+                resolve_expression(value, scope);
+            }
+        }
+        Expression::ArrayIndex { index, .. }
+        | Expression::AssetCount { index, .. }
+        | Expression::InputIntrospection { index, .. }
+        | Expression::OutputIntrospection { index, .. }
+        | Expression::GroupSum { index, .. }
+        | Expression::GroupNumIO { index, .. } => resolve_expression(index, scope),
+        Expression::AssetLookup {
+            index,
+            asset_txid,
+            asset_gidx,
+            ..
+        }
+        | Expression::AssetHas {
+            index,
+            asset_txid,
+            asset_gidx,
+            ..
+        } => {
+            resolve_expression(index, scope);
+            resolve_expression(asset_txid, scope);
+            resolve_expression(asset_gidx, scope);
+        }
+        Expression::AssetAt {
+            io_index,
+            asset_index,
+            ..
+        } => {
+            resolve_expression(io_index, scope);
+            resolve_expression(asset_index, scope);
+        }
+        Expression::BinaryOp { left, right, .. }
+        | Expression::Concat { left, right }
+        | Expression::Cat { left, right } => {
+            resolve_expression(left, scope);
+            resolve_expression(right, scope);
+        }
+        Expression::GroupFind {
+            asset_txid,
+            asset_gidx,
+        }
+        | Expression::GroupHas {
+            asset_txid,
+            asset_gidx,
+        }
+        | Expression::GroupControlIs {
+            asset_txid,
+            asset_gidx,
+            ..
+        } => {
+            resolve_expression(asset_txid, scope);
+            resolve_expression(asset_gidx, scope);
+        }
+        Expression::GroupIOAccess {
+            group_index,
+            io_index,
+            ..
+        } => {
+            resolve_expression(group_index, scope);
+            resolve_expression(io_index, scope);
+        }
+        Expression::Sha256 { data }
+        | Expression::Sha256Initialize { data }
+        | Expression::Negate { value: data }
+        | Expression::Bin2Num { data }
+        | Expression::ReverseBytes { data }
+        | Expression::SizeOf { data }
+        | Expression::PacketInspect { packet_type: data } => resolve_expression(data, scope),
+        Expression::Sha256Update { context, chunk } => {
+            resolve_expression(context, scope);
+            resolve_expression(chunk, scope);
+        }
+        Expression::Sha256Finalize {
+            context,
+            last_chunk,
+        } => {
+            resolve_expression(context, scope);
+            resolve_expression(last_chunk, scope);
+        }
+        Expression::Sighash { hash_type } => resolve_expression(hash_type, scope),
+        Expression::Digest { data, hash_type } => {
+            resolve_expression(data, scope);
+            resolve_expression(hash_type, scope);
+        }
+        Expression::ModExp {
+            base,
+            exponent,
+            modulus,
+        } => {
+            for child in [base, exponent, modulus] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::EcAdd {
+            x1,
+            y1,
+            x2,
+            y2,
+            curve_id,
+        } => {
+            for child in [x1, y1, x2, y2, curve_id] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::EcMul {
+            x,
+            y,
+            scalar,
+            curve_id,
+        } => {
+            for child in [x, y, scalar, curve_id] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::EcPairing {
+            g1_x,
+            g1_y,
+            g2_x_c1,
+            g2_x_c0,
+            g2_y_c1,
+            g2_y_c0,
+            curve_id,
+        } => {
+            for child in [g1_x, g1_y, g2_x_c1, g2_x_c0, g2_y_c1, g2_y_c0, curve_id] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::EcMulScalarVerify {
+            scalar,
+            point_p,
+            point_q,
+        } => {
+            for child in [scalar, point_p, point_q] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::TweakVerify {
+            point_p,
+            tweak,
+            point_q,
+        } => {
+            for child in [point_p, tweak, point_q] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::Substr { data, offset, size } => {
+            for child in [data, offset, size] {
+                resolve_expression(child, scope);
+            }
+        }
+        Expression::Num2Bin { value, size } => {
+            resolve_expression(value, scope);
+            resolve_expression(size, scope);
+        }
+        Expression::InputPacketInspect { index, packet_type } => {
+            resolve_expression(index, scope);
+            resolve_expression(packet_type, scope);
+        }
+        Expression::Variable(_)
+        | Expression::Literal(_)
+        | Expression::Property(_)
+        | Expression::CurrentInput(_)
+        | Expression::TxIntrospection { .. }
+        | Expression::GroupProperty { .. }
+        | Expression::AssetGroupsLength
+        | Expression::CheckSigExpr { .. }
+        | Expression::CheckSigFromStackExpr { .. }
+        | Expression::CheckSigFromStackVerify { .. } => {}
+    }
+
+    let Expression::Property(path) = expression else {
+        return;
+    };
+    let Some((group, property)) = path.split_once('.') else {
+        return;
+    };
+    if property.contains('.')
+        || !matches!(
+            property,
+            "numInputs"
+                | "numOutputs"
+                | "sumInputs"
+                | "sumOutputs"
+                | "delta"
+                | "hasControl"
+                | "metadataHash"
+                | "assetId"
+                | "isFresh"
+        )
+        || matches!(scope.get(group), Some(ArkType::Struct(_)))
+    {
+        return;
+    }
+    *expression = Expression::GroupProperty {
+        group: group.to_string(),
+        property: property.to_string(),
+    };
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /// Type-check an entire contract.

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -158,6 +158,19 @@ fn insert_type_bindings(
         }
         return;
     }
+    if let Some(fields) = crate::models::builtin_struct_fields(declared_type) {
+        scope.insert(name.to_string(), ArkType::Struct(declared_type.to_string()));
+        for (field_name, field_type) in fields {
+            insert_type_bindings(
+                scope,
+                &format!("{name}.{field_name}"),
+                field_type,
+                structs,
+                stack,
+            );
+        }
+        return;
+    }
     if let Some(definition) = structs
         .iter()
         .find(|definition| definition.name == declared_type)
@@ -256,6 +269,14 @@ fn check_statement(
                     &[crate::models::Parameter {
                         name: name.clone(),
                         param_type: declared_type.clone(),
+                    }],
+                    structs,
+                ));
+            } else if matches!(t, ArkType::Struct(_)) {
+                scope.extend(build_scope_with_structs(
+                    &[crate::models::Parameter {
+                        name: name.clone(),
+                        param_type: t.as_str(),
                     }],
                     structs,
                 ));
@@ -602,7 +623,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
             Some("value") => ArkType::Int,
             Some("scriptPubKey") => ArkType::Bytes,
             Some("sequence") => ArkType::Int,
-            Some("outpoint") => ArkType::Bytes32,
+            Some("outpoint") => ArkType::Struct("Outpoint".to_string()),
             _ => ArkType::Unknown,
         },
 
@@ -619,7 +640,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
             "value" => ArkType::Int,
             "scriptPubKey" => ArkType::Bytes,
             "sequence" => ArkType::Int,
-            "outpoint" => ArkType::Bytes32,
+            "outpoint" => ArkType::Struct("Outpoint".to_string()),
             "arkadeScriptHash" | "arkadeWitnessHash" => ArkType::Bytes32,
             _ => ArkType::Unknown,
         },
@@ -637,11 +658,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
         Expression::AssetCount { .. } => ArkType::Int,
         Expression::AssetAt { property, .. } => match property.as_str() {
             "amount" => ArkType::Int,
-            // TODO(asset-id-struct): `.assetId` is really a two-item canonical
-            // Asset ID (asset_txid, asset_gidx), NOT a single bytes32. Typed as
-            // Bytes32 only as a stopgap until the composite `AssetId` struct
-            // return type lands (separate PR).
-            "assetId" => ArkType::Bytes32,
+            "assetId" => ArkType::Struct("AssetId".to_string()),
             _ => ArkType::Unknown,
         },
 
@@ -655,12 +672,8 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
         Expression::GroupProperty { property, .. } => match property.as_str() {
             "sumInputs" | "sumOutputs" | "delta" => ArkType::Int,
             "numInputs" | "numOutputs" => ArkType::Int,
-            // TODO(asset-id-struct): `assetId` is really a two-item canonical
-            // Asset ID (asset_txid, asset_gidx), not a single bytes32; typed
-            // Bytes32 only as a stopgap until the composite `AssetId` struct
-            // lands, so `==` over it is unsound until then. `metadataHash`
-            // is genuinely a 32-byte hash and is correct.
-            "metadataHash" | "assetId" => ArkType::Bytes32,
+            "metadataHash" => ArkType::Bytes32,
+            "assetId" => ArkType::Struct("AssetId".to_string()),
             "isFresh" | "hasControl" => ArkType::Bool,
             _ => ArkType::Unknown,
         },
@@ -690,7 +703,9 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
         | Expression::EcPairing { .. }
         | Expression::EcMulScalarVerify { .. }
         | Expression::TweakVerify { .. } => ArkType::Bool,
-        Expression::EcAdd { .. } | Expression::EcMul { .. } => ArkType::Unknown,
+        Expression::EcAdd { .. } | Expression::EcMul { .. } => {
+            ArkType::Struct("ECPoint".to_string())
+        }
 
         // Contract instantiation resolves to a scriptPubKey bytes value.
         Expression::ContractInstance { .. } => ArkType::Bytes,

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -195,6 +195,28 @@ fn insert_type_bindings(
     scope.insert(name.to_string(), ArkType::parse(declared_type));
 }
 
+pub(crate) fn bind_local_type(
+    scope: &mut Scope,
+    name: &str,
+    declared_type: Option<&str>,
+    inferred: ArkType,
+    structs: &[crate::models::StructDefinition],
+) {
+    let expanded = match declared_type {
+        Some(declared_type) => Some(declared_type.to_string()),
+        None if matches!(inferred, ArkType::Struct(_)) => Some(inferred.as_str()),
+        None => None,
+    };
+    match expanded {
+        Some(declared_type) => {
+            insert_type_bindings(scope, name, &declared_type, structs, &mut Vec::new())
+        }
+        None => {
+            scope.insert(name.to_string(), inferred);
+        }
+    }
+}
+
 pub(crate) fn resolve_group_properties(contract: &mut Contract) {
     let constructor_scope = build_scope_with_structs(&contract.parameters, &contract.structs);
     for function in &mut contract.functions {
@@ -232,25 +254,7 @@ fn resolve_statements(
                     .as_deref()
                     .map(ArkType::parse)
                     .unwrap_or_else(|| infer_type(value, scope));
-                if let Some(declared_type) = declared_type {
-                    scope.extend(build_scope_with_structs(
-                        &[crate::models::Parameter {
-                            name: name.clone(),
-                            param_type: declared_type.clone(),
-                        }],
-                        structs,
-                    ));
-                } else if matches!(binding_type, ArkType::Struct(_)) {
-                    scope.extend(build_scope_with_structs(
-                        &[crate::models::Parameter {
-                            name: name.clone(),
-                            param_type: binding_type.as_str(),
-                        }],
-                        structs,
-                    ));
-                } else {
-                    scope.insert(name.clone(), binding_type);
-                }
+                bind_local_type(scope, name, declared_type.as_deref(), binding_type, structs);
             }
             Statement::VarAssign { value, .. } => resolve_expression(value, scope),
             Statement::IfElse {
@@ -564,25 +568,7 @@ fn check_statement(
                 .as_deref()
                 .map(ArkType::parse)
                 .unwrap_or(inferred);
-            if let Some(declared_type) = declared_type {
-                scope.extend(build_scope_with_structs(
-                    &[crate::models::Parameter {
-                        name: name.clone(),
-                        param_type: declared_type.clone(),
-                    }],
-                    structs,
-                ));
-            } else if matches!(t, ArkType::Struct(_)) {
-                scope.extend(build_scope_with_structs(
-                    &[crate::models::Parameter {
-                        name: name.clone(),
-                        param_type: t.as_str(),
-                    }],
-                    structs,
-                ));
-            } else {
-                scope.insert(name.clone(), t);
-            }
+            bind_local_type(scope, name, declared_type.as_deref(), t, structs);
         }
         Statement::VarAssign { name, value } => {
             let original_type = scope.get(name.as_str()).cloned();

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -43,6 +43,8 @@ pub enum ArkType {
     // ── Composite ──────────────────────────────────────────────────────────
     /// Homogeneous fixed-size array (e.g., `pubkey[3]`)
     Array(Box<ArkType>, usize),
+    /// Named user-defined struct.
+    Struct(String),
 
     /// Type could not be resolved (variable not in scope, etc.)
     Unknown,
@@ -63,6 +65,7 @@ impl ArkType {
             "int" => ArkType::Int,
             "bool" => ArkType::Bool,
             "asset" => ArkType::Asset,
+            _ if !s.is_empty() => ArkType::Struct(s.to_string()),
             _ => ArkType::Unknown,
         }
     }
@@ -82,6 +85,7 @@ impl ArkType {
             ArkType::Bool => "scriptnum",
             ArkType::Asset => "raw-32",
             ArkType::Array(..) => "array",
+            ArkType::Struct(..) => "struct",
             ArkType::Unknown => "unknown",
         }
     }
@@ -98,6 +102,7 @@ impl ArkType {
             ArkType::Bool => "bool".to_string(),
             ArkType::Asset => "asset".to_string(),
             ArkType::Array(inner, length) => format!("{}[{length}]", inner.as_str()),
+            ArkType::Struct(name) => name.clone(),
             ArkType::Unknown => "unknown".to_string(),
         }
     }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -548,6 +548,7 @@ fn child_exprs(expr: &Expression) -> Vec<&Expression> {
         Expression::ArrayIndex { index, .. } => vec![index],
 
         Expression::ArrayLiteral(elements) => elements.iter().collect(),
+        Expression::StructLiteral(fields) => fields.iter().map(|(_, value)| value).collect(),
 
         Expression::AssetLookup {
             index,
@@ -742,7 +743,13 @@ fn check_binding_semantics(contract: &Contract, issues: &mut Vec<ValidationIssue
             &contract.structs,
         );
         let mut scopes = vec![root];
-        validate_binding_statements(&function.statements, &function.name, &mut scopes, issues);
+        validate_binding_statements(
+            &function.statements,
+            &function.name,
+            &mut scopes,
+            &contract.structs,
+            issues,
+        );
     }
 }
 
@@ -750,6 +757,7 @@ fn validate_binding_statements(
     statements: &[Statement],
     function_name: &str,
     scopes: &mut BindingScopes,
+    structs: &[crate::models::StructDefinition],
     issues: &mut Vec<ValidationIssue>,
 ) {
     for statement in statements {
@@ -774,6 +782,27 @@ fn validate_binding_statements(
                                 issues,
                                 true,
                             );
+                        }
+                    }
+                    Expression::StructLiteral(fields) => {
+                        match declared_type.as_deref().and_then(|declared_type| {
+                            structs
+                                .iter()
+                                .find(|definition| definition.name == declared_type)
+                        }) {
+                            Some(definition) => validate_struct_literal(
+                                name,
+                                definition,
+                                fields,
+                                function_name,
+                                scopes,
+                                structs,
+                                issues,
+                            ),
+                            None => issues.push(ValidationIssue::error(format!(
+                                "function '{}': struct literal needs a declared struct type",
+                                function_name
+                            ))),
                         }
                     }
                     _ => validate_binding_expression(value, function_name, scopes, issues, true),
@@ -827,27 +856,42 @@ fn validate_binding_statements(
                         function_name, name
                     )));
                 }
+                if let ArkType::Struct(_) = &binding_type {
+                    if !matches!(value, Expression::StructLiteral(_)) {
+                        issues.push(ValidationIssue::error(format!(
+                            "function '{}': struct binding '{}' must be initialized with a struct literal",
+                            function_name, name
+                        )));
+                    }
+                }
                 let frame = scopes
                     .last_mut()
                     .expect("binding validation always has a scope");
-                if let ArkType::Array(element, length) = &binding_type {
-                    for index in 0..*length {
+                if let Some(declared_type) = declared_type {
+                    let parameter = crate::models::Parameter {
+                        name: name.clone(),
+                        param_type: declared_type.clone(),
+                    };
+                    for (binding_name, binding_type) in
+                        build_scope_with_structs(&[parameter], structs)
+                    {
                         frame.insert(
-                            format!("{name}[{index}]"),
+                            binding_name,
                             BindingInfo {
-                                binding_type: (**element).clone(),
+                                binding_type,
                                 source: BindingSource::Local,
                             },
                         );
                     }
+                } else {
+                    frame.insert(
+                        name.clone(),
+                        BindingInfo {
+                            binding_type,
+                            source: BindingSource::Local,
+                        },
+                    );
                 }
-                frame.insert(
-                    name.clone(),
-                    BindingInfo {
-                        binding_type,
-                        source: BindingSource::Local,
-                    },
-                );
             }
             Statement::VarAssign { name, value } => {
                 validate_binding_expression(value, function_name, scopes, issues, true);
@@ -897,11 +941,11 @@ fn validate_binding_statements(
                     )));
                 }
                 scopes.push(HashMap::new());
-                validate_binding_statements(then_body, function_name, scopes, issues);
+                validate_binding_statements(then_body, function_name, scopes, structs, issues);
                 scopes.pop();
                 if let Some(else_body) = else_body {
                     scopes.push(HashMap::new());
-                    validate_binding_statements(else_body, function_name, scopes, issues);
+                    validate_binding_statements(else_body, function_name, scopes, structs, issues);
                     scopes.pop();
                 }
             }
@@ -966,9 +1010,115 @@ fn validate_binding_statements(
                     );
                 }
                 scopes.push(frame);
-                validate_binding_statements(body, function_name, scopes, issues);
+                validate_binding_statements(body, function_name, scopes, structs, issues);
                 scopes.pop();
             }
+        }
+    }
+}
+
+fn validate_struct_literal(
+    access_name: &str,
+    definition: &crate::models::StructDefinition,
+    fields: &[(String, Expression)],
+    function_name: &str,
+    scopes: &BindingScopes,
+    structs: &[crate::models::StructDefinition],
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let mut seen = HashSet::new();
+    for (name, _) in fields {
+        if !seen.insert(name.as_str()) {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': struct literal '{}' initializes field '{}' more than once",
+                function_name, access_name, name
+            )));
+        }
+        if !definition.fields.iter().any(|field| field.name == *name) {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': struct literal '{}' has unknown field '{}'",
+                function_name, access_name, name
+            )));
+        }
+    }
+
+    for field in &definition.fields {
+        let Some((_, value)) = fields.iter().find(|(name, _)| name == &field.name) else {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': struct literal '{}' is missing field '{}'",
+                function_name, access_name, field.name
+            )));
+            continue;
+        };
+        let field_name = format!("{access_name}.{}", field.name);
+        if let Some((element_type, length)) = crate::models::array_type_parts(&field.param_type) {
+            let Expression::ArrayLiteral(elements) = value else {
+                issues.push(ValidationIssue::error(format!(
+                    "function '{}': field '{}' must be initialized with an array literal",
+                    function_name, field_name
+                )));
+                continue;
+            };
+            if elements.len() != length {
+                issues.push(ValidationIssue::error(format!(
+                    "function '{}': array field '{}' declares {} elements but its initializer has {}",
+                    function_name,
+                    field_name,
+                    length,
+                    elements.len()
+                )));
+            }
+            let expected = ArkType::parse(element_type);
+            for (index, element) in elements.iter().enumerate() {
+                validate_binding_expression(element, function_name, scopes, issues, true);
+                let actual = resolved_expression_type(element, scopes);
+                if actual != ArkType::Unknown && !binding_types_compatible(&expected, &actual) {
+                    issues.push(ValidationIssue::error(format!(
+                        "function '{}': field '{}[{}]' has type '{}', expected '{}'",
+                        function_name,
+                        field_name,
+                        index,
+                        actual.as_str(),
+                        expected.as_str()
+                    )));
+                }
+            }
+            continue;
+        }
+        if let Some(nested) = structs
+            .iter()
+            .find(|definition| definition.name == field.param_type)
+        {
+            let Expression::StructLiteral(nested_fields) = value else {
+                issues.push(ValidationIssue::error(format!(
+                    "function '{}': field '{}' must be initialized with a struct literal",
+                    function_name, field_name
+                )));
+                continue;
+            };
+            validate_struct_literal(
+                &field_name,
+                nested,
+                nested_fields,
+                function_name,
+                scopes,
+                structs,
+                issues,
+            );
+            continue;
+        }
+
+        validate_binding_expression(value, function_name, scopes, issues, true);
+        let expected = ArkType::parse(&field.param_type);
+        let actual = resolved_expression_type(value, scopes);
+        if actual != ArkType::Unknown && !binding_types_compatible(&expected, &actual) {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': field '{}' has type '{}', expected '{}'",
+                function_name,
+                field_name,
+                actual.as_str(),
+                expected.as_str()
+            )));
         }
     }
 }
@@ -1224,6 +1374,12 @@ fn validate_binding_expression(
     }
 
     match expression {
+        Expression::StructLiteral(_) => {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': struct literals may only initialize typed struct declarations",
+                function_name
+            )));
+        }
         Expression::Variable(name) => {
             validate_named_binding(name, None, "binding", function_name, scopes, issues);
         }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -234,7 +234,9 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
 fn check_struct_definitions(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     let mut names = HashSet::new();
     for definition in &contract.structs {
-        if crate::models::is_builtin_type(&definition.name) {
+        if crate::models::is_builtin_type(&definition.name)
+            || crate::models::is_builtin_struct(&definition.name)
+        {
             issues.push(ValidationIssue::error(format!(
                 "struct '{}' collides with a built-in type",
                 definition.name
@@ -299,12 +301,16 @@ fn validate_local_types(
             Statement::LetBinding {
                 declared_type: Some(declared_type),
                 ..
-            } => validate_declared_type(
-                declared_type,
-                &format!("local declaration in function '{function_name}'"),
-                definitions,
-                issues,
-            ),
+            } => {
+                if !crate::models::is_builtin_struct(declared_type) {
+                    validate_declared_type(
+                        declared_type,
+                        &format!("local declaration in function '{function_name}'"),
+                        definitions,
+                        issues,
+                    );
+                }
+            }
             Statement::IfElse {
                 then_body,
                 else_body,
@@ -414,7 +420,13 @@ fn check_asset_id_operands(contract: &Contract, issues: &mut Vec<ValidationIssue
             &func.parameters,
             &contract.structs,
         ));
-        walk_asset_id_stmts(&func.statements, &mut scope, &func.name, issues);
+        walk_asset_id_stmts(
+            &func.statements,
+            &mut scope,
+            &func.name,
+            &contract.structs,
+            issues,
+        );
     }
 }
 
@@ -422,6 +434,7 @@ fn walk_asset_id_stmts(
     stmts: &[Statement],
     scope: &mut Scope,
     fname: &str,
+    structs: &[crate::models::StructDefinition],
     issues: &mut Vec<ValidationIssue>,
 ) {
     for stmt in stmts {
@@ -436,10 +449,27 @@ fn walk_asset_id_stmts(
                 }
                 _ => {}
             },
-            Statement::LetBinding { name, value, .. } => {
+            Statement::LetBinding {
+                name,
+                declared_type,
+                value,
+            } => {
                 check_asset_id_expr(value, scope, fname, issues);
-                let t = infer_type(value, scope);
-                scope.insert(name.clone(), t);
+                let binding_type = declared_type
+                    .as_deref()
+                    .map(ArkType::parse)
+                    .unwrap_or_else(|| infer_type(value, scope));
+                if matches!(binding_type, ArkType::Struct(_)) {
+                    scope.extend(build_scope_with_structs(
+                        &[crate::models::Parameter {
+                            name: name.clone(),
+                            param_type: binding_type.as_str(),
+                        }],
+                        structs,
+                    ));
+                } else {
+                    scope.insert(name.clone(), binding_type);
+                }
             }
             Statement::VarAssign { name, value } => {
                 check_asset_id_expr(value, scope, fname, issues);
@@ -452,9 +482,9 @@ fn walk_asset_id_stmts(
                 else_body,
             } => {
                 check_asset_id_expr(condition, scope, fname, issues);
-                walk_asset_id_stmts(then_body, &mut scope.clone(), fname, issues);
+                walk_asset_id_stmts(then_body, &mut scope.clone(), fname, structs, issues);
                 if let Some(eb) = else_body {
-                    walk_asset_id_stmts(eb, &mut scope.clone(), fname, issues);
+                    walk_asset_id_stmts(eb, &mut scope.clone(), fname, structs, issues);
                 }
             }
             Statement::ForIn {
@@ -466,7 +496,7 @@ fn walk_asset_id_stmts(
                 let mut loop_scope = scope.clone();
                 loop_scope.insert(index_var.clone(), ArkType::Int);
                 loop_scope.insert(value_var.clone(), ArkType::Unknown);
-                walk_asset_id_stmts(body, &mut loop_scope, fname, issues);
+                walk_asset_id_stmts(body, &mut loop_scope, fname, structs, issues);
             }
         }
     }
@@ -769,8 +799,8 @@ fn validate_binding_statements(
                 declared_type,
                 value,
             } => {
-                // Array literals are the one composite value allowed in a value
-                // position, and only here; validate their elements instead.
+                // Composite initializers are validated through their scalar
+                // children; the declaration itself owns their result shape.
                 match value {
                     Expression::ArrayLiteral(elements) => {
                         for element in elements {
@@ -804,7 +834,13 @@ fn validate_binding_statements(
                             ))),
                         }
                     }
-                    _ => validate_binding_expression(value, function_name, scopes, issues, true),
+                    _ => validate_binding_expression(
+                        value,
+                        function_name,
+                        scopes,
+                        issues,
+                        crate::models::expression_result_struct(value).is_none(),
+                    ),
                 }
                 let inferred = resolved_expression_type(value, scopes);
                 let binding_type = declared_type
@@ -855,11 +891,14 @@ fn validate_binding_statements(
                         function_name, name
                     )));
                 }
-                if let ArkType::Struct(_) = &binding_type {
-                    if !matches!(value, Expression::StructLiteral(_)) {
+                if let ArkType::Struct(struct_type) = &binding_type {
+                    let result_type = crate::models::expression_result_struct(value);
+                    if !matches!(value, Expression::StructLiteral(_))
+                        && result_type != Some(struct_type.as_str())
+                    {
                         issues.push(ValidationIssue::error(format!(
-                            "function '{}': struct binding '{}' must be initialized with a struct literal",
-                            function_name, name
+                            "function '{}': struct binding '{}' must be initialized with a matching struct value",
+                            function_name, name,
                         )));
                     }
                 }
@@ -870,6 +909,22 @@ fn validate_binding_statements(
                     let parameter = crate::models::Parameter {
                         name: name.clone(),
                         param_type: declared_type.clone(),
+                    };
+                    for (binding_name, binding_type) in
+                        build_scope_with_structs(&[parameter], structs)
+                    {
+                        frame.insert(
+                            binding_name,
+                            BindingInfo {
+                                binding_type,
+                                source: BindingSource::Local,
+                            },
+                        );
+                    }
+                } else if matches!(binding_type, ArkType::Struct(_)) {
+                    let parameter = crate::models::Parameter {
+                        name: name.clone(),
+                        param_type: binding_type.as_str(),
                     };
                     for (binding_name, binding_type) in
                         build_scope_with_structs(&[parameter], structs)
@@ -1305,31 +1360,6 @@ fn validate_binding_expression(
         )));
     }
     if value_position
-        && (matches!(
-            expression,
-            Expression::EcAdd { .. } | Expression::EcMul { .. }
-        ) || matches!(
-            expression,
-            Expression::AssetAt { property, .. } if property == "assetId"
-        ))
-    {
-        issues.push(ValidationIssue::error(format!(
-            "function '{}': expression produces 2 stack items; composite values are not supported",
-            function_name
-        )));
-    }
-    if value_position
-        && matches!(
-            expression,
-            Expression::GroupProperty { property, .. } if property == "assetId"
-        )
-    {
-        issues.push(ValidationIssue::error(format!(
-            "function '{}': expression produces 2 stack items; composite values are not supported",
-            function_name
-        )));
-    }
-    if value_position
         && matches!(
             expression,
             Expression::GroupIOAccess { property: None, .. }
@@ -1340,20 +1370,6 @@ fn validate_binding_expression(
     {
         issues.push(ValidationIssue::error(format!(
             "function '{}': expression does not produce one stack item",
-            function_name
-        )));
-    }
-    if value_position
-        && (matches!(
-            expression,
-            Expression::CurrentInput(Some(property)) if property == "outpoint"
-        ) || matches!(
-            expression,
-            Expression::InputIntrospection { property, .. } if property == "outpoint"
-        ))
-    {
-        issues.push(ValidationIssue::error(format!(
-            "function '{}': outpoint inspection produces 2 stack items; composite values are not supported",
             function_name
         )));
     }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -20,7 +20,7 @@
 //! whether any are fatal.
 
 use crate::models::{Contract, ContractJson, Expression, Requirement, Statement};
-use crate::typechecker::{build_scope, infer_type, ArkType, Scope};
+use crate::typechecker::{build_scope_with_structs, infer_type, ArkType, Scope};
 use std::collections::{HashMap, HashSet};
 
 // ─── Issue types ──────────────────────────────────────────────────────────────
@@ -408,10 +408,13 @@ fn validate_source_identifier(name: &str, context: &str, issues: &mut Vec<Valida
 /// variable stays `Unknown` (no iterable-element typing yet) and is therefore
 /// not accepted as an Asset ID component.
 fn check_asset_id_operands(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
-    let ctor_scope = build_scope(&contract.parameters);
+    let ctor_scope = build_scope_with_structs(&contract.parameters, &contract.structs);
     for func in &contract.functions {
         let mut scope = ctor_scope.clone();
-        scope.extend(build_scope(&func.parameters));
+        scope.extend(build_scope_with_structs(
+            &func.parameters,
+            &contract.structs,
+        ));
         walk_asset_id_stmts(&func.statements, &mut scope, &func.name, issues);
     }
 }
@@ -667,36 +670,17 @@ fn insert_parameters(
     frame: &mut HashMap<String, BindingInfo>,
     parameters: &[crate::models::Parameter],
     source: BindingSource,
+    structs: &[crate::models::StructDefinition],
 ) {
-    for parameter in parameters {
-        if let Some((element_type, length)) = crate::models::array_type_parts(&parameter.param_type)
-        {
-            let element_type = ArkType::parse(element_type);
-            frame.insert(
-                parameter.name.clone(),
-                BindingInfo {
-                    binding_type: ArkType::Array(Box::new(element_type.clone()), length),
-                    source,
-                },
-            );
-            for index in 0..length {
-                frame.insert(
-                    format!("{}[{}]", parameter.name, index),
-                    BindingInfo {
-                        binding_type: element_type.clone(),
-                        source,
-                    },
-                );
-            }
-        } else {
-            frame.insert(
-                parameter.name.clone(),
-                BindingInfo {
-                    binding_type: ArkType::parse(&parameter.param_type),
-                    source,
-                },
-            );
-        }
+    let types = build_scope_with_structs(parameters, structs);
+    for (name, binding_type) in types {
+        frame.insert(
+            name,
+            BindingInfo {
+                binding_type,
+                source,
+            },
+        );
     }
 }
 
@@ -745,11 +729,17 @@ fn binding_types_compatible(expected: &ArkType, actual: &ArkType) -> bool {
 fn check_binding_semantics(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     for function in &contract.functions {
         let mut root = HashMap::new();
-        insert_parameters(&mut root, &contract.parameters, BindingSource::Constructor);
+        insert_parameters(
+            &mut root,
+            &contract.parameters,
+            BindingSource::Constructor,
+            &contract.structs,
+        );
         insert_parameters(
             &mut root,
             &function.parameters,
             BindingSource::FunctionInput,
+            &contract.structs,
         );
         let mut scopes = vec![root];
         validate_binding_statements(&function.statements, &function.name, &mut scopes, issues);
@@ -922,28 +912,32 @@ fn validate_binding_statements(
                 body,
             } => {
                 let element_type = match iterable {
-                    Expression::Variable(name) => match find_binding(scopes, name) {
-                        Some(BindingInfo {
-                            binding_type: ArkType::Array(element, _),
-                            ..
-                        }) => (**element).clone(),
-                        Some(binding) => {
-                            issues.push(ValidationIssue::error(format!(
+                    Expression::Variable(name) | Expression::Property(name)
+                        if name.trim() != "tx.assetGroups" =>
+                    {
+                        match find_binding(scopes, name) {
+                            Some(BindingInfo {
+                                binding_type: ArkType::Array(element, _),
+                                ..
+                            }) => (**element).clone(),
+                            Some(binding) => {
+                                issues.push(ValidationIssue::error(format!(
                                 "function '{}': loop iterable '{}' has type '{}', expected array",
                                 function_name,
                                 name,
                                 binding.binding_type.as_str()
                             )));
-                            ArkType::Unknown
+                                ArkType::Unknown
+                            }
+                            None => {
+                                issues.push(ValidationIssue::error(format!(
+                                    "function '{}': loop iterable '{}' is undefined",
+                                    function_name, name
+                                )));
+                                ArkType::Unknown
+                            }
                         }
-                        None => {
-                            issues.push(ValidationIssue::error(format!(
-                                "function '{}': loop iterable '{}' is undefined",
-                                function_name, name
-                            )));
-                            ArkType::Unknown
-                        }
-                    },
+                    }
                     Expression::Property(property) if property.trim() == "tx.assetGroups" => {
                         issues.push(ValidationIssue::error(format!(
                             "function '{}': cannot iterate 'tx.assetGroups'; the group count is \
@@ -1149,15 +1143,16 @@ fn validate_binding_expression(
     issues: &mut Vec<ValidationIssue>,
     value_position: bool,
 ) {
-    if value_position
-        && matches!(
-            resolved_expression_type(expression, scopes),
-            ArkType::Array(..)
-        )
-    {
+    let expression_type = resolved_expression_type(expression, scopes);
+    if value_position && matches!(expression_type, ArkType::Array(..) | ArkType::Struct(..)) {
+        let kind = if matches!(expression_type, ArkType::Struct(..)) {
+            "struct"
+        } else {
+            "array"
+        };
         issues.push(ValidationIssue::error(format!(
-            "function '{}': array expressions are composite values and cannot be used here",
-            function_name
+            "function '{}': {kind} expressions are composite values and cannot be used here",
+            function_name,
         )));
     }
     if value_position
@@ -1280,6 +1275,15 @@ fn validate_binding_expression(
                     "function '{}': '{}' is not an array; '.length' is undefined",
                     function_name, array
                 )));
+            }
+        }
+        Expression::Property(name) => {
+            let root = name.split('.').next().unwrap_or(name);
+            if matches!(
+                find_binding(scopes, root).map(|binding| &binding.binding_type),
+                Some(ArkType::Struct(..))
+            ) {
+                validate_named_binding(name, None, "field", function_name, scopes, issues);
             }
         }
         Expression::GroupProperty { group, .. } | Expression::GroupControlIs { group, .. }
@@ -1617,7 +1621,15 @@ fn walk_scope(
 /// still collide here (e.g. `int[] xs` vs `int xs_0`).
 fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     // Constructor params expanded exactly as the emitter expands them (array flattening).
-    let ctor_expanded = crate::compiler::expanded_placeholder_params(&contract.parameters);
+    let ctor_expanded =
+        match crate::compiler::expanded_placeholder_params(&contract.parameters, &contract.structs)
+        {
+            Ok(parameters) => parameters,
+            Err(error) => {
+                issues.push(ValidationIssue::error(error));
+                return;
+            }
+        };
 
     for func in contract.functions.iter().filter(|f| !f.is_internal) {
         let mut seen: HashSet<String> = HashSet::new();
@@ -1631,7 +1643,16 @@ fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssu
             );
         }
 
-        for p in crate::compiler::expanded_placeholder_params(&func.parameters) {
+        let expanded =
+            match crate::compiler::expanded_placeholder_params(&func.parameters, &contract.structs)
+            {
+                Ok(parameters) => parameters,
+                Err(error) => {
+                    issues.push(ValidationIssue::error(error));
+                    continue;
+                }
+            };
+        for p in expanded {
             record_name(
                 p.name,
                 &format!("function '{}'", func.name),
@@ -1651,7 +1672,17 @@ fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssu
                 issues,
             );
         }
-        for p in crate::compiler::expanded_placeholder_params(&tapscript.inputs) {
+        let expanded = match crate::compiler::expanded_placeholder_params(
+            &tapscript.inputs,
+            &contract.structs,
+        ) {
+            Ok(parameters) => parameters,
+            Err(error) => {
+                issues.push(ValidationIssue::error(error));
+                continue;
+            }
+        };
+        for p in expanded {
             record_name(
                 p.name,
                 &format!("tapscript '{}'", tapscript.name),
@@ -1707,12 +1738,23 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
             // The ABI keeps one entry per source parameter; the prologue pushes
             // one placeholder per array element, so compare against the
             // flattened namespace.
-            let expected_prologue =
-                crate::compiler::expanded_placeholder_params(&output.parameters)
+            let expected_prologue = match crate::compiler::expanded_placeholder_params(
+                &output.parameters,
+                &output.structs,
+            ) {
+                Ok(parameters) => parameters
                     .iter()
                     .rev()
                     .map(|parameter| format!("<{}>", parameter.name))
-                    .collect::<Vec<_>>();
+                    .collect::<Vec<_>>(),
+                Err(error) => {
+                    issues.push(ValidationIssue::error(format!(
+                        "group '{}' has an invalid type layout: {error}",
+                        group.name
+                    )));
+                    continue;
+                }
+            };
             if !arkade.asm.starts_with(&expected_prologue) {
                 issues.push(ValidationIssue::error(format!(
                     "group '{}' arkade covenant has an invalid constructor prologue",

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -82,6 +82,8 @@ pub fn has_errors(issues: &[ValidationIssue]) -> bool {
 pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
     let mut issues = Vec::new();
 
+    check_struct_definitions(contract, &mut issues);
+
     // ── Contract name ──────────────────────────────────────────────────────
     if contract.name.is_empty() {
         issues.push(ValidationIssue::error("contract name must not be empty"));
@@ -199,6 +201,16 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
                     ts.name, p.name, p.param_type
                 )));
             }
+            if contract
+                .structs
+                .iter()
+                .any(|definition| definition.name == p.param_type)
+            {
+                issues.push(ValidationIssue::error(format!(
+                    "tapscript '{}' input '{}' has struct type '{}'; struct witnesses are not supported in tapscript functions",
+                    ts.name, p.name, p.param_type
+                )));
+            }
         }
         // Duplicate input names within a tapscript.
         let mut seen = std::collections::HashSet::new();
@@ -218,6 +230,160 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
     check_asset_id_operands(contract, &mut issues);
 
     issues
+}
+
+fn check_struct_definitions(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
+    let mut names = HashSet::new();
+    for definition in &contract.structs {
+        if crate::models::is_builtin_type(&definition.name) {
+            issues.push(ValidationIssue::error(format!(
+                "struct '{}' collides with a built-in type",
+                definition.name
+            )));
+        }
+        if !names.insert(definition.name.as_str()) {
+            issues.push(ValidationIssue::error(format!(
+                "duplicate struct definition '{}'",
+                definition.name
+            )));
+        }
+        let mut fields = HashSet::new();
+        for field in &definition.fields {
+            if !fields.insert(field.name.as_str()) {
+                issues.push(ValidationIssue::error(format!(
+                    "duplicate field '{}' in struct '{}'",
+                    field.name, definition.name
+                )));
+            }
+        }
+    }
+
+    let definitions = contract
+        .structs
+        .iter()
+        .map(|definition| (definition.name.as_str(), definition))
+        .collect::<HashMap<_, _>>();
+    for definition in &contract.structs {
+        validate_struct_fields(definition, &definitions, &mut Vec::new(), issues);
+    }
+    for parameter in contract
+        .parameters
+        .iter()
+        .chain(
+            contract
+                .functions
+                .iter()
+                .flat_map(|function| &function.parameters),
+        )
+        .chain(
+            contract
+                .tapscripts
+                .iter()
+                .flat_map(|tapscript| &tapscript.inputs),
+        )
+    {
+        validate_declared_type(&parameter.param_type, "parameter", &definitions, issues);
+    }
+    for function in &contract.functions {
+        validate_local_types(&function.statements, &function.name, &definitions, issues);
+    }
+}
+
+fn validate_local_types(
+    statements: &[Statement],
+    function_name: &str,
+    definitions: &HashMap<&str, &crate::models::StructDefinition>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    for statement in statements {
+        match statement {
+            Statement::LetBinding {
+                declared_type: Some(declared_type),
+                ..
+            } => validate_declared_type(
+                declared_type,
+                &format!("local declaration in function '{function_name}'"),
+                definitions,
+                issues,
+            ),
+            Statement::IfElse {
+                then_body,
+                else_body,
+                ..
+            } => {
+                validate_local_types(then_body, function_name, definitions, issues);
+                if let Some(else_body) = else_body {
+                    validate_local_types(else_body, function_name, definitions, issues);
+                }
+            }
+            Statement::ForIn { body, .. } => {
+                validate_local_types(body, function_name, definitions, issues);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn validate_struct_fields<'a>(
+    definition: &'a crate::models::StructDefinition,
+    definitions: &HashMap<&'a str, &'a crate::models::StructDefinition>,
+    stack: &mut Vec<&'a str>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    if stack.contains(&definition.name.as_str()) {
+        let mut cycle = stack.join(" -> ");
+        if !cycle.is_empty() {
+            cycle.push_str(" -> ");
+        }
+        cycle.push_str(&definition.name);
+        issues.push(ValidationIssue::error(format!(
+            "recursive struct layout: {cycle}"
+        )));
+        return;
+    }
+    stack.push(&definition.name);
+    for field in &definition.fields {
+        validate_declared_type(
+            &field.param_type,
+            &format!("field '{}.{}'", definition.name, field.name),
+            definitions,
+            issues,
+        );
+        let (base, is_array) = crate::models::array_type_parts(&field.param_type)
+            .map(|(base, _)| (base, true))
+            .unwrap_or((field.param_type.as_str(), false));
+        if let Some(nested) = definitions.get(base) {
+            if is_array {
+                issues.push(ValidationIssue::error(format!(
+                    "field '{}.{}' is an array of structs; arrays of structs are not supported",
+                    definition.name, field.name
+                )));
+            } else {
+                validate_struct_fields(nested, definitions, stack, issues);
+            }
+        }
+    }
+    stack.pop();
+}
+
+fn validate_declared_type(
+    declared_type: &str,
+    context: &str,
+    definitions: &HashMap<&str, &crate::models::StructDefinition>,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let array = crate::models::array_type_parts(declared_type);
+    let base = array.map(|(base, _)| base).unwrap_or(declared_type);
+    if !crate::models::is_builtin_type(base) && !definitions.contains_key(base) {
+        issues.push(ValidationIssue::error(format!(
+            "{context} uses unknown type '{base}'"
+        )));
+    }
+    if array.is_some() && definitions.contains_key(base) {
+        issues.push(ValidationIssue::error(format!(
+            "{context} uses an array of structs; arrays of structs are not supported"
+        )));
+    }
 }
 
 fn validate_source_identifier(name: &str, context: &str, issues: &mut Vec<ValidationIssue>) {
@@ -1607,6 +1773,7 @@ mod tests {
     fn make_contract(name: &str) -> Contract {
         Contract {
             name: name.to_string(),
+            structs: vec![],
             parameters: vec![Parameter {
                 name: "owner".to_string(),
                 param_type: "pubkey".to_string(),
@@ -1731,6 +1898,7 @@ mod tests {
         }];
         ContractJson {
             name: name.to_string(),
+            structs: vec![],
             parameters: vec![],
             functions: vec![AbiFunctionGroup {
                 name: "spend".to_string(),

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -201,10 +201,11 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
                     ts.name, p.name, p.param_type
                 )));
             }
-            if contract
-                .structs
-                .iter()
-                .any(|definition| definition.name == p.param_type)
+            if crate::models::is_builtin_struct(&p.param_type)
+                || contract
+                    .structs
+                    .iter()
+                    .any(|definition| definition.name == p.param_type)
             {
                 issues.push(ValidationIssue::error(format!(
                     "tapscript '{}' input '{}' has struct type '{}'; struct witnesses are not supported in tapscript functions",
@@ -348,12 +349,14 @@ fn validate_struct_fields<'a>(
     }
     stack.push(&definition.name);
     for field in &definition.fields {
-        validate_declared_type(
-            &field.param_type,
-            &format!("field '{}.{}'", definition.name, field.name),
-            definitions,
-            issues,
-        );
+        if !crate::models::is_builtin_struct(&field.param_type) {
+            validate_declared_type(
+                &field.param_type,
+                &format!("field '{}.{}'", definition.name, field.name),
+                definitions,
+                issues,
+            );
+        }
         let (base, is_array) = crate::models::array_type_parts(&field.param_type)
             .map(|(base, _)| (base, true))
             .unwrap_or((field.param_type.as_str(), false));
@@ -1159,6 +1162,21 @@ fn validate_struct_literal(
                 structs,
                 issues,
             );
+            continue;
+        }
+        if crate::models::is_builtin_struct(&field.param_type) {
+            validate_binding_expression(value, function_name, scopes, issues, false);
+            let expected = ArkType::parse(&field.param_type);
+            let actual = resolved_expression_type(value, scopes);
+            if actual != expected {
+                issues.push(ValidationIssue::error(format!(
+                    "function '{}': field '{}' has type '{}', expected '{}'",
+                    function_name,
+                    field_name,
+                    actual.as_str(),
+                    expected.as_str()
+                )));
+            }
             continue;
         }
 

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -225,7 +225,6 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
     }
 
     check_shadowing(contract, &mut issues);
-    check_expanded_namespace(contract, &mut issues);
     check_binding_semantics(contract, &mut issues);
     check_asset_id_operands(contract, &mut issues);
 
@@ -1771,98 +1770,6 @@ fn walk_scope(
     }
 }
 
-/// Check 2: the names a function's parameters and the constructor's parameters
-/// contribute to the *emitted* placeholder namespace after array flattening
-/// must be unique. Distinct source names can
-/// still collide here (e.g. `int[] xs` vs `int xs_0`).
-fn check_expanded_namespace(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
-    // Constructor params expanded exactly as the emitter expands them (array flattening).
-    let ctor_expanded =
-        match crate::compiler::expanded_placeholder_params(&contract.parameters, &contract.structs)
-        {
-            Ok(parameters) => parameters,
-            Err(error) => {
-                issues.push(ValidationIssue::error(error));
-                return;
-            }
-        };
-
-    for func in contract.functions.iter().filter(|f| !f.is_internal) {
-        let mut seen: HashSet<String> = HashSet::new();
-
-        for p in &ctor_expanded {
-            record_name(
-                p.name.clone(),
-                &format!("function '{}'", func.name),
-                &mut seen,
-                issues,
-            );
-        }
-
-        let expanded =
-            match crate::compiler::expanded_placeholder_params(&func.parameters, &contract.structs)
-            {
-                Ok(parameters) => parameters,
-                Err(error) => {
-                    issues.push(ValidationIssue::error(error));
-                    continue;
-                }
-            };
-        for p in expanded {
-            record_name(
-                p.name,
-                &format!("function '{}'", func.name),
-                &mut seen,
-                issues,
-            );
-        }
-    }
-
-    for tapscript in &contract.tapscripts {
-        let mut seen: HashSet<String> = HashSet::new();
-        for p in &ctor_expanded {
-            record_name(
-                p.name.clone(),
-                &format!("tapscript '{}'", tapscript.name),
-                &mut seen,
-                issues,
-            );
-        }
-        let expanded = match crate::compiler::expanded_placeholder_params(
-            &tapscript.inputs,
-            &contract.structs,
-        ) {
-            Ok(parameters) => parameters,
-            Err(error) => {
-                issues.push(ValidationIssue::error(error));
-                continue;
-            }
-        };
-        for p in expanded {
-            record_name(
-                p.name,
-                &format!("tapscript '{}'", tapscript.name),
-                &mut seen,
-                issues,
-            );
-        }
-    }
-}
-
-/// Insert an emitted name; on the first duplicate, record a collision error.
-fn record_name(
-    name: String,
-    context: &str,
-    seen: &mut HashSet<String>,
-    issues: &mut Vec<ValidationIssue>,
-) {
-    if !seen.insert(name.clone()) {
-        issues.push(ValidationIssue::error(format!(
-            "parameters in {context} collide in the emitted namespace as '{name}'"
-        )));
-    }
-}
-
 // ─── Output validation ────────────────────────────────────────────────────────
 
 /// Validate the compiled [`ContractJson`] output for structural invariants.
@@ -1892,8 +1799,8 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
                 )));
             }
             // The ABI keeps one entry per source parameter; the prologue pushes
-            // one placeholder per array element, so compare against the
-            // flattened namespace.
+            // one placeholder per scalar leaf, so compare against the flattened
+            // layout.
             let expected_prologue = match crate::compiler::expanded_placeholder_params(
                 &output.parameters,
                 &output.structs,

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -265,8 +265,15 @@ fn check_struct_definitions(contract: &Contract, issues: &mut Vec<ValidationIssu
         .iter()
         .map(|definition| (definition.name.as_str(), definition))
         .collect::<HashMap<_, _>>();
+    let mut validated = HashSet::new();
     for definition in &contract.structs {
-        validate_struct_fields(definition, &definitions, &mut Vec::new(), issues);
+        validate_struct_fields(
+            definition,
+            &definitions,
+            &mut Vec::new(),
+            &mut validated,
+            issues,
+        );
     }
     for parameter in contract
         .parameters
@@ -334,6 +341,7 @@ fn validate_struct_fields<'a>(
     definition: &'a crate::models::StructDefinition,
     definitions: &HashMap<&'a str, &'a crate::models::StructDefinition>,
     stack: &mut Vec<&'a str>,
+    validated: &mut HashSet<&'a str>,
     issues: &mut Vec<ValidationIssue>,
 ) {
     if stack.contains(&definition.name.as_str()) {
@@ -345,6 +353,9 @@ fn validate_struct_fields<'a>(
         issues.push(ValidationIssue::error(format!(
             "recursive struct layout: {cycle}"
         )));
+        return;
+    }
+    if !validated.insert(definition.name.as_str()) {
         return;
     }
     stack.push(&definition.name);
@@ -367,7 +378,7 @@ fn validate_struct_fields<'a>(
                     definition.name, field.name
                 )));
             } else {
-                validate_struct_fields(nested, definitions, stack, issues);
+                validate_struct_fields(nested, definitions, stack, validated, issues);
             }
         }
     }
@@ -382,12 +393,16 @@ fn validate_declared_type(
 ) {
     let array = crate::models::array_type_parts(declared_type);
     let base = array.map(|(base, _)| base).unwrap_or(declared_type);
-    if !crate::models::is_builtin_type(base) && !definitions.contains_key(base) {
+    if !crate::models::is_builtin_type(base)
+        && !crate::models::is_builtin_struct(base)
+        && !definitions.contains_key(base)
+    {
         issues.push(ValidationIssue::error(format!(
             "{context} uses unknown type '{base}'"
         )));
     }
-    if array.is_some() && definitions.contains_key(base) {
+    if array.is_some() && (definitions.contains_key(base) || crate::models::is_builtin_struct(base))
+    {
         issues.push(ValidationIssue::error(format!(
             "{context} uses an array of structs; arrays of structs are not supported"
         )));
@@ -462,17 +477,13 @@ fn walk_asset_id_stmts(
                     .as_deref()
                     .map(ArkType::parse)
                     .unwrap_or_else(|| infer_type(value, scope));
-                if matches!(binding_type, ArkType::Struct(_)) {
-                    scope.extend(build_scope_with_structs(
-                        &[crate::models::Parameter {
-                            name: name.clone(),
-                            param_type: binding_type.as_str(),
-                        }],
-                        structs,
-                    ));
-                } else {
-                    scope.insert(name.clone(), binding_type);
-                }
+                crate::typechecker::bind_local_type(
+                    scope,
+                    name,
+                    declared_type.as_deref(),
+                    binding_type,
+                    structs,
+                );
             }
             Statement::VarAssign { name, value } => {
                 check_asset_id_expr(value, scope, fname, issues);
@@ -908,41 +919,17 @@ fn validate_binding_statements(
                 let frame = scopes
                     .last_mut()
                     .expect("binding validation always has a scope");
-                if let Some(declared_type) = declared_type {
-                    let parameter = crate::models::Parameter {
-                        name: name.clone(),
-                        param_type: declared_type.clone(),
-                    };
-                    for (binding_name, binding_type) in
-                        build_scope_with_structs(&[parameter], structs)
-                    {
-                        frame.insert(
-                            binding_name,
-                            BindingInfo {
-                                binding_type,
-                                source: BindingSource::Local,
-                            },
-                        );
-                    }
-                } else if matches!(binding_type, ArkType::Struct(_)) {
-                    let parameter = crate::models::Parameter {
-                        name: name.clone(),
-                        param_type: binding_type.as_str(),
-                    };
-                    for (binding_name, binding_type) in
-                        build_scope_with_structs(&[parameter], structs)
-                    {
-                        frame.insert(
-                            binding_name,
-                            BindingInfo {
-                                binding_type,
-                                source: BindingSource::Local,
-                            },
-                        );
-                    }
-                } else {
+                let mut local = Scope::new();
+                crate::typechecker::bind_local_type(
+                    &mut local,
+                    name,
+                    declared_type.as_deref(),
+                    binding_type,
+                    structs,
+                );
+                for (binding_name, binding_type) in local {
                     frame.insert(
-                        name.clone(),
+                        binding_name,
                         BindingInfo {
                             binding_type,
                             source: BindingSource::Local,
@@ -1454,7 +1441,9 @@ fn validate_binding_expression(
         Expression::Property(name) if name.contains('[') => {
             validate_named_binding(name, None, "binding", function_name, scopes, issues);
         }
-        Expression::Property(name) if name.ends_with(".length") => {
+        Expression::Property(name)
+            if name.ends_with(".length") && find_binding(scopes, name).is_none() =>
+        {
             let array = name.trim_end_matches(".length");
             if !matches!(
                 find_binding(scopes, array).map(|binding| &binding.binding_type),
@@ -1468,10 +1457,7 @@ fn validate_binding_expression(
         }
         Expression::Property(name) => {
             let root = name.split('.').next().unwrap_or(name);
-            if matches!(
-                find_binding(scopes, root).map(|binding| &binding.binding_type),
-                Some(ArkType::Struct(..))
-            ) {
+            if name.contains('.') && find_binding(scopes, root).is_some() {
                 validate_named_binding(name, None, "field", function_name, scopes, issues);
             }
         }
@@ -1615,8 +1601,9 @@ fn validate_asset_id(
 
 fn describe_operand(expr: &Expression) -> String {
     match expr {
-        Expression::Variable(v) => format!("'{}'", v),
-        Expression::Literal(l) => format!("'{}'", l),
+        Expression::Variable(name) | Expression::Literal(name) | Expression::Property(name) => {
+            format!("'{}'", name)
+        }
         _ => "<expr>".to_string(),
     }
 }
@@ -1650,16 +1637,24 @@ fn statement_guarantees_require(stmt: &Statement) -> bool {
     }
 }
 
-/// Check 1: reject any binding that shadows a name still live in an enclosing
-/// scope, plus `for (x, x)`. Function parameters are compared against
-/// constructor parameters explicitly before seeding (a collapsed set would
-/// silently swallow the duplicate).
+/// Check 1: reject any binding that shadows a name still live in an enclosing scope.
 fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     let ctor_names: HashSet<&str> = contract
         .parameters
         .iter()
         .map(|p| p.name.as_str())
         .collect();
+
+    for tapscript in &contract.tapscripts {
+        for input in &tapscript.inputs {
+            if ctor_names.contains(input.name.as_str()) {
+                issues.push(ValidationIssue::error(format!(
+                    "input '{}' in tapscript '{}' shadows constructor parameter '{}'",
+                    input.name, tapscript.name, input.name
+                )));
+            }
+        }
+    }
 
     for func in &contract.functions {
         // Seed frame: constructor params + this function's params.

--- a/tests/e2e/contracts/structs.ark
+++ b/tests/e2e/contracts/structs.ark
@@ -1,0 +1,76 @@
+struct Inner {
+  int b;
+}
+
+struct Rules {
+  int a_b;
+  Inner a;
+  int[3] weights;
+}
+
+struct Point {
+  int x;
+  int y;
+}
+
+struct Account {
+  pubkey owner;
+  Rules rules;
+}
+
+contract Structs(Account account) {
+  function spend(
+    Rules supplied,
+    Point generator,
+    int index,
+    int expected,
+    signature ownerSig
+  ) {
+    require(account.rules.a_b == 11, "constructor field");
+    require(account.rules.a.b == 17, "nested constructor field");
+    require(account.rules.weights[2] == 23, "constructor array field");
+    require(supplied.a_b == 29, "function field");
+    require(supplied.a.b == 37, "nested function field");
+    require(supplied.weights[index] == 43, "indexed struct array");
+
+    Rules local = {
+      weights: [supplied.weights[0], supplied.weights[1], supplied.weights[2]],
+      a: { b: supplied.a.b },
+      a_b: supplied.a_b
+    };
+    local.a.b = local.a.b + account.rules.a.b;
+    local.weights[1] = local.weights[1] + account.rules.weights[1];
+
+    int total = local.a_b + local.a.b;
+    for (i, weight) in local.weights {
+      total = total + (weight * (i + 1));
+    }
+    require(local.weights.length == 3, "array field length");
+    require(total == expected, "local struct result");
+
+    let indexedOutpoint = tx.inputs[0].outpoint;
+    Outpoint currentOutpoint = tx.input.current.outpoint;
+    require(indexedOutpoint.txid == currentOutpoint.txid, "outpoint txid");
+    require(indexedOutpoint.vout == currentOutpoint.vout, "outpoint vout");
+    require(currentOutpoint.vout == 0, "funding vout");
+
+    let outputAssetId = tx.outputs[0].assets[0].assetId;
+    require(outputAssetId.gidx == 0, "asset group index");
+    require(tx.outputs[0].assets.lookup(outputAssetId.txid, outputAssetId.gidx) == 7, "asset lookup");
+    let assetGroup = tx.assetGroups.find(outputAssetId.txid, outputAssetId.gidx);
+    AssetId groupAssetId = assetGroup.assetId;
+    require(groupAssetId.txid == outputAssetId.txid, "group asset txid");
+    require(groupAssetId.gidx == outputAssetId.gidx, "group asset index");
+
+    let generatorX = generator.x;
+    let generatorY = generator.y;
+    ECPoint added = ecAdd(0, 0, generatorX, generatorY, 0);
+    let multiplied = ecMul(generatorX, generatorY, 1, 0);
+    require(added.x == generator.x, "ecAdd x");
+    require(added.y == generator.y, "ecAdd y");
+    require(multiplied.x == generator.x, "ecMul x");
+    require(multiplied.y == generator.y, "ecMul y");
+
+    require(checkSig(ownerSig, account.owner));
+  }
+}

--- a/tests/e2e/static_arrays_test.go
+++ b/tests/e2e/static_arrays_test.go
@@ -46,7 +46,7 @@ func TestStaticArrays(t *testing.T) {
 		"owner": schnorr.SerializePubKey(ownerKey.PubKey()),
 	}
 	for i, weight := range weights {
-		constructorValues[fmt.Sprintf("weights_%d", i)] = scriptInt(t, weight)
+		constructorValues[fmt.Sprintf("weights.%d", i)] = scriptInt(t, weight)
 	}
 	arrays := instantiateGroup(
 		t, contract, "spend", constructorValues, serverKey.PubKey(), emulatorKey.PubKey(),
@@ -117,7 +117,7 @@ func TestStaticArrays(t *testing.T) {
 				"ownerSig":   nil,
 			}
 			for i, sample := range testCase.samples {
-				values[fmt.Sprintf("samples_%d", i)] = scriptInt(t, sample)
+				values[fmt.Sprintf("samples.%d", i)] = scriptInt(t, sample)
 			}
 
 			deployment := fundingTx(arrays.pkScript, 10_000)

--- a/tests/e2e/static_arrays_test.go
+++ b/tests/e2e/static_arrays_test.go
@@ -123,12 +123,12 @@ func TestStaticArrays(t *testing.T) {
 			deployment := fundingTx(arrays.pkScript, 10_000)
 			unsigned := spendingPSBTWithWitness(
 				t, deployment, arrays, 10_000, arrays.pkScript,
-				covenantWitness(t, group, values),
+				covenantWitness(t, contract, group, values),
 			)
 			values["ownerSig"] = signArkadeSighash(t, unsigned, 0, ownerKey)
 			signed := spendingPSBTWithWitness(
 				t, deployment, arrays, 10_000, arrays.pkScript,
-				covenantWitness(t, group, values),
+				covenantWitness(t, contract, group, values),
 			)
 
 			requireVMResult(t, signed, emulatorKey.PubKey(), testCase.wantErr)

--- a/tests/e2e/structs_test.go
+++ b/tests/e2e/structs_test.go
@@ -38,7 +38,11 @@ func TestStructs(t *testing.T) {
 	}
 
 	group := covenantGroup(t, contract, "spend")
-	for index, name := range expandInput(contract.ConstructorInputs[0], contract.Structs) {
+	constructorInputs := expandInput(contract.ConstructorInputs[0], contract.Structs)
+	if got, want := len(group.Arkade.ASM), len(constructorInputs); got < want {
+		t.Fatalf("covenant asm has %d tokens, need at least %d constructor prologue tokens", got, want)
+	}
+	for index, name := range constructorInputs {
 		if got, want := group.Arkade.ASM[index], "<"+name+">"; got != want {
 			t.Fatalf("constructor prologue token %d = %q, want %q", index, got, want)
 		}

--- a/tests/e2e/structs_test.go
+++ b/tests/e2e/structs_test.go
@@ -1,0 +1,170 @@
+package e2e
+
+import (
+	"bytes"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	"github.com/arkade-os/emulator/pkg/arkade"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+)
+
+func TestStructs(t *testing.T) {
+	contract := compileArtifact(t, "contracts/structs.ark")
+	serverKey := fixedPrivateKey(1)
+	emulatorKey := fixedPrivateKey(2)
+	ownerKey := fixedPrivateKey(4)
+
+	if got := contract.ConstructorInputs; len(got) != 1 || got[0].Name != "account" || got[0].Type != "Account" {
+		t.Fatalf("constructor inputs = %+v, want account Account", got)
+	}
+	if got, want := structNames(contract.Structs), []string{"Inner", "Rules", "Point", "Account"}; !slices.Equal(got, want) {
+		t.Fatalf("struct definitions = %v, want %v", got, want)
+	}
+
+	accountLeaves := flattenInput("account", "Account", contract.Structs)
+	wantAccountLeaves := []string{
+		"account.owner",
+		"account.rules.a_b",
+		"account.rules.a.b",
+		"account.rules.weights.0",
+		"account.rules.weights.1",
+		"account.rules.weights.2",
+	}
+	if !slices.Equal(accountLeaves, wantAccountLeaves) {
+		t.Fatalf("account leaves = %v, want %v", accountLeaves, wantAccountLeaves)
+	}
+
+	group := covenantGroup(t, contract, "spend")
+	for index, name := range expandInput(contract.ConstructorInputs[0], contract.Structs) {
+		if got, want := group.Arkade.ASM[index], "<"+name+">"; got != want {
+			t.Fatalf("constructor prologue token %d = %q, want %q", index, got, want)
+		}
+	}
+	if got, want := inputTypes(group.Arkade.Inputs), []string{"Rules", "Point", "int", "int", "signature"}; !slices.Equal(got, want) {
+		t.Fatalf("covenant input types = %v, want %v", got, want)
+	}
+
+	constructorValues := map[string][]byte{
+		"account.owner":           schnorr.SerializePubKey(ownerKey.PubKey()),
+		"account.rules.a_b":       scriptInt(t, 11),
+		"account.rules.a.b":       scriptInt(t, 17),
+		"account.rules.weights.0": scriptInt(t, 19),
+		"account.rules.weights.1": scriptInt(t, 21),
+		"account.rules.weights.2": scriptInt(t, 23),
+	}
+	instance := instantiateGroup(
+		t, contract, "spend", constructorValues, serverKey.PubKey(), emulatorKey.PubKey(),
+	)
+
+	generator := fixedPrivateKey(9).PubKey().SerializeUncompressed()
+	baseValues := map[string][]byte{
+		"supplied.a_b":       scriptInt(t, 29),
+		"supplied.a.b":       scriptInt(t, 37),
+		"supplied.weights.0": scriptInt(t, 41),
+		"supplied.weights.1": scriptInt(t, 43),
+		"supplied.weights.2": scriptInt(t, 47),
+		"generator.x":        scriptPositiveBigInt(t, generator[1:33]),
+		"generator.y":        scriptPositiveBigInt(t, generator[33:]),
+		"index":              scriptInt(t, 1),
+		"expected":           scriptInt(t, 393),
+		"ownerSig":           nil,
+	}
+
+	assetOutput, err := asset.NewAssetOutput(0, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetGroup, err := asset.NewAssetGroup(nil, nil, nil, []asset.AssetOutput{*assetOutput}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assetPacket, err := asset.NewPacket([]asset.AssetGroup{*assetGroup})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name    string
+		key     string
+		value   int64
+		wantErr string
+	}{
+		{name: "valid"},
+		{name: "underscore field is distinct from nested path", key: "supplied.a_b", value: 37, wantErr: "OP_VERIFY failed"},
+		{name: "nested field is distinct from underscore path", key: "supplied.a.b", value: 29, wantErr: "OP_VERIFY failed"},
+		{name: "nested array field", key: "supplied.weights.1", value: 44, wantErr: "OP_VERIFY failed"},
+		{name: "runtime array bound", key: "index", value: 3, wantErr: "OP_VERIFY failed"},
+		{name: "local struct mutation result", key: "expected", value: 394, wantErr: "OP_VERIFY failed"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			values := maps.Clone(baseValues)
+			if testCase.key != "" {
+				values[testCase.key] = scriptInt(t, testCase.value)
+			}
+
+			deployment := fundingTx(instance.pkScript, 10_000)
+			unsigned := spendingPSBTWithWitness(
+				t,
+				deployment,
+				instance,
+				10_000,
+				instance.pkScript,
+				covenantWitness(t, contract, group, values),
+				assetPacket,
+			)
+			values["ownerSig"] = signArkadeSighash(t, unsigned, 0, ownerKey)
+			signed := spendingPSBTWithWitness(
+				t,
+				deployment,
+				instance,
+				10_000,
+				instance.pkScript,
+				covenantWitness(t, contract, group, values),
+				assetPacket,
+			)
+
+			requireVMResult(t, signed, emulatorKey.PubKey(), testCase.wantErr)
+		})
+	}
+}
+
+func structNames(definitions []structDefinition) []string {
+	names := make([]string, len(definitions))
+	for index, definition := range definitions {
+		names[index] = definition.Name
+	}
+	return names
+}
+
+func inputTypes(inputs []abiInput) []string {
+	types := make([]string, len(inputs))
+	for index, input := range inputs {
+		types[index] = input.Type
+	}
+	return types
+}
+
+func scriptPositiveBigInt(t *testing.T, bigEndian []byte) []byte {
+	t.Helper()
+
+	encoded := bytes.TrimLeft(bigEndian, "\x00")
+	encoded = slices.Clone(encoded)
+	slices.Reverse(encoded)
+	if len(encoded) > 0 && encoded[len(encoded)-1]&0x80 != 0 {
+		encoded = append(encoded, 0)
+	}
+	number, err := arkade.BigNumFromBytes(encoded)
+	if err != nil {
+		t.Fatalf("encode positive big integer: %v", err)
+	}
+	encoded, err = number.Bytes()
+	if err != nil {
+		t.Fatalf("encode positive big integer: %v", err)
+	}
+	return encoded
+}

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -171,7 +171,7 @@ func arrayTypeParts(typeStr string) (string, int) {
 }
 
 // expandInput maps one ABI entry to the stack items it contributes, deepest
-// first: an array entry becomes name_{N-1} … name_0, so element 0 ends up
+// first: an array entry becomes name.{N-1} … name.0, so element 0 ends up
 // closest to the top.
 func expandInput(input abiInput) []string {
 	_, length := arrayTypeParts(input.Type)
@@ -180,7 +180,7 @@ func expandInput(input abiInput) []string {
 	}
 	names := make([]string, 0, length)
 	for index := length - 1; index >= 0; index-- {
-		names = append(names, fmt.Sprintf("%s_%d", input.Name, index))
+		names = append(names, fmt.Sprintf("%s.%d", input.Name, index))
 	}
 	return names
 }

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -22,10 +23,16 @@ import (
 )
 
 type artifact struct {
-	Name              string          `json:"contractName"`
-	ConstructorInputs []abiInput      `json:"constructorInputs"`
-	Functions         []functionGroup `json:"functions"`
-	Warnings          []string        `json:"warnings"`
+	Name              string             `json:"contractName"`
+	Structs           []structDefinition `json:"structs"`
+	ConstructorInputs []abiInput         `json:"constructorInputs"`
+	Functions         []functionGroup    `json:"functions"`
+	Warnings          []string           `json:"warnings"`
+}
+
+type structDefinition struct {
+	Name   string     `json:"name"`
+	Fields []abiInput `json:"fields"`
 }
 
 type abiInput struct {
@@ -170,26 +177,43 @@ func arrayTypeParts(typeStr string) (string, int) {
 	return typeStr[:open], length
 }
 
-// expandInput maps one ABI entry to the stack items it contributes, deepest
-// first: an array entry becomes name.{N-1} … name.0, so element 0 ends up
-// closest to the top.
-func expandInput(input abiInput) []string {
-	_, length := arrayTypeParts(input.Type)
+func flattenInput(name, typeName string, structs []structDefinition) []string {
+	for _, definition := range structs {
+		if definition.Name != typeName {
+			continue
+		}
+		var names []string
+		for _, field := range definition.Fields {
+			names = append(names, flattenInput(name+"."+field.Name, field.Type, structs)...)
+		}
+		return names
+	}
+
+	_, length := arrayTypeParts(typeName)
 	if length == 0 {
-		return []string{input.Name}
+		return []string{name}
 	}
 	names := make([]string, 0, length)
-	for index := length - 1; index >= 0; index-- {
-		names = append(names, fmt.Sprintf("%s.%d", input.Name, index))
+	for index := range length {
+		names = append(names, fmt.Sprintf("%s.%d", name, index))
 	}
 	return names
 }
 
+// expandInput maps one ABI entry to the physical stack items it contributes,
+// deepest first, so the first logical scalar leaf ends up closest to the top.
+func expandInput(input abiInput, structs []structDefinition) []string {
+	names := flattenInput(input.Name, input.Type, structs)
+	slices.Reverse(names)
+	return names
+}
+
 // covenantWitness builds the covenant witness from the ABI alone: inputs in
-// reverse declaration order, array entries expanded per expandInput. This is
-// the client-side convention the artifact documents.
+// reverse declaration order, with composite entries expanded per expandInput.
+// This is the client-side convention the artifact documents.
 func covenantWitness(
 	t *testing.T,
+	contract artifact,
 	group *functionGroup,
 	values map[string][]byte,
 ) wire.TxWitness {
@@ -198,7 +222,7 @@ func covenantWitness(
 	inputs := group.Arkade.Inputs
 	witness := make(wire.TxWitness, 0, len(inputs))
 	for i := len(inputs) - 1; i >= 0; i-- {
-		for _, name := range expandInput(inputs[i]) {
+		for _, name := range expandInput(inputs[i], contract.Structs) {
 			value, ok := values[name]
 			if !ok {
 				t.Fatalf("missing witness value for covenant input %q", name)

--- a/tests/examples/threshold_oracle.rs
+++ b/tests/examples/threshold_oracle.rs
@@ -66,7 +66,7 @@ fn test_threshold_oracle_constructor_array_is_one_grouped_input() {
 
     // The asm prologue still pushes one placeholder per element.
     let asm = crate::common::arkade_asm(&output, "attest");
-    for placeholder in ["<oracles_0>", "<oracles_1>", "<oracles_2>"] {
+    for placeholder in ["<oracles.0>", "<oracles.1>", "<oracles.2>"] {
         assert!(asm.contains(placeholder), "missing {placeholder} in: {asm}");
     }
 }
@@ -114,20 +114,20 @@ fn test_threshold_oracle_array_indexing_in_loop() {
 
     let asm_str = arkade_asm(&output, "attest");
 
-    // When loop unrolls, oracles[i] should become <oracles_0>, <oracles_1>, <oracles_2>
+    // When loop unrolls, oracles[i] should become <oracles.0>, <oracles.1>, <oracles.2>
     assert!(
-        asm_str.contains("<oracles_0>"),
-        "Missing <oracles_0> in assembly (from oracles[0]). ASM: {}",
+        asm_str.contains("<oracles.0>"),
+        "Missing <oracles.0> in assembly (from oracles[0]). ASM: {}",
         asm_str
     );
     assert!(
-        asm_str.contains("<oracles_1>"),
-        "Missing <oracles_1> in assembly (from oracles[1]). ASM: {}",
+        asm_str.contains("<oracles.1>"),
+        "Missing <oracles.1> in assembly (from oracles[1]). ASM: {}",
         asm_str
     );
     assert!(
-        asm_str.contains("<oracles_2>"),
-        "Missing <oracles_2> in assembly (from oracles[2]). ASM: {}",
+        asm_str.contains("<oracles.2>"),
+        "Missing <oracles.2> in assembly (from oracles[2]). ASM: {}",
         asm_str
     );
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -30,6 +30,8 @@ mod opcode_functions;
 mod packet_primitives;
 #[path = "features/static_arrays.rs"]
 mod static_arrays;
+#[path = "features/structs.rs"]
+mod structs;
 #[path = "features/symbolic_stack.rs"]
 mod symbolic_stack;
 #[path = "features/tapscript_abi.rs"]

--- a/tests/features/asset_introspection.rs
+++ b/tests/features/asset_introspection.rs
@@ -1,7 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
     OP_INSPECTINASSETAT, OP_INSPECTINASSETCOUNT, OP_INSPECTOUTASSETAT, OP_INSPECTOUTASSETCOUNT,
-    OP_NIP,
+    OP_NIP, OP_SWAP,
 };
 
 /// Test asset count and indexed asset access opcodes
@@ -71,23 +71,23 @@ fn test_asset_at_amount_parsing() {
 }
 
 #[test]
-fn test_asset_at_assetid_cannot_be_bound_as_one_value() {
+fn test_asset_at_assetid_returns_struct() {
     let code = r#"
         contract AssetIdInspector(pubkey owner, bytes32 expectedTxid) {
             function checkAssetId(signature ownerSig) {
                 require(checkSig(ownerSig, owner));
                 let assetId = tx.outputs[0].assets[0].assetId;
+                require(assetId.txid == expectedTxid);
+                require(assetId.gidx >= 0);
+                require(tx.outputs[0].assets.lookup(assetId.txid, assetId.gidx) >= 0);
             }
         }
     "#;
 
-    let error = compile(code)
-        .expect_err("assetId is a two-item value")
-        .to_string();
-    assert!(
-        error.contains("expression produces 2 stack items"),
-        "assetId binding must be rejected: {error}"
-    );
+    let output = compile(code).expect("assetId returns an AssetId struct");
+    let asm = crate::common::arkade_asm_tokens(&output, "checkAssetId");
+    assert!(asm.iter().any(|token| token == OP_INSPECTOUTASSETAT));
+    assert!(asm.iter().any(|token| token == OP_SWAP));
 }
 
 #[test]

--- a/tests/features/contract_import_instantiation.rs
+++ b/tests/features/contract_import_instantiation.rs
@@ -448,7 +448,7 @@ contract Forwarder(pubkey[3] owners) {
         .expect("VTXO placeholder");
     assert_eq!(
         placeholder,
-        "<VTXO:ThresholdOracle(<owners_0>,<owners_1>,<owners_2>)>"
+        "<VTXO:ThresholdOracle(<owners.0>,<owners.1>,<owners.2>)>"
     );
 }
 

--- a/tests/features/group_properties.rs
+++ b/tests/features/group_properties.rs
@@ -2,31 +2,32 @@ use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
     OP_0, OP_1, OP_DROP, OP_FINDASSETGROUPBYASSETID, OP_INSPECTASSETGROUPASSETID,
     OP_INSPECTASSETGROUPCTRL, OP_INSPECTASSETGROUPMETADATAHASH, OP_INSPECTASSETGROUPNUM,
-    OP_INSPECTASSETGROUPSUM, OP_SUB, OP_TXID,
+    OP_INSPECTASSETGROUPSUM, OP_SUB, OP_SWAP, OP_TXID,
 };
 
 use crate::common::arkade_asm;
 
-/// Test that group.assetId emits OP_INSPECTASSETGROUPASSETID
+/// Test that group.assetId returns an AssetId struct.
 #[test]
-fn test_group_asset_id_cannot_be_compared_as_one_value() {
+fn test_group_asset_id_returns_struct() {
     let code = r#"
-        contract AssetIdTest(bytes32 tokenAssetIdTxid, int tokenAssetIdGidx, bytes32 expectedAssetId) {
+        contract AssetIdTest(bytes32 tokenAssetIdTxid, int tokenAssetIdGidx) {
             function checkAssetId(signature ownerSig, pubkey owner) {
                 require(checkSig(ownerSig, owner));
                 let tokenGroup = tx.assetGroups.find(tokenAssetIdTxid, tokenAssetIdGidx);
-                require(tokenGroup.assetId == expectedAssetId, "asset id mismatch");
+                AssetId id = tokenGroup.assetId;
+                require(id.txid == tokenAssetIdTxid, "asset txid mismatch");
+                require(id.gidx == tokenAssetIdGidx, "asset gidx mismatch");
+                let sameGroup = tx.assetGroups.find(id.txid, id.gidx);
+                require(sameGroup == tokenGroup);
             }
         }
     "#;
 
-    let error = compile(code)
-        .expect_err("group assetId is a two-item value")
-        .to_string();
-    assert!(
-        error.contains("expression produces 2 stack items"),
-        "group assetId comparison must be rejected: {error}"
-    );
+    let output = compile(code).expect("group assetId returns an AssetId struct");
+    let asm = crate::common::arkade_asm_tokens(&output, "checkAssetId");
+    assert!(asm.iter().any(|token| token == OP_INSPECTASSETGROUPASSETID));
+    assert!(asm.iter().any(|token| token == OP_SWAP));
 }
 
 /// Test that group.isFresh emits the correct opcode sequence:

--- a/tests/features/io_introspection.rs
+++ b/tests/features/io_introspection.rs
@@ -1,7 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_INSPECTINPUTSCRIPTPUBKEY, OP_INSPECTINPUTSEQUENCE, OP_INSPECTINPUTVALUE,
-    OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE,
+    OP_INSPECTINPUTOUTPOINT, OP_INSPECTINPUTSCRIPTPUBKEY, OP_INSPECTINPUTSEQUENCE,
+    OP_INSPECTINPUTVALUE, OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE, OP_SWAP,
 };
 
 /// Test input introspection opcodes
@@ -87,23 +87,24 @@ fn test_input_sequence() {
 }
 
 #[test]
-fn test_input_outpoint_cannot_be_compared_as_one_value() {
+fn test_input_outpoint_returns_struct() {
     let code = r#"
-        contract OutpointChecker(pubkey owner, bytes32 expectedOutpoint) {
-            function checkOutpoint(signature ownerSig) {
+        contract OutpointChecker(pubkey owner, bytes32 expectedTxid, int expectedVout) {
+            function checkOutpoint(signature ownerSig, int inputIndex) {
                 require(checkSig(ownerSig, owner));
-                require(tx.inputs[0].outpoint == expectedOutpoint);
+                let outpoint = tx.inputs[inputIndex].outpoint;
+                Outpoint current = tx.input.current.outpoint;
+                require(outpoint.txid == expectedTxid);
+                require(outpoint.vout == expectedVout);
+                require(current.vout >= 0);
             }
         }
     "#;
 
-    let error = compile(code)
-        .expect_err("outpoint is a two-item value")
-        .to_string();
-    assert!(
-        error.contains("outpoint inspection produces 2 stack items"),
-        "outpoint comparison must be rejected: {error}"
-    );
+    let output = compile(code).expect("outpoint returns an Outpoint struct");
+    let asm = crate::common::arkade_asm_tokens(&output, "checkOutpoint");
+    assert!(asm.iter().any(|token| token == OP_INSPECTINPUTOUTPOINT));
+    assert!(asm.iter().any(|token| token == OP_SWAP));
 }
 
 /// Test output introspection opcodes

--- a/tests/features/io_introspection.rs
+++ b/tests/features/io_introspection.rs
@@ -107,6 +107,27 @@ fn test_input_outpoint_returns_struct() {
     assert!(asm.iter().any(|token| token == OP_SWAP));
 }
 
+#[test]
+fn test_input_outpoint_cannot_be_compared_as_a_scalar() {
+    let error = compile(
+        r#"
+        contract OutpointChecker() {
+            function checkOutpoint() {
+                let expected = tx.input.current.outpoint;
+                require(tx.inputs[0].outpoint == expected);
+            }
+        }
+    "#,
+    )
+    .expect_err("outpoint equality is a composite comparison")
+    .to_string();
+
+    assert!(
+        error.contains("struct expressions are composite values"),
+        "{error}"
+    );
+}
+
 /// Test output introspection opcodes
 #[test]
 fn test_output_value() {

--- a/tests/features/no_shadowing.rs
+++ b/tests/features/no_shadowing.rs
@@ -175,8 +175,7 @@ contract Demo(pubkey[3] ks) {
 }
 
 #[test]
-fn rejects_array_element_colliding_with_scalar_param() {
-    // Constructor `int[3] xs` -> xs_0, xs_1, xs_2 ; function `int xs_0` -> xs_0.
+fn dotted_array_elements_do_not_collide_with_scalar_params() {
     let src = r#"
 contract Demo(int[3] xs) {
   function f(int xs_0) {
@@ -184,55 +183,11 @@ contract Demo(int[3] xs) {
   }
 }
 "#;
-    let err = compile(src)
-        .expect_err("expected a namespace collision error")
-        .to_string();
-    assert!(
-        err.contains("collide in the emitted namespace"),
-        "unexpected error: {err}"
-    );
+    compile(src).expect("xs.0 and xs_0 are distinct placeholder names");
 }
 
 #[test]
-fn flattened_abi_names_do_not_alias_array_elements() {
-    let cases = [
-        r#"
-contract Demo(int[3] xs) {
-  function f() {
-    require(xs_0 >= 1);
-  }
-}
-"#,
-        r#"
-contract Demo() {
-  function f(int[3] xs) {
-    xs_0 = 5;
-    require(xs[0] >= 1);
-  }
-}
-"#,
-        r#"
-contract Demo(pubkey[3] keys) {
-  function f(signature sig, bytes32 msg) {
-    require(checkSigFromStack(sig, keys_0, msg));
-  }
-}
-"#,
-    ];
-
-    for source in cases {
-        let error = compile(source)
-            .expect_err("flattened ABI name must not resolve as an array element")
-            .to_string();
-        assert!(
-            error.contains("undefined") || error.contains("undeclared"),
-            "unexpected error: {error}"
-        );
-    }
-}
-
-#[test]
-fn source_bindings_can_reuse_flattened_abi_names() {
+fn underscore_names_remain_regular_source_bindings() {
     let source = r#"
 contract Demo(int[3] xs) {
   function f() {
@@ -251,24 +206,21 @@ contract Demo(int[3] xs) {
 }
 
 #[test]
-fn rejects_tapscript_array_expansion_collisions() {
-    // Tapscript inputs cannot be arrays, so the collision can only come from a
-    // constructor array expanding onto a declared tapscript input name.
-    let error = compile(
+fn dotted_array_elements_do_not_collide_with_tapscript_inputs() {
+    let output = compile(
         r#"
-contract Demo(pubkey[3] owners) {
-  function leaf(signature sig, pubkey owners_0) tapscript {
-    require(checkSig(sig, owners_0));
+contract Demo(pubkey[3] owners, int exitDelay) {
+  function unilateral(signature arraySig, signature scalarSig, pubkey owners_0) tapscript {
+    require(older(exitDelay));
+    require(checkMultisig([owners[0], owners_0], [arraySig, scalarSig], 2));
   }
 }
 "#,
     )
-    .expect_err("expanded tapscript names must not collide")
-    .to_string();
-    assert!(
-        error.contains("collide in the emitted namespace"),
-        "unexpected error: {error}"
-    );
+    .expect("owners.0 and owners_0 are distinct placeholder names");
+    let asm = &output.functions[0].leaves[0].asm;
+    assert!(asm.contains(&"<owners.0>".to_string()));
+    assert!(asm.contains(&"<owners_0>".to_string()));
 }
 
 #[test]

--- a/tests/features/no_shadowing.rs
+++ b/tests/features/no_shadowing.rs
@@ -248,3 +248,23 @@ contract Demo(pubkey[3] ks) {
     let result = compile(src);
     assert!(result.is_ok(), "expected clean compile: {:?}", result.err());
 }
+
+#[test]
+fn rejects_tapscript_input_shadowing_constructor_param() {
+    let err = compile(
+        r#"
+contract Demo(pubkey owner, int exitDelay) {
+  function unilateral(signature sig, pubkey owner) tapscript {
+    require(older(exitDelay));
+    require(checkSig(sig, owner));
+  }
+}
+"#,
+    )
+    .expect_err("expected a tapscript shadowing error")
+    .to_string();
+    assert!(
+        err.contains("input 'owner' in tapscript 'unilateral' shadows constructor parameter"),
+        "unexpected error: {err}"
+    );
+}

--- a/tests/features/opcode_functions.rs
+++ b/tests/features/opcode_functions.rs
@@ -300,6 +300,27 @@ fn test_ec_mul_infers_point_type() {
 }
 
 #[test]
+fn test_inferred_point_fields_keep_their_types_during_concat_rewrite() {
+    let error = compile(
+        r#"
+        contract EllipticCurve(int curveId) {
+            function multiply(int x, int y, int scalar, bytes suffix) {
+                let result = ecMul(x, y, scalar, curveId);
+                require(result.x + suffix == suffix);
+            }
+        }
+    "#,
+    )
+    .expect_err("numeric ECPoint field needs an explicit byte width")
+    .to_string();
+
+    assert!(
+        error.contains("cannot concatenate bytes with the left `int` operand"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn test_ec_pairing() {
     let code = r#"
         contract EllipticCurve(int curveId) {

--- a/tests/features/opcode_functions.rs
+++ b/tests/features/opcode_functions.rs
@@ -1,8 +1,8 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_0, OP_1, OP_ADD, OP_CAT, OP_CHECKSIGFROMSTACK, OP_DIGEST, OP_ECMULSCALARVERIFY,
-    OP_ECPAIRING, OP_MODEXP, OP_NEGATE, OP_PICK, OP_SHA256FINALIZE, OP_SHA256INITIALIZE,
-    OP_SHA256UPDATE, OP_SIGHASH, OP_SUB, OP_TWEAKVERIFY,
+    OP_0, OP_1, OP_ADD, OP_CAT, OP_CHECKSIGFROMSTACK, OP_DIGEST, OP_ECADD, OP_ECMUL,
+    OP_ECMULSCALARVERIFY, OP_ECPAIRING, OP_MODEXP, OP_NEGATE, OP_PICK, OP_SHA256FINALIZE,
+    OP_SHA256INITIALIZE, OP_SHA256UPDATE, OP_SIGHASH, OP_SUB, OP_SWAP, OP_TWEAKVERIFY,
 };
 
 fn contains_tokens(asm: &[String], expected: &[&str]) -> bool {
@@ -239,42 +239,63 @@ fn test_mod_exp() {
 // ─── Elliptic Curve ────────────────────────────────────────────────────
 
 #[test]
-fn test_ec_add_cannot_be_bound_as_one_value() {
+fn test_ec_add_returns_typed_point() {
     let code = r#"
         contract EllipticCurve(int curveId) {
             function add(int x1, int y1, int x2, int y2) {
-                let result = ecAdd(x1, y1, x2, y2, curveId);
-                require(true);
+                ECPoint result = ecAdd(x1, y1, x2, y2, curveId);
+                require(result.x >= 0);
+                require(result.y >= 0);
             }
         }
     "#;
 
-    let error = compile(code)
-        .expect_err("ecAdd produces a composite value")
-        .to_string();
+    let output = compile(code).expect("ecAdd returns ECPoint");
+    let asm = crate::common::arkade_asm_tokens(&output, "add");
     assert!(
-        error.contains("expression produces 2 stack items"),
-        "ecAdd binding must be rejected: {error}"
+        contains_tokens(&asm, &[OP_ECADD, OP_SWAP, OP_0, OP_PICK]),
+        "EC point output must be normalized to struct field order: {asm:?}"
     );
 }
 
 #[test]
-fn test_ec_mul_cannot_be_bound_as_one_value() {
+fn test_native_result_type_must_match_declaration() {
+    let error = compile(
+        r#"
+        contract EllipticCurve(int curveId) {
+            function add(int x1, int y1, int x2, int y2) {
+                AssetId result = ecAdd(x1, y1, x2, y2, curveId);
+                require(result.gidx >= 0);
+            }
+        }
+    "#,
+    )
+    .expect_err("ECPoint cannot initialize AssetId")
+    .to_string();
+
+    assert!(
+        error.contains("declares type 'AssetId' but initializer has type 'ECPoint'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn test_ec_mul_infers_point_type() {
     let code = r#"
         contract EllipticCurve(int curveId) {
             function multiply(int x, int y, int scalar) {
                 let result = ecMul(x, y, scalar, curveId);
-                require(true);
+                require(result.x >= 0);
+                require(result.y >= 0);
             }
         }
     "#;
 
-    let error = compile(code)
-        .expect_err("ecMul produces a composite value")
-        .to_string();
+    let output = compile(code).expect("ecMul infers ECPoint");
+    let asm = crate::common::arkade_asm_tokens(&output, "multiply");
     assert!(
-        error.contains("expression produces 2 stack items"),
-        "ecMul binding must be rejected: {error}"
+        contains_tokens(&asm, &[OP_ECMUL, OP_SWAP]),
+        "EC point output must be normalized to struct field order: {asm:?}"
     );
 }
 

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -43,14 +43,14 @@ contract Sized(pubkey[2] owners) {
     );
 
     let asm = crate::common::arkade_asm(&output, "spend");
-    for placeholder in ["<owners_0>", "<owners_1>"] {
+    for placeholder in ["<owners.0>", "<owners.1>"] {
         assert!(
             asm.contains(placeholder),
             "constructor array expands to its declared size: {asm}"
         );
     }
     assert!(
-        !asm.contains("<owners_2>"),
+        !asm.contains("<owners.2>"),
         "constructor array must not expand past its declared size: {asm}"
     );
 }

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -269,3 +269,120 @@ contract C(Ambiguous value) {
 
     assert!(error.contains("value_a_b"), "{error}");
 }
+
+#[test]
+fn local_struct_literals_bind_and_assign_scalar_leaves() {
+    let output = compile(
+        r#"
+struct Signer { pubkey key; int weight; }
+struct Policy { Signer primary; int[2] limits; }
+contract C() {
+    function spend(pubkey key, int replacement) {
+        Policy policy = {
+            limits: [1, 2],
+            primary: { weight: 3, key: key }
+        };
+        policy.primary.weight = replacement;
+        policy.limits[1] = replacement;
+        require(policy.primary.weight == policy.limits[1]);
+    }
+}
+"#,
+    )
+    .expect("local struct leaves should behave like scalar locals");
+
+    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert!(asm.iter().all(|token| !token.contains("policy.")));
+}
+
+#[test]
+fn struct_literals_require_the_exact_declared_shape() {
+    let cases = [
+        (
+            r#"
+struct Point { int x; int y; }
+contract C() { function spend() { Point point = { x: 1 }; require(true); } }
+"#,
+            "missing field 'y'",
+        ),
+        (
+            r#"
+struct Point { int x; int y; }
+contract C() { function spend() { Point point = { x: 1, y: 2, z: 3 }; require(true); } }
+"#,
+            "unknown field 'z'",
+        ),
+        (
+            r#"
+struct Point { int x; int y; }
+contract C() { function spend() { Point point = { x: 1, x: 2, y: 3 }; require(true); } }
+"#,
+            "more than once",
+        ),
+        (
+            r#"
+struct Values { int[2] items; }
+contract C() { function spend() { Values values = { items: [1] }; require(true); } }
+"#,
+            "declares 2 elements",
+        ),
+        (
+            r#"
+struct Point { int x; int y; }
+contract C() { function spend() { Point point = { x: true, y: 2 }; require(true); } }
+"#,
+            "has type 'bool', expected 'int'",
+        ),
+        (
+            r#"
+struct Point { int x; int y; }
+contract C() { function spend() { let point = { x: 1, y: 2 }; require(true); } }
+"#,
+            "needs a declared struct type",
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let error = compile(source).expect_err(expected).to_string();
+        assert!(error.contains(expected), "unexpected error: {error}");
+    }
+}
+
+#[test]
+fn whole_struct_copy_and_constructor_field_assignment_are_rejected() {
+    let copy = compile(
+        r#"
+struct Point { int x; int y; }
+contract C(Point initial) {
+    function spend() {
+        Point copied = initial;
+        require(copied.x == 1);
+    }
+}
+"#,
+    )
+    .expect_err("whole struct copy")
+    .to_string();
+    assert!(
+        copy.contains("must be initialized with a struct literal"),
+        "{copy}"
+    );
+
+    let mutation = compile(
+        r#"
+struct Point { int x; int y; }
+contract C(Point point) {
+    function spend(int next) {
+        point.x = next;
+        require(point.x == next);
+    }
+}
+"#,
+    )
+    .expect_err("constructor field mutation")
+    .to_string();
+    assert!(
+        mutation.contains("cannot assign to constructor parameter 'point.x'"),
+        "{mutation}"
+    );
+}

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -469,3 +469,107 @@ contract C(Point point) {
         "{mutation}"
     );
 }
+
+#[test]
+fn shared_nested_structs_are_validated_once() {
+    let mut source = String::from("struct S0 { Missing m; }\n");
+    for level in 1..=12 {
+        source.push_str(&format!(
+            "struct S{level} {{ S{prev} a; S{prev} b; }}\n",
+            prev = level - 1
+        ));
+    }
+    source.push_str("contract C(S12 q) { function f() { require(true); } }\n");
+
+    let error = compile(&source)
+        .expect_err("an unknown field type must be rejected")
+        .to_string();
+    assert_eq!(
+        error.matches("unknown type 'Missing'").count(),
+        1,
+        "expected one diagnostic per bad field, got: {error}"
+    );
+}
+
+#[test]
+fn whitespace_around_field_separators_is_ignored() {
+    compile(
+        r#"
+struct Policy { pubkey key; int weight; bytes32 txid; int gidx; }
+contract C(Policy policy) {
+    function spend(int amount) {
+        require(amount == policy . weight);
+        require(tx.outputs[0].assets.lookup(policy . txid, policy . gidx) >= 0);
+    }
+}
+"#,
+    )
+    .expect("interior whitespace in a field path is insignificant");
+}
+
+#[test]
+fn struct_fields_are_accepted_as_hash_and_timelock_operands() {
+    compile(
+        r#"
+struct Terms { bytes32 digest; int deadline; }
+contract C(Terms terms) {
+    function claim(bytes preimage) {
+        require(tx.time >= terms.deadline);
+        require(sha256(preimage) == terms.digest);
+    }
+}
+"#,
+    )
+    .expect("struct fields are valid hash and timelock operands");
+}
+
+#[test]
+fn native_result_structs_are_valid_parameter_types() {
+    let output = compile(
+        r#"
+contract C(AssetId expected) {
+    function spend(Outpoint previous, int vout) {
+        require(previous.vout == vout);
+        require(previous.txid == expected.txid);
+    }
+}
+"#,
+    )
+    .expect("native result structs flatten like any other struct");
+
+    assert_eq!(output.parameters[0].param_type, "AssetId");
+    let covenant = output.functions[0].arkade.as_ref().expect("covenant");
+    assert_eq!(covenant.inputs[0].param_type, "Outpoint");
+    assert_eq!(
+        &covenant.asm[..2],
+        ["<expected.gidx>", "<expected.txid>"],
+        "constructor leaves push in reverse flattened order"
+    );
+}
+
+#[test]
+fn a_field_named_length_outranks_the_array_length_form() {
+    let output = compile(
+        r#"
+struct Packet { int length; int[3] payload; }
+struct Wrapper { Packet length; }
+struct ArrayField { int[2] length; }
+contract C(Packet packet, Wrapper wrapper, ArrayField array) {
+    function spend(int expected) {
+        require(packet.length == expected);
+        require(packet.payload.length == 3);
+        require(packet.payload[0] == expected);
+        require(wrapper.length.length == expected);
+        require(array.length[0] == expected);
+    }
+}
+"#,
+    )
+    .expect("a scalar field named `length` is a binding, not an array length");
+
+    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert!(
+        asm.iter().any(|token| token == "<packet.length>"),
+        "the field must be read from its own stack leaf: {asm:?}"
+    );
+}

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -142,10 +142,10 @@ contract Vault(Policy policy) {
     assert_eq!(
         &arkade.asm[..4],
         [
-            "<policy_limits_1>",
-            "<policy_limits_0>",
-            "<policy_primary_weight>",
-            "<policy_primary_key>",
+            "<policy.limits.1>",
+            "<policy.limits.0>",
+            "<policy.primary.weight>",
+            "<policy.primary.key>",
         ]
     );
     assert!(arkade.asm.iter().any(|token| token == OP_CHECKSIGFROMSTACK));
@@ -206,7 +206,7 @@ contract C(Point point) {
         .as_ref()
         .expect("covenant")
         .asm
-        .contains(&"<VTXO:C(<point_x>,<point_y>)>".to_string()));
+        .contains(&"<VTXO:C(<point.x>,<point.y>)>".to_string()));
 }
 
 #[test]
@@ -225,8 +225,8 @@ contract C(Owner owner) {
     .expect("scalar constructor fields in tapscript");
 
     let asm = &output.functions[0].leaves[0].asm;
-    assert!(asm.contains(&"<owner_exit>".to_string()));
-    assert!(asm.contains(&"<owner_key>".to_string()));
+    assert!(asm.contains(&"<owner.exit>".to_string()));
+    assert!(asm.contains(&"<owner.key>".to_string()));
     assert!(asm.contains(&OP_CHECKSIG.to_string()));
 }
 
@@ -254,8 +254,8 @@ contract C(Values values) {
 }
 
 #[test]
-fn flattened_struct_names_cannot_collide() {
-    let error = compile(
+fn dotted_paths_distinguish_underscores_from_nesting() {
+    let output = compile(
         r#"
 struct Inner { int b; }
 struct Ambiguous { int a_b; Inner a; }
@@ -264,10 +264,12 @@ contract C(Ambiguous value) {
 }
 "#,
     )
-    .expect_err("flattened fields collide")
-    .to_string();
+    .expect("dotted field paths are unambiguous");
 
-    assert!(error.contains("value_a_b"), "{error}");
+    assert_eq!(
+        &output.functions[0].arkade.as_ref().expect("covenant").asm[..2],
+        ["<value.a.b>", "<value.a_b>"]
+    );
 }
 
 #[test]

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -84,6 +84,13 @@ contract C(Pair pair) { function spend() { require(true); } }
 "#,
             "duplicate field 'value'",
         ),
+        (
+            r#"
+struct AssetId { bytes32 txid; int gidx; }
+contract C() { function spend() { require(true); } }
+"#,
+            "collides with a built-in type",
+        ),
     ];
 
     for (source, expected) in cases {
@@ -365,10 +372,7 @@ contract C(Point initial) {
     )
     .expect_err("whole struct copy")
     .to_string();
-    assert!(
-        copy.contains("must be initialized with a struct literal"),
-        "{copy}"
-    );
+    assert!(copy.contains("matching struct value"), "{copy}");
 
     let mutation = compile(
         r#"

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,4 +1,5 @@
 use arkade_compiler::compile;
+use arkade_compiler::opcodes::{OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_LESSTHAN};
 
 #[test]
 fn struct_definitions_are_preserved_in_the_artifact() {
@@ -107,4 +108,164 @@ contract C(pubkey owner) {
     .to_string();
 
     assert!(error.contains("struct witnesses are not supported"));
+}
+
+#[test]
+fn nested_struct_parameters_flatten_and_fields_read_by_stack_depth() {
+    let output = compile(
+        r#"
+struct Signer {
+    pubkey key;
+    int weight;
+}
+
+struct Policy {
+    Signer primary;
+    int[2] limits;
+}
+
+contract Vault(Policy policy) {
+    function spend(Policy candidate, signature sig, bytes32 message) {
+        require(checkSigFromStack(sig, policy.primary.key, message));
+        require(candidate.limits[1] >= policy.primary.weight);
+        require(policy.limits.length == 2);
+    }
+}
+"#,
+    )
+    .expect("nested struct fields should compile");
+
+    assert_eq!(output.parameters[0].param_type, "Policy");
+    let arkade = output.functions[0].arkade.as_ref().expect("covenant");
+    assert_eq!(arkade.inputs[0].name, "candidate");
+    assert_eq!(arkade.inputs[0].param_type, "Policy");
+    assert_eq!(
+        &arkade.asm[..4],
+        [
+            "<policy_limits_1>",
+            "<policy_limits_0>",
+            "<policy_primary_weight>",
+            "<policy_primary_key>",
+        ]
+    );
+    assert!(arkade.asm.iter().any(|token| token == OP_CHECKSIGFROMSTACK));
+    assert!(arkade.asm[4..]
+        .iter()
+        .all(|token| !token.contains("policy.")));
+}
+
+#[test]
+fn unknown_fields_and_bare_struct_values_are_rejected() {
+    let unknown = compile(
+        r#"
+struct Point { int x; int y; }
+contract C(Point point) {
+    function spend() { require(point.z == 0); }
+}
+"#,
+    )
+    .expect_err("unknown field")
+    .to_string();
+    assert!(
+        unknown.contains("field 'point.z' is undefined"),
+        "{unknown}"
+    );
+
+    let composite = compile(
+        r#"
+struct Point { int x; int y; }
+contract C(Point point) {
+    function spend() { require(point == point); }
+}
+"#,
+    )
+    .expect_err("bare struct")
+    .to_string();
+    assert!(
+        composite.contains("struct expressions are composite values"),
+        "{composite}"
+    );
+}
+
+#[test]
+fn constructor_struct_arguments_expand_recursively() {
+    let output = compile(
+        r#"
+struct Point { int x; int y; }
+contract C(Point point) {
+    function renew() {
+        require(tx.outputs[0].scriptPubKey == new C(point));
+    }
+}
+"#,
+    )
+    .expect("whole constructor struct argument");
+
+    assert!(output.functions[0]
+        .arkade
+        .as_ref()
+        .expect("covenant")
+        .asm
+        .contains(&"<VTXO:C(<point_x>,<point_y>)>".to_string()));
+}
+
+#[test]
+fn constructor_struct_fields_are_available_to_tapscripts() {
+    let output = compile(
+        r#"
+struct Owner { pubkey key; int exit; }
+contract C(Owner owner) {
+    function exit(signature sig) tapscript {
+        require(older(owner.exit));
+        require(checkSig(sig, owner.key));
+    }
+}
+"#,
+    )
+    .expect("scalar constructor fields in tapscript");
+
+    let asm = &output.functions[0].leaves[0].asm;
+    assert!(asm.contains(&"<owner_exit>".to_string()));
+    assert!(asm.contains(&"<owner_key>".to_string()));
+    assert!(asm.contains(&OP_CHECKSIG.to_string()));
+}
+
+#[test]
+fn array_fields_support_runtime_indexing_and_loop_unrolling() {
+    let output = compile(
+        r#"
+struct Values { int[3] items; }
+contract C(Values values) {
+    function spend(int index, int expected) {
+        int total = 0;
+        for (i, value) in values.items {
+            total = total + value;
+        }
+        require(values.items[index] + total == expected);
+    }
+}
+"#,
+    )
+    .expect("array fields should retain array behavior");
+
+    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert!(asm.windows(2).any(|tokens| tokens == ["OP_3", OP_LESSTHAN]));
+    assert!(asm.iter().filter(|token| token.as_str() == OP_ADD).count() >= 4);
+}
+
+#[test]
+fn flattened_struct_names_cannot_collide() {
+    let error = compile(
+        r#"
+struct Inner { int b; }
+struct Ambiguous { int a_b; Inner a; }
+contract C(Ambiguous value) {
+    function spend() { require(true); }
+}
+"#,
+    )
+    .expect_err("flattened fields collide")
+    .to_string();
+
+    assert!(error.contains("value_a_b"), "{error}");
 }

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,0 +1,110 @@
+use arkade_compiler::compile;
+
+#[test]
+fn struct_definitions_are_preserved_in_the_artifact() {
+    let output = compile(
+        r#"
+struct Signer {
+    pubkey key;
+    int weight;
+}
+
+struct Policy {
+    Signer primary;
+    int[2] limits;
+}
+
+contract Vault(Policy policy) {
+    function spend() {
+        require(true);
+    }
+}
+"#,
+    )
+    .expect("struct declarations should compile");
+
+    assert_eq!(output.structs.len(), 2);
+    assert_eq!(output.structs[0].name, "Signer");
+    assert_eq!(output.structs[0].fields[0].name, "key");
+    assert_eq!(output.structs[1].fields[0].param_type, "Signer");
+    assert_eq!(output.parameters[0].param_type, "Policy");
+}
+
+#[test]
+fn forward_struct_references_are_allowed() {
+    compile(
+        r#"
+struct Outer {
+    Inner inner;
+}
+
+struct Inner {
+    int value;
+}
+
+contract Forward(Outer value) {
+    function spend() {
+        require(true);
+    }
+}
+"#,
+    )
+    .expect("struct layouts are resolved after parsing all definitions");
+}
+
+#[test]
+fn invalid_struct_layouts_are_rejected() {
+    let cases = [
+        (
+            r#"
+struct Bad { Missing value; }
+contract C(Bad value) { function spend() { require(true); } }
+"#,
+            "unknown type 'Missing'",
+        ),
+        (
+            r#"
+struct Node { Node child; }
+contract C(Node value) { function spend() { require(true); } }
+"#,
+            "recursive struct layout",
+        ),
+        (
+            r#"
+struct Item { int value; }
+contract C(Item[2] values) { function spend() { require(true); } }
+"#,
+            "arrays of structs are not supported",
+        ),
+        (
+            r#"
+struct Pair { int value; bool value; }
+contract C(Pair pair) { function spend() { require(true); } }
+"#,
+            "duplicate field 'value'",
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let error = compile(source).expect_err(expected).to_string();
+        assert!(error.contains(expected), "unexpected error: {error}");
+    }
+}
+
+#[test]
+fn struct_tapscript_inputs_are_rejected() {
+    let error = compile(
+        r#"
+struct Proof { bytes preimage; }
+contract C(pubkey owner) {
+    function exit(Proof proof, signature sig) tapscript {
+        require(checkSig(sig, owner));
+    }
+}
+"#,
+    )
+    .expect_err("struct tapscript witness")
+    .to_string();
+
+    assert!(error.contains("struct witnesses are not supported"));
+}

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,6 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTASSETGROUPASSETID, OP_LESSTHAN, OP_PICK,
+    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_EQUAL, OP_INSPECTASSETGROUPASSETID,
+    OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN, OP_PICK, OP_SWAP,
 };
 
 #[test]
@@ -240,6 +241,29 @@ contract C(Owner owner) {
 }
 
 #[test]
+fn composite_constructor_values_are_rejected_in_tapscripts() {
+    let error = compile(
+        r#"
+struct Delay { int blocks; }
+struct Policy { Delay exit; }
+contract C(Policy policy, pubkey owner) {
+    function exit(signature sig) tapscript {
+        require(older(policy.exit));
+        require(checkSig(sig, owner));
+    }
+}
+"#,
+    )
+    .expect_err("intermediate struct values are not tapscript operands")
+    .to_string();
+
+    assert!(
+        error.contains("timelock `policy.exit` is not a literal"),
+        "{error}"
+    );
+}
+
+#[test]
 fn array_fields_support_runtime_indexing_and_loop_unrolling() {
     let output = compile(
         r#"
@@ -321,6 +345,40 @@ contract C() {
 
     let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
     assert!(asm.iter().all(|token| !token.contains("policy.")));
+    assert!(asm.iter().filter(|token| *token == OP_PICK).count() >= 2);
+    assert!(asm.iter().any(|token| token == OP_EQUAL));
+}
+
+#[test]
+fn native_results_can_initialize_nested_struct_fields() {
+    let output = compile(
+        r#"
+struct Snapshot { Outpoint outpoint; int minimumVout; }
+contract C(Snapshot expected) {
+    function spend(int inputIndex) {
+        Snapshot snapshot = {
+            outpoint: tx.inputs[inputIndex].outpoint,
+            minimumVout: expected.minimumVout
+        };
+        require(snapshot.outpoint.vout >= expected.outpoint.vout);
+    }
+}
+"#,
+    )
+    .expect("native struct result nested in a user struct");
+
+    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert_eq!(
+        &asm[..3],
+        [
+            "<expected.minimumVout>",
+            "<expected.outpoint.vout>",
+            "<expected.outpoint.txid>",
+        ]
+    );
+    assert!(asm.iter().any(|token| token == OP_INSPECTINPUTOUTPOINT));
+    assert!(asm.iter().any(|token| token == OP_SWAP));
+    assert!(asm.iter().filter(|token| *token == OP_PICK).count() >= 2);
 }
 
 #[test]

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,5 +1,7 @@
 use arkade_compiler::compile;
-use arkade_compiler::opcodes::{OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_LESSTHAN};
+use arkade_compiler::opcodes::{
+    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTASSETGROUPASSETID, OP_LESSTHAN, OP_PICK,
+};
 
 #[test]
 fn struct_definitions_are_preserved_in_the_artifact() {
@@ -277,6 +279,23 @@ contract C(Ambiguous value) {
         &output.functions[0].arkade.as_ref().expect("covenant").asm[..2],
         ["<value.a.b>", "<value.a_b>"]
     );
+}
+
+#[test]
+fn group_property_names_are_valid_struct_fields() {
+    let output = compile(
+        r#"
+struct Token { int assetId; }
+contract C(Token token) {
+    function spend() { require(token.assetId >= 0); }
+}
+"#,
+    )
+    .expect("asset-group property names should remain valid struct fields");
+
+    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert!(asm.iter().all(|token| token != OP_INSPECTASSETGROUPASSETID));
+    assert!(asm.iter().any(|token| token == OP_PICK));
 }
 
 #[test]

--- a/tests/features/validation_error.rs
+++ b/tests/features/validation_error.rs
@@ -338,3 +338,21 @@ fn all_validation_errors_have_non_empty_messages() {
         );
     }
 }
+
+#[test]
+fn undefined_byte_operands_are_caught_by_validation() {
+    let error = compile(
+        r#"
+contract Demo(bytes32 expected) {
+    function spend() {
+        require(reverseBytes(missing) == expected);
+    }
+}"#,
+    )
+    .expect_err("an undefined byte operand must be rejected")
+    .to_string();
+    assert!(
+        error.contains("function 'spend': binding 'missing' is undefined"),
+        "expected a validation diagnostic, got: {error}"
+    );
+}


### PR DESCRIPTION
## Summary

- add named struct declarations with recursive scalar-leaf stack layouts
- support nested constructor and covenant inputs, local struct literals, field reads and scalar-leaf assignments
- use unambiguous dotted artifact paths and expose struct schemas to bindgen and playground clients
- represent fixed-width multi-value builtin results as native `AssetId`, `Outpoint`, and `ECPoint` structs
- add comprehensive compiler, bindgen, playground, and emulator E2E coverage

## Impact

Contracts can group related values into named, nestable types while retaining the existing one-stack-item-per-scalar ABI. Artifact consumers can recursively flatten these values from the published schema, and fixed-width builtin results can now be handled as typed values instead of loose stack outputs.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `./playground/build.sh`
- `./scripts/e2e.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named structs, nested structs, fixed-size arrays, struct literals, and nested property access.
  * Added native multi-value results for assets, outpoints, and elliptic-curve points.
  * Added the StructVault example and playground support for struct syntax and completions.
  * Go and TypeScript bindings now preserve distinct nested and underscored field names.
* **Bug Fixes**
  * Improved validation for invalid, incomplete, recursive, or unsupported layouts.
  * Standardized flattened array and struct field paths with dotted notation.
* **Documentation**
  * Expanded language and ABI references with struct and array usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->