### PR TITLE
Add MiningMarginVault: stateful mining-margin two-token vault (hashrate derivatives)

### DIFF
--- a/examples/mining_margin/mining_margin.md
+++ b/examples/mining_margin/mining_margin.md
@@ -1,0 +1,73 @@
+# Mining Margin Vault
+
+A liquid market for the economics of running a machine, so nobody has to run
+the machine to hold them.
+
+Bitcoin is over-provisioned: fleets of old-generation ASICs stay racked as a
+bet on hashprice, and PPA / interconnect capacity is hoarded for its option
+value while AI demand bids for the same electrons. All of that exposure is
+held physically — by burning energy — because there is no financial
+instrument to hold it instead. This contract is that instrument.
+
+## The primitive
+
+One series per `(oracle, hashTicker, powerTicker, cap, maturity)`. A contract
+unit is a fixed quantity of hashrate-time at a reference efficiency (e.g.
+1 PH·day at 20 J/TH), fixed off-chain. At maturity the oracle signs two
+fixings, both denominated in sats per unit: `hashPrice` (what the unit
+earned) and `powerCost` (what its electricity cost). The settled value is the
+**mining margin**:
+
+```
+margin = clamp(hashPrice − powerCost, 0, cap)
+```
+
+Depositing `cap` sats mints a pair of fungible Arkade Assets:
+
+| Leg | Pays at maturity | Financially is |
+|---|---|---|
+| RIG | `margin` | a machine on a PPA, without the machine |
+| GRID | `cap − margin` | the same watts sold elsewhere instead |
+
+The clamp at zero is the curtailment right — a rig is never forced to mine at
+a loss. The two legs always sum to `cap`, so the vault is exactly
+collateralized at every fixing: no margin calls, no liquidations, no pro-rata
+pots, no division. Legs trade like any asset via Arkade intents; the premium
+never touches the contract.
+
+## Positions
+
+- **Sell fleet exposure** — a miner shorts RIG (mint pairs, keep GRID, sell
+  RIG) sized to the fleet. The hedge replaces the machines: exposure stays,
+  metal can be unplugged.
+- **Fleet wind-down** — list a series at an old generation's efficiency. When
+  its RIG trades near zero, the market has priced the zombie fleet's option
+  value; the operator sells it and decommissions instead of idling rigs hot.
+- **PPA carve-out** — an energy holder leasing capacity to an AI datacenter
+  buys RIG to stay long mining economics while the electrons go to compute;
+  GRID is the financial form of "send the power elsewhere".
+- **Synthetic ASIC** — buy RIG across maturities: a strip of mining margin is
+  a machine's revenue stream with no silicon, power draw, or e-waste.
+
+## Lifecycle
+
+- `issue(amount)` — permissionless: escrow `amount × cap`, mint paired
+  RIG + GRID.
+- `burnPair(amount)` — permissionless unwind: burn a matched pair, take the
+  escrow back.
+- `redeemRig` / `redeemGrid(amount, fixings…)` — burn a leg against the two
+  oracle fixings for its exact side of the escrow, in any order.
+
+The vault is stateless: supply lives in the asset groups, collateral in the
+vault balance, and settlement is re-verified per redemption. Both fixings are
+signed over exactly `maturity`, so the signature itself is the maturity gate —
+no timelocks anywhere.
+
+## Trust assumptions
+
+- The oracle signs at most one price per `(ticker, maturity)`; two signatures
+  over the same stamp are provable equivocation.
+- If the oracle never publishes, legs cannot redeem (matched pairs can still
+  `burnPair` out) — holders bear oracle liveness.
+- Per-holder exit uses the off-chain recurrent exit tree parameterized by
+  `exit`, as in the other pooled examples.

--- a/examples/mining_margin/mining_margin.md
+++ b/examples/mining_margin/mining_margin.md
@@ -1,79 +1,135 @@
 # Mining Margin Vault
 
-A liquid market for the economics of running a machine, so nobody has to run
-the machine to hold them.
+A market price for the economics of running a machine.
 
-Bitcoin is over-provisioned: fleets of old-generation ASICs stay racked as a
-bet on hashprice, and PPA / interconnect capacity is hoarded for its option
-value while AI demand bids for the same electrons. All of that exposure is
-held physically — by burning energy — because there is no financial
-instrument to hold it instead. This contract is that instrument.
+Bitcoin's capacity decisions are made through lumpy physical channels:
+old-generation fleets stay racked as an unpriced bet on the margin, and PPA /
+interconnect capacity is hoarded for option value while AI demand bids for
+the same electrons. Hashprice alone trades (NDF markets exist); the **mining
+margin** — hashprice minus power, the actual P&L line of a machine — has no
+non-custodial, fully-collateralized, fungible instrument. This contract is
+that instrument.
+
+> **Status**: dynamic contract transitions are disabled in the compiler, so
+> the five state-transition functions ship commented out and only a
+> `disabled()` placeholder compiles — the artifact has no satisfiable spend
+> path and must not be deployed. A CI guard test keeps the commented design
+> compiling-modulo-the-gate and fires when transitions are restored.
+
+## What this can and cannot do
+
+Honest mechanism first. A cash-settled derivative cannot reduce Bitcoin's
+aggregate energy burn: the difficulty adjustment re-pins mining spend to
+protocol revenue whoever holds the paper, and hedging historically *lowers*
+producers' cost of capital. What a margin price actually does:
+
+- **Prices the keep-vs-scrap decision.** A racked old-gen fleet is a call
+  option on the margin whose value is mostly time value — a number spot
+  hashprice and a power bill cannot supply. Traded RIG at that fleet's
+  efficiency *is* that number; when it stays below carrying cost across the
+  strip, decommissioning is rational (the harvest is avoided carry plus
+  salvage, not the sale proceeds).
+- **Turns idle-hot fleets into price-responsive dispatch.** A miner who has
+  locked the margin has no reason to mine through negative spreads: hedged
+  metal runs in the spike hours and curtails otherwise.
+- **Accelerates efficiency turnover.** Retiring high-J/TH hardware lets the
+  same revenue-pinned security spend buy more hashes from fewer joules.
+- **Keeps AI-pivoting power owners financially long mining.** A carve-out
+  buyer holds margin exposure while the electrons go to compute — financial
+  exposure, not hashrate; the network's security is physical.
 
 ## The primitive
 
 One series per `(oracle, hashTicker, powerTicker, cap, maturity)`. A contract
 unit is a fixed quantity of hashrate-time at a reference efficiency (e.g.
-1 PH·day at 20 J/TH), fixed off-chain. At maturity the oracle attests two
-fixings, both denominated in sats per unit: `hashPrice` (what the unit
-earned) and `powerCost` (what its electricity cost). The settled value is the
-**mining margin**:
+1 PH·day at 20 J/TH). Both fixings are **averaged (Asian) indices** over a
+window stated in the oracle spec and ending at maturity — the settlement form
+physical power markets use, because a point print on power is unrepresentative
+and gameable. The ticker preimage must encode unit, reference efficiency,
+averaging window, and hub, so a series is self-describing. The settled value:
 
 ```
 margin = clamp(hashPrice − powerCost, 0, cap)
 ```
 
+Both fixings are signed over exactly `maturity`: one message slot per
+`(ticker, maturity)`, so a fixing cannot be replayed across series, there is
+no timestamp window for a settler to shop in, and two prices for one slot are
+provable oracle equivocation. Negative power fixings are admitted — routine
+at volatile hubs.
+
 Depositing `cap` sats mints a pair of fungible Arkade Assets:
 
 | Leg | Pays at settlement | Financially is |
 |---|---|---|
-| RIG | `margin` | a machine on a PPA, without the machine |
-| GRID | `cap − margin` | the same watts sold elsewhere instead |
+| RIG | `margin` | long a call spread on the margin |
+| GRID | `cap − margin` | a cap-sat escrow claim, short the same spread |
 
-The clamp at zero is the curtailment right — a rig is never forced to mine at
-a loss. The two legs always sum to `cap`, so the vault is exactly
-collateralized at every fixing: no margin calls, no liquidations. Legs trade
-like any asset via Arkade intents; the premium never touches the contract.
+RIG + GRID always equals cap, so the vault is exactly collateralized at every
+fixing — no margin calls, no liquidations. Note what the legs are *not*: GRID
+alone is not "the watts sold elsewhere" (that reading holds only as an
+overlay — e.g. a running miner holding GRID has locked power-sale economics);
+and RIG alone is not a machine — a machine is a strip of *hourly* curtailment
+options, worth more than a single averaged fixing near breakeven (Jensen), so
+machine replication takes a strip of maturities and keeps a known, one-sided,
+priceable basis.
 
 ## Positions
 
-- **Sell fleet exposure** — a miner shorts RIG (mint pairs, keep GRID, sell
-  RIG) sized to the fleet. The hedge replaces the machines: exposure stays,
-  metal can be unplugged.
-- **Fleet wind-down** — list a series at an old generation's efficiency. When
-  its RIG trades near zero, the market has priced the zombie fleet's option
-  value; the operator sells it and decommissions instead of idling rigs hot.
-- **PPA carve-out** — an energy holder leasing capacity to an AI datacenter
-  buys RIG to stay long mining economics while the electrons go to compute;
-  GRID is the financial form of "send the power elsewhere".
-- **Synthetic ASIC** — buy RIG across maturities: a strip of mining margin is
-  a machine's revenue stream with no silicon, power draw, or e-waste.
+- **Lock the margin (producer hedge).** Mint pairs, sell RIG, keep GRID,
+  keep operating: the book is premium + locked margin in every state, and the
+  rational dispatch is run-in-spikes, curtail otherwise. This — not
+  unplugging — is the flagship trade; a seller who unplugs holds a naked
+  short via GRID.
+- **Wind-down signal.** Compare traded RIG at the fleet's efficiency against
+  carrying cost across the strip. One near-zero series is not the test — a
+  near-breakeven fleet's hourly curtailment value exceeds any single averaged
+  fixing; the strip is the test.
+- **PPA carve-out.** An energy holder leasing capacity to an AI datacenter
+  buys RIG to stay long mining economics while the electrons go to compute.
+- **Synthetic ASIC.** A strip of RIG across maturities converges to a
+  machine's revenue stream up to intraday curtailment basis — and is short
+  the tail above `cap`.
+
+The natural short base is **merchant-power miners** (floating power cost).
+Miners on fixed-price PPAs already own the power leg contractually; for them
+a plain hashprice hedge composes more cleanly than a two-fixing margin
+product.
 
 ## Lifecycle
 
-Stateful two-token vault, following the hashprice option vault design: shares
-and pots are constructor state, updated by dynamic recreation on every spend.
-
 - `issue(amount)` — permissionless, pre-maturity: escrow `amount × cap`,
   mint paired RIG + GRID gated by the vault identity singleton.
-- `burnPair(amount)` — permissionless, pre-maturity unwind: burn a matched
-  pair, take the escrow back 1:1.
-- `settle(fixings…)` — permissionless, once: two attestations timestamped
-  within `±settleWindow` of maturity fix the margin and split the pot
-  (`rigPot = shares × margin`, `gridPot` the exact remainder — no division).
+- `burnPair(amount)` — permissionless **any time before settlement**: a
+  matched pair is worth exactly cap under every fixing, so the unwind stays
+  open after maturity and is the recovery path if the oracle never publishes.
+- `settle(fixings…)` — permissionless, once, at or after maturity (wall-clock
+  gated): the two maturity-stamped fixings set the margin and split the pot
+  exactly, no division.
 - `redeemRig` / `redeemGrid(amount)` — after settlement: burn a leg for a
-  pro-rata slice of its pot; pot and supply drain together, so the rate is
-  invariant under redemption order.
+  pro-rata slice of its pot. Floor division shifts sub-share remainders to
+  later redeemers (bounded; the final full-supply redemption sweeps exactly).
 
-> **Status**: state transitions need dynamic taproot reconstruction, which
-> the compiler currently disables; the transition functions ship commented
-> out (only a `disabled` placeholder compiles), matching the other stateful
-> examples. Uncomment them when dynamic contract transitions are restored.
+## Design trade-offs
+
+- **Hard cap.** `cap` is both payoff cap and per-pair escrow: trust-minimal
+  full collateralization, at the cost of truncating the tail above cap and
+  locking dead capital if cap is set wide. The hashprice USD vault (#57)
+  shows the decoupled alternative (`pairCollateral`) that trades tail credit
+  risk for capital efficiency.
+- **Sats numeraire.** Sats cancel BTC/USD out of the revenue leg, isolating
+  difficulty-and-fee risk; the power leg then embeds BTC/USD (a fiat-sticky
+  bill priced in sats). USD-account hedgers compose with BTC/USD instruments,
+  or a USD-quoted variant can follow #57's.
 
 ## Trust assumptions
 
-- The oracle attests one price per ticker inside the settlement window;
-  signing two different prices there is equivocation the market can observe.
-- If the oracle never attests inside the window, the vault cannot settle —
-  holders bear that liveness risk.
+- The oracle signs at most one price per `(ticker, maturity)` slot; two
+  signatures over one slot are provable equivocation.
+- If the oracle never publishes, matched pairs recover escrow via
+  `burnPair`; single-sided legs bear that liveness risk.
+- The identity singleton's genesis mints exactly one token — mint control
+  and the single-vault-UTXO model rest on it; every spend pins the vault at
+  input 0.
 - Per-holder exit uses the off-chain recurrent exit tree parameterized by
   `exit`, as in the other pooled examples.

--- a/examples/mining_margin/mining_margin.md
+++ b/examples/mining_margin/mining_margin.md
@@ -13,7 +13,7 @@ instrument to hold it instead. This contract is that instrument.
 
 One series per `(oracle, hashTicker, powerTicker, cap, maturity)`. A contract
 unit is a fixed quantity of hashrate-time at a reference efficiency (e.g.
-1 PH·day at 20 J/TH), fixed off-chain. At maturity the oracle signs two
+1 PH·day at 20 J/TH), fixed off-chain. At maturity the oracle attests two
 fixings, both denominated in sats per unit: `hashPrice` (what the unit
 earned) and `powerCost` (what its electricity cost). The settled value is the
 **mining margin**:
@@ -24,16 +24,15 @@ margin = clamp(hashPrice − powerCost, 0, cap)
 
 Depositing `cap` sats mints a pair of fungible Arkade Assets:
 
-| Leg | Pays at maturity | Financially is |
+| Leg | Pays at settlement | Financially is |
 |---|---|---|
 | RIG | `margin` | a machine on a PPA, without the machine |
 | GRID | `cap − margin` | the same watts sold elsewhere instead |
 
 The clamp at zero is the curtailment right — a rig is never forced to mine at
 a loss. The two legs always sum to `cap`, so the vault is exactly
-collateralized at every fixing: no margin calls, no liquidations, no pro-rata
-pots, no division. Legs trade like any asset via Arkade intents; the premium
-never touches the contract.
+collateralized at every fixing: no margin calls, no liquidations. Legs trade
+like any asset via Arkade intents; the premium never touches the contract.
 
 ## Positions
 
@@ -51,23 +50,30 @@ never touches the contract.
 
 ## Lifecycle
 
-- `issue(amount)` — permissionless: escrow `amount × cap`, mint paired
-  RIG + GRID.
-- `burnPair(amount)` — permissionless unwind: burn a matched pair, take the
-  escrow back.
-- `redeemRig` / `redeemGrid(amount, fixings…)` — burn a leg against the two
-  oracle fixings for its exact side of the escrow, in any order.
+Stateful two-token vault, following the hashprice option vault design: shares
+and pots are constructor state, updated by dynamic recreation on every spend.
 
-The vault is stateless: supply lives in the asset groups, collateral in the
-vault balance, and settlement is re-verified per redemption. Both fixings are
-signed over exactly `maturity`, so the signature itself is the maturity gate —
-no timelocks anywhere.
+- `issue(amount)` — permissionless, pre-maturity: escrow `amount × cap`,
+  mint paired RIG + GRID gated by the vault identity singleton.
+- `burnPair(amount)` — permissionless, pre-maturity unwind: burn a matched
+  pair, take the escrow back 1:1.
+- `settle(fixings…)` — permissionless, once: two attestations timestamped
+  within `±settleWindow` of maturity fix the margin and split the pot
+  (`rigPot = shares × margin`, `gridPot` the exact remainder — no division).
+- `redeemRig` / `redeemGrid(amount)` — after settlement: burn a leg for a
+  pro-rata slice of its pot; pot and supply drain together, so the rate is
+  invariant under redemption order.
+
+> **Status**: state transitions need dynamic taproot reconstruction, which
+> the compiler currently disables; the transition functions ship commented
+> out (only a `disabled` placeholder compiles), matching the other stateful
+> examples. Uncomment them when dynamic contract transitions are restored.
 
 ## Trust assumptions
 
-- The oracle signs at most one price per `(ticker, maturity)`; two signatures
-  over the same stamp are provable equivocation.
-- If the oracle never publishes, legs cannot redeem (matched pairs can still
-  `burnPair` out) — holders bear oracle liveness.
+- The oracle attests one price per ticker inside the settlement window;
+  signing two different prices there is equivocation the market can observe.
+- If the oracle never attests inside the window, the vault cannot settle —
+  holders bear that liveness risk.
 - Per-holder exit uses the off-chain recurrent exit tree parameterized by
   `exit`, as in the other pooled examples.

--- a/examples/mining_margin/mining_margin_vault.ark
+++ b/examples/mining_margin/mining_margin_vault.ark
@@ -1,0 +1,215 @@
+// MiningMarginVault Contract
+//
+// A stateless, fully-collateralized two-token vault on the MINING MARGIN —
+// what one contract unit of hashrate earns over the power it burns:
+//
+//   margin = clamp(hashPrice − powerCost, 0, cap)   sats per pair
+//
+// One vault per (oracle, hashTicker, powerTicker, cap, maturity) series. A
+// contract unit is a fixed quantity of hashrate-time at a reference machine
+// efficiency (e.g. 1 PH·day at 20 J/TH), set off-chain per series; the
+// hashprice fixing is the sats that unit earns and the power fixing is the
+// sats its electricity costs at the series' power hub.
+//
+// ── Two legs, one escrow ────────────────────────────────────────────────────
+//   Depositing `cap` sats mints one RIG + one GRID, both fungible Arkade
+//   Assets; burning a matched pair redeems the escrow 1:1. At maturity:
+//     RIG  pays margin          — a machine-on-a-PPA, without the machine.
+//     GRID pays cap − margin    — the same watts sold elsewhere instead.
+//   The clamp at zero is the curtailment right (a rig is never forced to mine
+//   at a loss); the clamp at cap bounds the writer's escrow. RIG + GRID always
+//   equals cap, so the vault is exact at every fixing: no margin calls, no
+//   pro-rata pots, and no division anywhere.
+//
+// ── Why it is stateless ─────────────────────────────────────────────────────
+//   The vault never records supply, pots, or a settled flag — constructor
+//   state is immutable and every spend recreates it verbatim. Supply lives in
+//   the asset groups, collateral lives in the vault balance (each spend is
+//   checked against tx.inputs[0].value), and settlement is re-verified per
+//   redemption from the oracle fixings. Because a pair is always worth
+//   exactly `cap` in aggregate, issue and burnPair are arbitrage-free at any
+//   time and need no clock at all.
+//
+// ── The fixing is the clock ─────────────────────────────────────────────────
+//   Both fixings must be signed over exactly `maturity`
+//   (msg = sha256(ticker || price(8) || maturity(8))); the oracle publishes
+//   them only once maturity arrives, so possession of a valid signature is
+//   the maturity gate — no CLTV, no wall-clock introspection. Trust
+//   assumptions: the oracle signs at most one price per (ticker, maturity) —
+//   two signatures over the same stamp are provable equivocation — and if it
+//   never publishes, redemption is stuck (holders bear oracle liveness, as in
+//   the other oracle-settled examples).
+//
+// ── Bounds ──────────────────────────────────────────────────────────────────
+//   issue caps amount at 2.1e15 / cap sats' worth, so amount × cap never
+//   exceeds total bitcoin supply; every later product (payouts, refunds) is
+//   bounded by sats actually escrowed, keeping all arithmetic inside int64.
+//
+// ── Exit model ──────────────────────────────────────────────────────────────
+//   A pooled vault cannot express per-holder unilateral exit as a single CSV
+//   leaf; `exit` parameterizes the off-chain recurrent exit tree (refreshed
+//   on every issue/burn), as in the other pooled examples.
+
+contract MiningMarginVault(
+  pubkey  oraclePk,        // signs both fixings
+  bytes32 hashTicker,      // e.g. sha256("HASHPRICE/BTC") — sats one unit earns
+  bytes32 powerTicker,     // e.g. sha256("POWER/ERCOT-WEST") — sats one unit's power costs
+  int     cap,             // sats per pair — margin cap and per-pair escrow
+  int     maturity,        // unix seconds; both fixings are stamped exactly with this
+  bytes32 rigIdTxid,       // RIG leg asset id — issuance txid
+  int     rigIdGidx,       // RIG leg asset id — issuance group index
+  bytes32 gridIdTxid,      // GRID leg asset id — issuance txid
+  int     gridIdGidx,      // GRID leg asset id — issuance group index
+  bytes32 contractIdTxid,  // vault identity singleton — genesis txid (mint control)
+  int     contractIdGidx,  // vault identity singleton — genesis group index
+  int     exit             // exit timelock in blocks (off-chain recurrent exit tree)
+) {
+
+  // ISSUE — permissionless. Deposit `amount × cap` sats; mint `amount` RIG +
+  // `amount` GRID to the depositor. Paired mint keeps the vault exact.
+  //   input[0]:  vault (holds the identity singleton)   input[1+]: depositor sats
+  //   output[0]: vault, value grown by the escrow       output[1]: both legs → depositor
+  function issue(int amount) {
+    require(amount > 0, "zero amount");
+    require(cap > 0, "empty band");
+    require(amount <= 2100000000000000 / cap, "exceeds sat supply");
+    require(this.activeInputIndex == 0, "vault must be input 0");
+    int deposit = amount * cap;
+
+    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+    require(rigGroup.delta == amount, "rig supply != amount");
+    require(rigGroup.controlIs(contractIdTxid, contractIdGidx), "wrong rig control");
+    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+    require(gridGroup.delta == amount, "grid supply != amount");
+    require(gridGroup.controlIs(contractIdTxid, contractIdGidx), "wrong grid control");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(tx.outputs[1].assets.lookup(rigIdTxid, rigIdGidx) == amount, "rig not delivered");
+    require(tx.outputs[1].assets.lookup(gridIdTxid, gridIdGidx) == amount, "grid not delivered");
+
+    require(
+      tx.outputs[0].scriptPubKey == new MiningMarginVault(
+        oraclePk, hashTicker, powerTicker, cap, maturity,
+        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
+        contractIdTxid, contractIdGidx, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= tx.inputs[0].value + deposit, "collateral not deposited");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+  }
+
+  // BURN PAIR — permissionless unwind. Return `amount` of BOTH legs, take the
+  // `amount × cap` escrow back. Burning the pair authenticates the holder; a
+  // single-sided holder exits by selling the leg via an Arkade intent.
+  //   output[0]: vault, value shrunk by the refund      output[1]: refund → burner
+  function burnPair(int amount) {
+    require(amount > 0, "zero amount");
+    require(this.activeInputIndex == 0, "vault must be input 0");
+    // amount ≤ circulating pairs, so refund ≤ sats escrowed — no overflow.
+    int refund = amount * cap;
+
+    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+    require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
+    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+    require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new MiningMarginVault(
+        oraclePk, hashTicker, powerTicker, cap, maturity,
+        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
+        contractIdTxid, contractIdGidx, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= tx.inputs[0].value - refund, "vault overdrawn");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+    if (refund > 330) {
+      require(tx.outputs[1].value >= refund, "burner underpaid");
+    }
+  }
+
+  // REDEEM RIG — burn `amount` RIG against the maturity fixings for
+  // `amount × margin` sats. Exact by construction: each redeemed token takes
+  // precisely its side of the escrow, in any order.
+  //   output[0]: vault, value shrunk by the payout      output[1]: payout → redeemer
+  function redeemRig(int amount, int hashPrice, signature hashSig, int powerCost, signature powerSig) {
+    require(amount > 0, "zero amount");
+    require(hashPrice >= 0, "negative hashprice");
+    require(powerCost >= 0, "negative power cost");
+    require(this.activeInputIndex == 0, "vault must be input 0");
+
+    let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(maturity, 8));
+    require(checkSigFromStack(hashSig, oraclePk, hashMsg), "invalid hashprice fixing");
+    let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(maturity, 8));
+    require(checkSigFromStack(powerSig, oraclePk, powerMsg), "invalid power fixing");
+
+    int margin = hashPrice - powerCost;
+    if (margin < 0) { margin = 0; }      // curtailment: never mine at a loss
+    if (margin > cap) { margin = cap; }  // escrow bounds the payout
+    int payout = amount * margin;
+
+    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+    require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
+    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+    require(gridGroup.delta == 0, "grid must not move");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new MiningMarginVault(
+        oraclePk, hashTicker, powerTicker, cap, maturity,
+        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
+        contractIdTxid, contractIdGidx, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= tx.inputs[0].value - payout, "vault overdrawn");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+    if (payout > 330) {
+      require(tx.outputs[1].value >= payout, "redeemer underpaid");
+    }
+  }
+
+  // REDEEM GRID — mirror of redeemRig for `amount × (cap − margin)` sats.
+  function redeemGrid(int amount, int hashPrice, signature hashSig, int powerCost, signature powerSig) {
+    require(amount > 0, "zero amount");
+    require(hashPrice >= 0, "negative hashprice");
+    require(powerCost >= 0, "negative power cost");
+    require(this.activeInputIndex == 0, "vault must be input 0");
+
+    let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(maturity, 8));
+    require(checkSigFromStack(hashSig, oraclePk, hashMsg), "invalid hashprice fixing");
+    let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(maturity, 8));
+    require(checkSigFromStack(powerSig, oraclePk, powerMsg), "invalid power fixing");
+
+    int margin = hashPrice - powerCost;
+    if (margin < 0) { margin = 0; }
+    if (margin > cap) { margin = cap; }
+    int payout = amount * (cap - margin);
+
+    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+    require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
+    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+    require(rigGroup.delta == 0, "rig must not move");
+    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+    require(idGroup.delta == 0, "identity supply changed");
+
+    require(
+      tx.outputs[0].scriptPubKey == new MiningMarginVault(
+        oraclePk, hashTicker, powerTicker, cap, maturity,
+        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
+        contractIdTxid, contractIdGidx, exit
+      ),
+      "invalid vault recreation"
+    );
+    require(tx.outputs[0].value >= tx.inputs[0].value - payout, "vault overdrawn");
+    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+    if (payout > 330) {
+      require(tx.outputs[1].value >= payout, "redeemer underpaid");
+    }
+  }
+}

--- a/examples/mining_margin/mining_margin_vault.ark
+++ b/examples/mining_margin/mining_margin_vault.ark
@@ -1,215 +1,293 @@
 // MiningMarginVault Contract
 //
-// A stateless, fully-collateralized two-token vault on the MINING MARGIN —
-// what one contract unit of hashrate earns over the power it burns:
+// A two-sided, fully-collateralized range vault on the MINING MARGIN — what
+// one contract unit of hashrate earns over the power it burns:
 //
 //   margin = clamp(hashPrice − powerCost, 0, cap)   sats per pair
 //
-// One vault per (oracle, hashTicker, powerTicker, cap, maturity) series. A
-// contract unit is a fixed quantity of hashrate-time at a reference machine
-// efficiency (e.g. 1 PH·day at 20 J/TH), set off-chain per series; the
-// hashprice fixing is the sats that unit earns and the power fixing is the
-// sats its electricity costs at the series' power hub.
+// One vault per (oracle, hashTicker, powerTicker, cap, maturity) series,
+// following the two-token stateful vault design of the hashprice option
+// vaults: both legs are fungible Arkade Assets minted in pairs against an
+// escrow of `cap` sats, the pot is split once at settlement, and legs redeem
+// pro-rata afterwards.
 //
-// ── Two legs, one escrow ────────────────────────────────────────────────────
-//   Depositing `cap` sats mints one RIG + one GRID, both fungible Arkade
-//   Assets; burning a matched pair redeems the escrow 1:1. At maturity:
-//     RIG  pays margin          — a machine-on-a-PPA, without the machine.
-//     GRID pays cap − margin    — the same watts sold elsewhere instead.
-//   The clamp at zero is the curtailment right (a rig is never forced to mine
-//   at a loss); the clamp at cap bounds the writer's escrow. RIG + GRID always
-//   equals cap, so the vault is exact at every fixing: no margin calls, no
-//   pro-rata pots, and no division anywhere.
+// A contract unit is a fixed quantity of hashrate-time at a reference machine
+// efficiency (e.g. 1 PH·day at 20 J/TH), set off-chain per series. The
+// hashprice fixing is the sats that unit earns; the power fixing is the sats
+// its electricity costs at the series' power hub. At the fixing:
 //
-// ── Why it is stateless ─────────────────────────────────────────────────────
-//   The vault never records supply, pots, or a settled flag — constructor
-//   state is immutable and every spend recreates it verbatim. Supply lives in
-//   the asset groups, collateral lives in the vault balance (each spend is
-//   checked against tx.inputs[0].value), and settlement is re-verified per
-//   redemption from the oracle fixings. Because a pair is always worth
-//   exactly `cap` in aggregate, issue and burnPair are arbitrage-free at any
-//   time and need no clock at all.
+//   RIG  pays margin per pair        — a machine on a PPA, without the machine
+//   GRID pays cap − margin per pair  — the same watts sold elsewhere instead
 //
-// ── The fixing is the clock ─────────────────────────────────────────────────
-//   Both fixings must be signed over exactly `maturity`
-//   (msg = sha256(ticker || price(8) || maturity(8))); the oracle publishes
-//   them only once maturity arrives, so possession of a valid signature is
-//   the maturity gate — no CLTV, no wall-clock introspection. Trust
-//   assumptions: the oracle signs at most one price per (ticker, maturity) —
-//   two signatures over the same stamp are provable equivocation — and if it
-//   never publishes, redemption is stuck (holders bear oracle liveness, as in
-//   the other oracle-settled examples).
+// The clamp at zero is the curtailment right (a rig is never forced to mine
+// at a loss); the clamp at cap bounds the escrow. RIG + GRID always equals
+// cap, so the vault holds exactly the right BTC at every fixing: no margin
+// calls, no liquidations.
 //
-// ── Bounds ──────────────────────────────────────────────────────────────────
-//   issue caps amount at 2.1e15 / cap sats' worth, so amount × cap never
-//   exceeds total bitcoin supply; every later product (payouts, refunds) is
-//   bounded by sats actually escrowed, keeping all arithmetic inside int64.
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+//   issue     — permissionless, pre-maturity: escrow amount × cap, mint
+//               paired RIG + GRID (gated by the vault identity singleton).
+//   burnPair  — permissionless, pre-maturity: burn a matched pair, take the
+//               escrow back 1:1.
+//   settle    — permissionless, once: two oracle attestations (hashprice and
+//               power cost) timestamped within ±settleWindow of maturity fix
+//               the margin and split the pot; no BTC leaves the vault.
+//   redeem*   — after settlement: burn a leg for a pro-rata slice of its
+//               pot; numerator and denominator drain together, so the rate
+//               is invariant under redemption order.
+//
+// ── Units & overflow ────────────────────────────────────────────────────────
+//   All prices are sats per contract unit; int64 throughout. Every product is
+//   bounded by sats actually escrowed (pairs × cap ≤ total bitcoin supply).
 //
 // ── Exit model ──────────────────────────────────────────────────────────────
 //   A pooled vault cannot express per-holder unilateral exit as a single CSV
 //   leaf; `exit` parameterizes the off-chain recurrent exit tree (refreshed
-//   on every issue/burn), as in the other pooled examples.
+//   on every issue/burn). If the oracle never attests inside the window the
+//   vault cannot settle — holders bear that liveness risk.
 
 contract MiningMarginVault(
   pubkey  oraclePk,        // signs both fixings
   bytes32 hashTicker,      // e.g. sha256("HASHPRICE/BTC") — sats one unit earns
   bytes32 powerTicker,     // e.g. sha256("POWER/ERCOT-WEST") — sats one unit's power costs
   int     cap,             // sats per pair — margin cap and per-pair escrow
-  int     maturity,        // unix seconds; both fixings are stamped exactly with this
+  int     maturity,        // maturity, unix seconds (oracle-timestamp domain)
+  int     settleWindow,    // seconds; fixings accepted within ±settleWindow of maturity
   bytes32 rigIdTxid,       // RIG leg asset id — issuance txid
   int     rigIdGidx,       // RIG leg asset id — issuance group index
   bytes32 gridIdTxid,      // GRID leg asset id — issuance txid
   int     gridIdGidx,      // GRID leg asset id — issuance group index
   bytes32 contractIdTxid,  // vault identity singleton — genesis txid (mint control)
   int     contractIdGidx,  // vault identity singleton — genesis group index
+  int     settled,         // 0 = open (pre-maturity), 1 = settled
+  int     rigShares,       // pre: RIG supply (== gridShares == pairs). post: remaining
+  int     gridShares,      // pre: GRID supply (== rigShares). post: remaining
+  int     rigPot,          // pre: 0. post: sats remaining for the RIG side
+  int     gridPot,         // pre: 0. post: sats remaining for the GRID side
   int     exit             // exit timelock in blocks (off-chain recurrent exit tree)
 ) {
 
-  // ISSUE — permissionless. Deposit `amount × cap` sats; mint `amount` RIG +
-  // `amount` GRID to the depositor. Paired mint keeps the vault exact.
-  //   input[0]:  vault (holds the identity singleton)   input[1+]: depositor sats
-  //   output[0]: vault, value grown by the escrow       output[1]: both legs → depositor
-  function issue(int amount) {
-    require(amount > 0, "zero amount");
-    require(cap > 0, "empty band");
-    require(amount <= 2100000000000000 / cap, "exceeds sat supply");
-    require(this.activeInputIndex == 0, "vault must be input 0");
-    int deposit = amount * cap;
+  // State transitions need dynamic taproot reconstruction. Restore the
+  // disabled functions once private functions plus EC return decomposition
+  // can implement them, or once a generic builtin provides the same
+  // verification.
 
-    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
-    require(rigGroup.delta == amount, "rig supply != amount");
-    require(rigGroup.controlIs(contractIdTxid, contractIdGidx), "wrong rig control");
-    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
-    require(gridGroup.delta == amount, "grid supply != amount");
-    require(gridGroup.controlIs(contractIdTxid, contractIdGidx), "wrong grid control");
-    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
-    require(idGroup.delta == 0, "identity supply changed");
+  // -------------------------------------------------------------------------
+  // ISSUE — permissionless, before maturity. Deposit `amount × cap` sats;
+  // mint `amount` RIG + `amount` GRID to the depositor. Both supplies rise
+  // together, so the pool stays exactly collateralized.
+  //   input[0]:  this vault's output (holds the identity singleton)
+  //   input[1+]: depositor's sats (>= amount × cap + fee)
+  //   output[0]: vault re-created (rigShares+amount, gridShares+amount)
+  //   output[1]: amount RIG + amount GRID → depositor
+  // -------------------------------------------------------------------------
+//   function issue(int amount) {
+//     require(settled == 0, "already settled");
+//     require(amount > 0, "zero amount");
+//     require(cap > 0, "empty band");
+//     int untilMaturity = maturity - tx.offchainTime;
+//     require(untilMaturity > 0, "matured");
 
-    require(tx.outputs[1].assets.lookup(rigIdTxid, rigIdGidx) == amount, "rig not delivered");
-    require(tx.outputs[1].assets.lookup(gridIdTxid, gridIdGidx) == amount, "grid not delivered");
+//     int newRig     = rigShares + amount;
+//     int newGrid    = gridShares + amount;
+//     int newBacking = newRig * cap;
 
-    require(
-      tx.outputs[0].scriptPubKey == new MiningMarginVault(
-        oraclePk, hashTicker, powerTicker, cap, maturity,
-        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
-        contractIdTxid, contractIdGidx, exit
-      ),
-      "invalid vault recreation"
-    );
-    require(tx.outputs[0].value >= tx.inputs[0].value + deposit, "collateral not deposited");
-    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-  }
+//     // Identity-gated paired mint: RIG and GRID supply each rise by exactly
+//     // `amount`, both controlled by the vault identity; identity unchanged.
+//     let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+//     require(rigGroup.delta == amount, "rig supply != amount");
+//     require(rigGroup.controlIs(contractIdTxid, contractIdGidx), "wrong rig control");
+//     let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+//     require(gridGroup.delta == amount, "grid supply != amount");
+//     require(gridGroup.controlIs(contractIdTxid, contractIdGidx), "wrong grid control");
+//     let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+//     require(idGroup.delta == 0, "identity supply changed");
 
-  // BURN PAIR — permissionless unwind. Return `amount` of BOTH legs, take the
-  // `amount × cap` escrow back. Burning the pair authenticates the holder; a
+//     // Both freshly minted legs go to the depositor.
+//     require(tx.outputs[1].assets.lookup(rigIdTxid, rigIdGidx) == amount, "rig not delivered");
+//     require(tx.outputs[1].assets.lookup(gridIdTxid, gridIdGidx) == amount, "grid not delivered");
+
+//     require(
+//       tx.outputs[0].scriptPubKey == new MiningMarginVault(
+//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
+//         settled, newRig, newGrid, rigPot, gridPot, exit
+//       ),
+//       "invalid vault recreation"
+//     );
+//     require(tx.outputs[0].value >= newBacking, "collateral not deposited");
+//     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+//   }
+
+  // -------------------------------------------------------------------------
+  // BURN PAIR — permissionless, before maturity. Return `amount` RIG +
+  // `amount` GRID (a matched pair) and take `amount × cap` sats back. The
+  // burn authenticates: the holder must spend both legs as inputs. A
   // single-sided holder exits by selling the leg via an Arkade intent.
-  //   output[0]: vault, value shrunk by the refund      output[1]: refund → burner
-  function burnPair(int amount) {
-    require(amount > 0, "zero amount");
-    require(this.activeInputIndex == 0, "vault must be input 0");
-    // amount ≤ circulating pairs, so refund ≤ sats escrowed — no overflow.
-    int refund = amount * cap;
+  //   output[0]: vault re-created (rigShares-amount, gridShares-amount)
+  //   output[1]: amount × cap sats → burner
+  // -------------------------------------------------------------------------
+//   function burnPair(int amount) {
+//     require(settled == 0, "already settled");
+//     require(amount > 0, "zero amount");
+//     int untilMaturity = maturity - tx.offchainTime;
+//     require(untilMaturity > 0, "matured");
 
-    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
-    require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
-    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
-    require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
-    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
-    require(idGroup.delta == 0, "identity supply changed");
+//     int newRig     = rigShares - amount;
+//     int newGrid    = gridShares - amount;
+//     int newBacking = newRig * cap;
+//     int refund     = amount * cap;
 
-    require(
-      tx.outputs[0].scriptPubKey == new MiningMarginVault(
-        oraclePk, hashTicker, powerTicker, cap, maturity,
-        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
-        contractIdTxid, contractIdGidx, exit
-      ),
-      "invalid vault recreation"
-    );
-    require(tx.outputs[0].value >= tx.inputs[0].value - refund, "vault overdrawn");
-    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-    if (refund > 330) {
-      require(tx.outputs[1].value >= refund, "burner underpaid");
-    }
-  }
+//     // Burn exactly `amount` of BOTH legs; identity unchanged.
+//     let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+//     require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
+//     let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+//     require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
+//     let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+//     require(idGroup.delta == 0, "identity supply changed");
 
-  // REDEEM RIG — burn `amount` RIG against the maturity fixings for
-  // `amount × margin` sats. Exact by construction: each redeemed token takes
-  // precisely its side of the escrow, in any order.
-  //   output[0]: vault, value shrunk by the payout      output[1]: payout → redeemer
-  function redeemRig(int amount, int hashPrice, signature hashSig, int powerCost, signature powerSig) {
-    require(amount > 0, "zero amount");
-    require(hashPrice >= 0, "negative hashprice");
-    require(powerCost >= 0, "negative power cost");
-    require(this.activeInputIndex == 0, "vault must be input 0");
+//     require(
+//       tx.outputs[0].scriptPubKey == new MiningMarginVault(
+//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
+//         settled, newRig, newGrid, rigPot, gridPot, exit
+//       ),
+//       "invalid vault recreation"
+//     );
+//     require(tx.outputs[0].value >= newBacking, "collateral not preserved");
+//     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
 
-    let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(maturity, 8));
-    require(checkSigFromStack(hashSig, oraclePk, hashMsg), "invalid hashprice fixing");
-    let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(maturity, 8));
-    require(checkSigFromStack(powerSig, oraclePk, powerMsg), "invalid power fixing");
+//     require(tx.outputs[1].value >= refund, "burner underpaid");
+//   }
 
-    int margin = hashPrice - powerCost;
-    if (margin < 0) { margin = 0; }      // curtailment: never mine at a loss
-    if (margin > cap) { margin = cap; }  // escrow bounds the payout
-    int payout = amount * margin;
+  // -------------------------------------------------------------------------
+  // SETTLE — permissionless, once, at maturity. Fix the margin from two
+  // oracle attestations (hashprice and power cost, both in sats per unit)
+  // timestamped within ±settleWindow of maturity, and split the pot. No BTC
+  // leaves the vault; this only records the split and flips `settled`.
+  // Payoffs are already sats, so the split is exact with no division:
+  // gridPot = totalPot − rigPot.
+  //   output[0]: vault re-created (settled=1, rigPot/gridPot set)
+  // -------------------------------------------------------------------------
+//   function settle(int hashPrice, int hashTime, signature hashSig, int powerCost, int powerTime, signature powerSig) {
+//     require(settled == 0, "already settled");
+//     require(rigShares == gridShares, "supply invariant broken");
+//     require(hashPrice >= 0, "negative hashprice");
+//     require(powerCost >= 0, "negative power cost");
 
-    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
-    require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
-    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
-    require(gridGroup.delta == 0, "grid must not move");
-    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
-    require(idGroup.delta == 0, "identity supply changed");
+//     // Both fixings must be attested inside the settlement window (binds
+//     // the margin to the maturity moment, not just "any fresh price").
+//     int windowStart = maturity - settleWindow;
+//     int windowEnd   = maturity + settleWindow;
+//     require(hashTime >= windowStart, "hash fixing before window");
+//     require(hashTime <= windowEnd, "hash fixing after window");
+//     require(powerTime >= windowStart, "power fixing before window");
+//     require(powerTime <= windowEnd, "power fixing after window");
+//     let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(hashTime, 8));
+//     require(checkSigFromStack(hashSig, oraclePk, hashMsg), "invalid hashprice fixing");
+//     let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(powerTime, 8));
+//     require(checkSigFromStack(powerSig, oraclePk, powerMsg), "invalid power fixing");
 
-    require(
-      tx.outputs[0].scriptPubKey == new MiningMarginVault(
-        oraclePk, hashTicker, powerTicker, cap, maturity,
-        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
-        contractIdTxid, contractIdGidx, exit
-      ),
-      "invalid vault recreation"
-    );
-    require(tx.outputs[0].value >= tx.inputs[0].value - payout, "vault overdrawn");
-    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-    if (payout > 330) {
-      require(tx.outputs[1].value >= payout, "redeemer underpaid");
-    }
-  }
+//     int margin = hashPrice - powerCost;
+//     if (margin < 0) { margin = 0; }      // curtailment: never mine at a loss
+//     if (margin > cap) { margin = cap; }  // escrow bounds the payout
+//     int totalPot   = rigShares * cap;
+//     int newRigPot  = rigShares * margin;
+//     int newGridPot = totalPot - newRigPot;
 
-  // REDEEM GRID — mirror of redeemRig for `amount × (cap − margin)` sats.
-  function redeemGrid(int amount, int hashPrice, signature hashSig, int powerCost, signature powerSig) {
-    require(amount > 0, "zero amount");
-    require(hashPrice >= 0, "negative hashprice");
-    require(powerCost >= 0, "negative power cost");
-    require(this.activeInputIndex == 0, "vault must be input 0");
+//     require(
+//       tx.outputs[0].scriptPubKey == new MiningMarginVault(
+//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
+//         1, rigShares, gridShares, newRigPot, newGridPot, exit
+//       ),
+//       "invalid settle output"
+//     );
+//     require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+//     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+//   }
 
-    let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(maturity, 8));
-    require(checkSigFromStack(hashSig, oraclePk, hashMsg), "invalid hashprice fixing");
-    let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(maturity, 8));
-    require(checkSigFromStack(powerSig, oraclePk, powerMsg), "invalid power fixing");
+  // -------------------------------------------------------------------------
+  // REDEEM RIG — after settlement. Burn `amount` RIG for a pro-rata slice of
+  // the RIG pot; numerator and denominator drain together so the rate is
+  // order-invariant. GRID supply must not move.
+  //   output[0]: vault re-created (rigShares-amount, rigPot-payout)
+  //   output[1]: payout sats → redeemer (when above dust)
+  // -------------------------------------------------------------------------
+//   function redeemRig(int amount) {
+//     require(settled == 1, "not settled");
+//     require(amount > 0, "zero amount");
+//     require(amount <= rigShares, "exceeds rig supply");
+//     require(rigShares > 0, "no rig supply");
 
-    int margin = hashPrice - powerCost;
-    if (margin < 0) { margin = 0; }
-    if (margin > cap) { margin = cap; }
-    int payout = amount * (cap - margin);
+//     int payout    = amount * rigPot / rigShares;
+//     int newRigPot = rigPot - payout;
+//     int newRig    = rigShares - amount;
+//     int remaining = newRigPot + gridPot;
 
-    let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
-    require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
-    let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
-    require(rigGroup.delta == 0, "rig must not move");
-    let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
-    require(idGroup.delta == 0, "identity supply changed");
+//     let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+//     require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
+//     let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+//     require(gridGroup.delta == 0, "grid must not move");
+//     let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+//     require(idGroup.delta == 0, "identity supply changed");
 
-    require(
-      tx.outputs[0].scriptPubKey == new MiningMarginVault(
-        oraclePk, hashTicker, powerTicker, cap, maturity,
-        rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx,
-        contractIdTxid, contractIdGidx, exit
-      ),
-      "invalid vault recreation"
-    );
-    require(tx.outputs[0].value >= tx.inputs[0].value - payout, "vault overdrawn");
-    require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-    if (payout > 330) {
-      require(tx.outputs[1].value >= payout, "redeemer underpaid");
-    }
+//     require(
+//       tx.outputs[0].scriptPubKey == new MiningMarginVault(
+//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
+//         1, newRig, gridShares, newRigPot, gridPot, exit
+//       ),
+//       "invalid vault recreation"
+//     );
+//     require(tx.outputs[0].value >= remaining, "pot not preserved");
+//     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+//     if (payout > 330) {
+//       require(tx.outputs[1].value >= payout, "redeemer underpaid");
+//     }
+//   }
+
+  // -------------------------------------------------------------------------
+  // REDEEM GRID — after settlement. Mirror of redeemRig on the GRID pot.
+  //   output[0]: vault re-created (gridShares-amount, gridPot-payout)
+  //   output[1]: payout sats → redeemer (when above dust)
+  // -------------------------------------------------------------------------
+//   function redeemGrid(int amount) {
+//     require(settled == 1, "not settled");
+//     require(amount > 0, "zero amount");
+//     require(amount <= gridShares, "exceeds grid supply");
+//     require(gridShares > 0, "no grid supply");
+
+//     int payout     = amount * gridPot / gridShares;
+//     int newGridPot = gridPot - payout;
+//     int newGrid    = gridShares - amount;
+//     int remaining  = rigPot + newGridPot;
+
+//     let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
+//     require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
+//     let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
+//     require(rigGroup.delta == 0, "rig must not move");
+//     let idGroup = tx.assetGroups.find(contractIdTxid, contractIdGidx);
+//     require(idGroup.delta == 0, "identity supply changed");
+
+//     require(
+//       tx.outputs[0].scriptPubKey == new MiningMarginVault(
+//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
+//         1, rigShares, newGrid, rigPot, newGridPot, exit
+//       ),
+//       "invalid vault recreation"
+//     );
+//     require(tx.outputs[0].value >= remaining, "pot not preserved");
+//     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
+
+//     if (payout > 330) {
+//       require(tx.outputs[1].value >= payout, "redeemer underpaid");
+//     }
+//   }
+
+  function disabled() {
+    require(0 == 1, "temporarily disabled");
   }
 }

--- a/examples/mining_margin/mining_margin_vault.ark
+++ b/examples/mining_margin/mining_margin_vault.ark
@@ -6,60 +6,76 @@
 //   margin = clamp(hashPrice − powerCost, 0, cap)   sats per pair
 //
 // One vault per (oracle, hashTicker, powerTicker, cap, maturity) series,
-// following the two-token stateful vault design of the hashprice option
+// following the stateful two-token vault design of the hashprice option
 // vaults: both legs are fungible Arkade Assets minted in pairs against an
 // escrow of `cap` sats, the pot is split once at settlement, and legs redeem
 // pro-rata afterwards.
 //
-// A contract unit is a fixed quantity of hashrate-time at a reference machine
-// efficiency (e.g. 1 PH·day at 20 J/TH), set off-chain per series. The
-// hashprice fixing is the sats that unit earns; the power fixing is the sats
-// its electricity costs at the series' power hub. At the fixing:
+// ── Fixings are averaged indices, stamped at maturity ───────────────────────
+//   A contract unit is a fixed quantity of hashrate-time at a reference
+//   machine efficiency (e.g. 1 PH·day at 20 J/TH). Both fixings are AVERAGED
+//   (Asian) indices over a window stated in the oracle spec and ending at
+//   maturity: hashPrice is the sats the unit earned over that window,
+//   powerCost the sats its electricity cost at the series' hub. Averages,
+//   not spot prints — a point print on power is unrepresentative and
+//   gameable; the average is what a machine actually earned. The ticker
+//   preimage must encode unit, reference efficiency, averaging window, and
+//   hub, so a series is self-describing
+//   (e.g. sha256("HASHPRICE/BTC/1PHDAY/AVG7D"), sha256("POWER/ERCOT-WEST/20JTH/AVG7D")).
 //
-//   RIG  pays margin per pair        — a machine on a PPA, without the machine
-//   GRID pays cap − margin per pair  — the same watts sold elsewhere instead
+//   Both fixings are signed over exactly `maturity`
+//   (msg = sha256(ticker || price(8) || maturity(8))): one message slot per
+//   (ticker, maturity), so two prices for one slot are provable oracle
+//   equivocation, a fixing for one series cannot be replayed into another,
+//   and there is no timestamp window for a settler to shop in. settle also
+//   requires wall-clock maturity, so an early print cannot fix the margin
+//   or freeze the vault ahead of schedule. Negative power fixings are
+//   admitted (routine at volatile hubs); the oracle spec must use the same
+//   signed 8-byte num2bin encoding.
 //
-// The clamp at zero is the curtailment right (a rig is never forced to mine
-// at a loss); the clamp at cap bounds the escrow. RIG + GRID always equals
-// cap, so the vault holds exactly the right BTC at every fixing: no margin
-// calls, no liquidations.
+// ── Two legs, one escrow ────────────────────────────────────────────────────
+//   RIG  pays margin       — long a call spread on the margin
+//   GRID pays cap − margin — a cap-sat escrow claim short the same spread
+//   The clamp at zero mirrors the curtailment right at the fixing horizon;
+//   the clamp at cap bounds the escrow, so RIG + GRID always equals cap and
+//   the vault is exactly collateralized at every fixing — no margin calls,
+//   no liquidations. One series settles one averaged window; replicating a
+//   machine's hour-by-hour curtailment takes a strip of maturities (basis
+//   and positioning are covered in mining_margin.md).
 //
-// ── Lifecycle ───────────────────────────────────────────────────────────────
-//   issue     — permissionless, pre-maturity: escrow amount × cap, mint
-//               paired RIG + GRID (gated by the vault identity singleton).
-//   burnPair  — permissionless, pre-maturity: burn a matched pair, take the
-//               escrow back 1:1.
-//   settle    — permissionless, once: two oracle attestations (hashprice and
-//               power cost) timestamped within ±settleWindow of maturity fix
-//               the margin and split the pot; no BTC leaves the vault.
-//   redeem*   — after settlement: burn a leg for a pro-rata slice of its
-//               pot; numerator and denominator drain together, so the rate
-//               is invariant under redemption order.
+// ── Recovery ────────────────────────────────────────────────────────────────
+//   burnPair stays open until settlement: a matched pair is worth exactly
+//   cap under every possible fixing, so if the oracle never publishes,
+//   matched pairs still recover escrow 1:1. Single-sided holders bear
+//   oracle liveness — a lone leg cannot be valued without the fixing.
 //
-// ── Units & overflow ────────────────────────────────────────────────────────
-//   All prices are sats per contract unit; int64 throughout. Every product is
-//   bounded by sats actually escrowed (pairs × cap ≤ total bitcoin supply).
+// ── Assumptions & bounds ────────────────────────────────────────────────────
+//   The identity singleton's genesis mints exactly ONE token: mint control
+//   and the single-vault-UTXO model both rest on that. Every function pins
+//   the vault at input 0, so two vault inputs cannot validate against one
+//   recreation. Vault value is accounted relative to the spent input, so
+//   incidental balance above the backing is preserved, never claimable.
+//   issue bounds amount so pairs × cap ≤ total bitcoin supply; fixings are
+//   range-bounded before use; all products stay inside int64.
 //
 // ── Exit model ──────────────────────────────────────────────────────────────
 //   A pooled vault cannot express per-holder unilateral exit as a single CSV
 //   leaf; `exit` parameterizes the off-chain recurrent exit tree (refreshed
-//   on every issue/burn). If the oracle never attests inside the window the
-//   vault cannot settle — holders bear that liveness risk.
+//   on every issue/burn), as in the other pooled examples.
 
 contract MiningMarginVault(
   pubkey  oraclePk,        // signs both fixings
-  bytes32 hashTicker,      // e.g. sha256("HASHPRICE/BTC") — sats one unit earns
-  bytes32 powerTicker,     // e.g. sha256("POWER/ERCOT-WEST") — sats one unit's power costs
+  bytes32 hashTicker,      // self-describing hashprice index id (unit, efficiency, window)
+  bytes32 powerTicker,     // self-describing power index id (hub, efficiency, window)
   int     cap,             // sats per pair — margin cap and per-pair escrow
-  int     maturity,        // maturity, unix seconds (oracle-timestamp domain)
-  int     settleWindow,    // seconds; fixings accepted within ±settleWindow of maturity
+  int     maturity,        // unix seconds; both fixings are signed over exactly this
   bytes32 rigIdTxid,       // RIG leg asset id — issuance txid
   int     rigIdGidx,       // RIG leg asset id — issuance group index
   bytes32 gridIdTxid,      // GRID leg asset id — issuance txid
   int     gridIdGidx,      // GRID leg asset id — issuance group index
   bytes32 contractIdTxid,  // vault identity singleton — genesis txid (mint control)
   int     contractIdGidx,  // vault identity singleton — genesis group index
-  int     settled,         // 0 = open (pre-maturity), 1 = settled
+  int     settled,         // 0 = open, 1 = settled
   int     rigShares,       // pre: RIG supply (== gridShares == pairs). post: remaining
   int     gridShares,      // pre: GRID supply (== rigShares). post: remaining
   int     rigPot,          // pre: 0. post: sats remaining for the RIG side
@@ -67,16 +83,21 @@ contract MiningMarginVault(
   int     exit             // exit timelock in blocks (off-chain recurrent exit tree)
 ) {
 
-  // State transitions need dynamic taproot reconstruction. Restore the
-  // disabled functions once private functions plus EC return decomposition
-  // can implement them, or once a generic builtin provides the same
-  // verification.
+  // State transitions need dynamic taproot reconstruction (the symbolic-stack
+  // validator rejects runtime values as contract-instance arguments). When
+  // the compiler restores dynamic contract transitions:
+  //   1. uncomment the five functions below,
+  //   2. delete the disabled() placeholder at the bottom,
+  //   3. in tests/examples/mining_margin.rs: remove the placeholder test,
+  //      un-ignore the five design tests, and retire the guard test
+  //      (test_commented_design_fails_only_on_dynamic_recreation), which
+  //      fails loudly the moment this design compiles.
 
   // -------------------------------------------------------------------------
   // ISSUE — permissionless, before maturity. Deposit `amount × cap` sats;
   // mint `amount` RIG + `amount` GRID to the depositor. Both supplies rise
   // together, so the pool stays exactly collateralized.
-  //   input[0]:  this vault's output (holds the identity singleton)
+  //   input[0]:  this vault (holds the identity singleton)
   //   input[1+]: depositor's sats (>= amount × cap + fee)
   //   output[0]: vault re-created (rigShares+amount, gridShares+amount)
   //   output[1]: amount RIG + amount GRID → depositor
@@ -85,9 +106,12 @@ contract MiningMarginVault(
 //     require(settled == 0, "already settled");
 //     require(amount > 0, "zero amount");
 //     require(cap > 0, "empty band");
+//     require(amount <= 2100000000000000 / cap, "exceeds sat supply");
+//     require(this.activeInputIndex == 0, "vault must be input 0");
 //     int untilMaturity = maturity - tx.offchainTime;
 //     require(untilMaturity > 0, "matured");
 
+//     int deposit    = amount * cap;
 //     int newRig     = rigShares + amount;
 //     int newGrid    = gridShares + amount;
 //     int newBacking = newRig * cap;
@@ -109,34 +133,38 @@ contract MiningMarginVault(
 
 //     require(
 //       tx.outputs[0].scriptPubKey == new MiningMarginVault(
-//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         oraclePk, hashTicker, powerTicker, cap, maturity,
 //         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
 //         settled, newRig, newGrid, rigPot, gridPot, exit
 //       ),
 //       "invalid vault recreation"
 //     );
-//     require(tx.outputs[0].value >= newBacking, "collateral not deposited");
+//     // Input-relative accounting preserves any incidental vault balance;
+//     // the absolute floor anchors backing >= pairs × cap inductively.
+//     require(tx.outputs[0].value >= tx.inputs[0].value + deposit, "collateral not deposited");
+//     require(tx.outputs[0].value >= newBacking, "backing below pairs x cap");
 //     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
 //   }
 
   // -------------------------------------------------------------------------
-  // BURN PAIR — permissionless, before maturity. Return `amount` RIG +
-  // `amount` GRID (a matched pair) and take `amount × cap` sats back. The
-  // burn authenticates: the holder must spend both legs as inputs. A
-  // single-sided holder exits by selling the leg via an Arkade intent.
+  // BURN PAIR — permissionless, any time before settlement. Return `amount`
+  // RIG + `amount` GRID (a matched pair) and take `amount × cap` sats back.
+  // Deliberately NOT maturity-gated: a matched pair is worth exactly cap
+  // under every possible fixing, so this stays arbitrage-free after maturity
+  // and is the recovery path if the oracle never publishes. The burn
+  // authenticates: the holder must spend both legs as inputs.
   //   output[0]: vault re-created (rigShares-amount, gridShares-amount)
   //   output[1]: amount × cap sats → burner
   // -------------------------------------------------------------------------
 //   function burnPair(int amount) {
 //     require(settled == 0, "already settled");
 //     require(amount > 0, "zero amount");
-//     int untilMaturity = maturity - tx.offchainTime;
-//     require(untilMaturity > 0, "matured");
+//     require(this.activeInputIndex == 0, "vault must be input 0");
 
-//     int newRig     = rigShares - amount;
-//     int newGrid    = gridShares - amount;
-//     int newBacking = newRig * cap;
-//     int refund     = amount * cap;
+//     // amount <= circulating pairs, so refund <= sats escrowed — in range.
+//     int refund  = amount * cap;
+//     int newRig  = rigShares - amount;
+//     int newGrid = gridShares - amount;
 
 //     // Burn exactly `amount` of BOTH legs; identity unchanged.
 //     let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
@@ -148,48 +176,54 @@ contract MiningMarginVault(
 
 //     require(
 //       tx.outputs[0].scriptPubKey == new MiningMarginVault(
-//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         oraclePk, hashTicker, powerTicker, cap, maturity,
 //         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
 //         settled, newRig, newGrid, rigPot, gridPot, exit
 //       ),
 //       "invalid vault recreation"
 //     );
-//     require(tx.outputs[0].value >= newBacking, "collateral not preserved");
+//     require(tx.outputs[0].value >= tx.inputs[0].value - refund, "vault overdrawn");
 //     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-
-//     require(tx.outputs[1].value >= refund, "burner underpaid");
+//     if (refund > 330) {
+//       require(tx.outputs[1].value >= refund, "burner underpaid");
+//     }
 //   }
 
   // -------------------------------------------------------------------------
-  // SETTLE — permissionless, once, at maturity. Fix the margin from two
-  // oracle attestations (hashprice and power cost, both in sats per unit)
-  // timestamped within ±settleWindow of maturity, and split the pot. No BTC
-  // leaves the vault; this only records the split and flips `settled`.
-  // Payoffs are already sats, so the split is exact with no division:
+  // SETTLE — permissionless, once, at or after maturity. Fix the margin from
+  // the two maturity-stamped fixings and split the pot. No BTC leaves the
+  // vault; this only records the split and flips `settled`. Payoffs are
+  // already sats, so the split is exact with no division:
   // gridPot = totalPot − rigPot.
   //   output[0]: vault re-created (settled=1, rigPot/gridPot set)
   // -------------------------------------------------------------------------
-//   function settle(int hashPrice, int hashTime, signature hashSig, int powerCost, int powerTime, signature powerSig) {
+//   function settle(int hashPrice, signature hashSig, int powerCost, signature powerSig) {
 //     require(settled == 0, "already settled");
 //     require(rigShares == gridShares, "supply invariant broken");
-//     require(hashPrice >= 0, "negative hashprice");
-//     require(powerCost >= 0, "negative power cost");
+//     require(rigShares > 0, "nothing to settle");
+//     require(this.activeInputIndex == 0, "vault must be input 0");
 
-//     // Both fixings must be attested inside the settlement window (binds
-//     // the margin to the maturity moment, not just "any fresh price").
-//     int windowStart = maturity - settleWindow;
-//     int windowEnd   = maturity + settleWindow;
-//     require(hashTime >= windowStart, "hash fixing before window");
-//     require(hashTime <= windowEnd, "hash fixing after window");
-//     require(powerTime >= windowStart, "power fixing before window");
-//     require(powerTime <= windowEnd, "power fixing after window");
-//     let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(hashTime, 8));
+//     // Wall-clock gate: an oracle print published early cannot fix the
+//     // margin or end the issue/burn phase before maturity.
+//     int sinceMaturity = tx.offchainTime - maturity;
+//     require(sinceMaturity >= 0, "before maturity");
+
+//     // Range-bound the fixings (revenue cannot be negative; power can —
+//     // both bounded by total sat supply so all arithmetic stays in int64).
+//     require(hashPrice >= 0, "negative hashprice");
+//     require(hashPrice <= 2100000000000000, "hashprice out of range");
+//     require(powerCost >= 0 - 2100000000000000, "power fixing out of range");
+//     require(powerCost <= 2100000000000000, "power fixing out of range");
+
+//     // One message slot per (ticker, maturity): no timestamp freedom, no
+//     // cross-series replay, equivocation provable.
+//     let hashMsg = sha256(hashTicker + num2bin(hashPrice, 8) + num2bin(maturity, 8));
 //     require(checkSigFromStack(hashSig, oraclePk, hashMsg), "invalid hashprice fixing");
-//     let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(powerTime, 8));
+//     let powerMsg = sha256(powerTicker + num2bin(powerCost, 8) + num2bin(maturity, 8));
 //     require(checkSigFromStack(powerSig, oraclePk, powerMsg), "invalid power fixing");
 
 //     int margin = hashPrice - powerCost;
-//     if (margin < 0) { margin = 0; }      // curtailment: never mine at a loss
+//     if (margin < 0) { margin = 0; }      // curtailment floor
 //     if (margin > cap) { margin = cap; }  // escrow bounds the payout
 //     int totalPot   = rigShares * cap;
 //     int newRigPot  = rigShares * margin;
@@ -197,20 +231,21 @@ contract MiningMarginVault(
 
 //     require(
 //       tx.outputs[0].scriptPubKey == new MiningMarginVault(
-//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         oraclePk, hashTicker, powerTicker, cap, maturity,
 //         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
 //         1, rigShares, gridShares, newRigPot, newGridPot, exit
 //       ),
 //       "invalid settle output"
 //     );
-//     require(tx.outputs[0].value >= totalPot, "collateral not preserved");
+//     require(tx.outputs[0].value >= tx.inputs[0].value, "vault drained at settle");
 //     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
 //   }
 
   // -------------------------------------------------------------------------
   // REDEEM RIG — after settlement. Burn `amount` RIG for a pro-rata slice of
-  // the RIG pot; numerator and denominator drain together so the rate is
-  // order-invariant. GRID supply must not move.
+  // the RIG pot. Pot and supply drain together; floor division shifts
+  // sub-share remainders to later redeemers (bounded, and the final
+  // full-supply redemption sweeps the pot exactly). GRID must not move.
   //   output[0]: vault re-created (rigShares-amount, rigPot-payout)
   //   output[1]: payout sats → redeemer (when above dust)
   // -------------------------------------------------------------------------
@@ -219,11 +254,11 @@ contract MiningMarginVault(
 //     require(amount > 0, "zero amount");
 //     require(amount <= rigShares, "exceeds rig supply");
 //     require(rigShares > 0, "no rig supply");
+//     require(this.activeInputIndex == 0, "vault must be input 0");
 
 //     int payout    = amount * rigPot / rigShares;
 //     int newRigPot = rigPot - payout;
 //     int newRig    = rigShares - amount;
-//     int remaining = newRigPot + gridPot;
 
 //     let rigGroup = tx.assetGroups.find(rigIdTxid, rigIdGidx);
 //     require(rigGroup.sumInputs == rigGroup.sumOutputs + amount, "rig not burned exactly");
@@ -234,15 +269,14 @@ contract MiningMarginVault(
 
 //     require(
 //       tx.outputs[0].scriptPubKey == new MiningMarginVault(
-//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         oraclePk, hashTicker, powerTicker, cap, maturity,
 //         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
 //         1, newRig, gridShares, newRigPot, gridPot, exit
 //       ),
 //       "invalid vault recreation"
 //     );
-//     require(tx.outputs[0].value >= remaining, "pot not preserved");
+//     require(tx.outputs[0].value >= tx.inputs[0].value - payout, "vault overdrawn");
 //     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-
 //     if (payout > 330) {
 //       require(tx.outputs[1].value >= payout, "redeemer underpaid");
 //     }
@@ -258,11 +292,11 @@ contract MiningMarginVault(
 //     require(amount > 0, "zero amount");
 //     require(amount <= gridShares, "exceeds grid supply");
 //     require(gridShares > 0, "no grid supply");
+//     require(this.activeInputIndex == 0, "vault must be input 0");
 
 //     int payout     = amount * gridPot / gridShares;
 //     int newGridPot = gridPot - payout;
 //     int newGrid    = gridShares - amount;
-//     int remaining  = rigPot + newGridPot;
 
 //     let gridGroup = tx.assetGroups.find(gridIdTxid, gridIdGidx);
 //     require(gridGroup.sumInputs == gridGroup.sumOutputs + amount, "grid not burned exactly");
@@ -273,20 +307,20 @@ contract MiningMarginVault(
 
 //     require(
 //       tx.outputs[0].scriptPubKey == new MiningMarginVault(
-//         oraclePk, hashTicker, powerTicker, cap, maturity, settleWindow,
+//         oraclePk, hashTicker, powerTicker, cap, maturity,
 //         rigIdTxid, rigIdGidx, gridIdTxid, gridIdGidx, contractIdTxid, contractIdGidx,
 //         1, rigShares, newGrid, rigPot, newGridPot, exit
 //       ),
 //       "invalid vault recreation"
 //     );
-//     require(tx.outputs[0].value >= remaining, "pot not preserved");
+//     require(tx.outputs[0].value >= tx.inputs[0].value - payout, "vault overdrawn");
 //     require(tx.outputs[0].assets.lookup(contractIdTxid, contractIdGidx) >= 1, "identity not retained");
-
 //     if (payout > 330) {
 //       require(tx.outputs[1].value >= payout, "redeemer underpaid");
 //     }
 //   }
 
+  // Delete this placeholder when restoring the functions above.
   function disabled() {
     require(0 == 1, "temporarily disabled");
   }

--- a/playground/main.js
+++ b/playground/main.js
@@ -39,6 +39,13 @@ const projects = {
             'repayment_pool.ark': contracts.repayment_pool,
             'bond_mint.ark': contracts.bond_mint,
         }
+    },
+    mining_margin: {
+        name: 'Mining Margin',
+        description: 'Hashrate derivatives on the mining margin: paired RIG/GRID legs escrow the margin cap and settle on oracle hashprice − power cost fixings',
+        files: {
+            'mining_margin_vault.ark': contracts.mining_margin_vault,
+        }
     }
 };
 

--- a/playground/main.js
+++ b/playground/main.js
@@ -42,7 +42,7 @@ const projects = {
     },
     mining_margin: {
         name: 'Mining Margin',
-        description: 'Hashrate derivatives on the mining margin: paired RIG/GRID legs escrow the margin cap and settle on oracle hashprice − power cost fixings',
+        description: 'Hashrate derivatives on the mining margin: paired RIG/GRID legs escrow the margin cap and settle on oracle hashprice − power cost fixings. State transitions await compiler support — compiles to a disabled placeholder today',
         files: {
             'mining_margin_vault.ark': contracts.mining_margin_vault,
         }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -24,6 +24,8 @@ mod fuji_safe;
 mod htlc;
 #[path = "examples/layerzero.rs"]
 mod layerzero;
+#[path = "examples/mining_margin.rs"]
+mod mining_margin;
 #[path = "examples/repayment_pool.rs"]
 mod repayment_pool;
 #[path = "examples/stability_vault.rs"]

--- a/tests/examples/compilation_roundtrip.rs
+++ b/tests/examples/compilation_roundtrip.rs
@@ -121,6 +121,12 @@ fn roundtrip_controlled_mint() {
 }
 
 #[test]
+fn roundtrip_mining_margin_vault() {
+    let output = compile_example("mining_margin/mining_margin_vault.ark");
+    assert_output_invariants(&output, "mining_margin/mining_margin_vault.ark");
+}
+
+#[test]
 fn roundtrip_nft_mint() {
     let output = compile_example("nft_mint/nft_mint.ark");
     assert_output_invariants(&output, "nft_mint/nft_mint.ark");

--- a/tests/examples/mining_margin.rs
+++ b/tests/examples/mining_margin.rs
@@ -1,0 +1,86 @@
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CHECKSIGFROMSTACK, OP_DIV, OP_FINDASSETGROUPBYASSETID, OP_INSPECTASSETGROUPCTRL,
+    OP_INSPECTOUTASSETLOOKUP, OP_MUL,
+};
+
+use crate::common::{arkade_asm, arkade_asm_tokens, arkade_inputs};
+
+const VAULT_CODE: &str = include_str!("../../examples/mining_margin/mining_margin_vault.ark");
+
+#[test]
+fn test_compiles_with_4_groups() {
+    // 4 covenant functions, each with a synthesized cooperative leaf.
+    let out = compile(VAULT_CODE).expect("compile");
+    assert_eq!(out.name, "MiningMarginVault");
+    assert_eq!(out.functions.len(), 4);
+}
+
+#[test]
+fn test_issue_and_burn_are_amount_only() {
+    // Collateral operations are permissionless and carry no oracle material.
+    let out = compile(VAULT_CODE).unwrap();
+    for fn_name in ["issue", "burnPair"] {
+        assert_eq!(
+            arkade_inputs(&out, fn_name),
+            vec!["amount"],
+            "{fn_name} must take only amount"
+        );
+        assert!(
+            !arkade_asm(&out, fn_name).contains(OP_CHECKSIGFROMSTACK),
+            "{fn_name} must not invoke the oracle"
+        );
+    }
+}
+
+#[test]
+fn test_redeems_verify_both_fixings() {
+    // Settlement is per-redemption: hashprice + power fixings, both checked.
+    let out = compile(VAULT_CODE).unwrap();
+    for fn_name in ["redeemRig", "redeemGrid"] {
+        assert_eq!(
+            arkade_inputs(&out, fn_name),
+            vec!["amount", "hashPrice", "hashSig", "powerCost", "powerSig"],
+            "{fn_name} witness shape"
+        );
+        let csfs = arkade_asm_tokens(&out, fn_name)
+            .iter()
+            .filter(|t| t.as_str() == OP_CHECKSIGFROMSTACK)
+            .count();
+        assert_eq!(csfs, 2, "{fn_name} must verify exactly 2 attestations");
+    }
+}
+
+#[test]
+fn test_settlement_is_exact_no_division() {
+    // Payouts are amount × margin — no pro-rata pots, so no OP_DIV outside
+    // the issue-time overflow guard.
+    let out = compile(VAULT_CODE).unwrap();
+    for fn_name in ["burnPair", "redeemRig", "redeemGrid"] {
+        let asm = arkade_asm(&out, fn_name);
+        assert!(!asm.contains(OP_DIV), "{fn_name} must not divide");
+        assert!(asm.contains(OP_MUL), "{fn_name} must scale by amount");
+    }
+    assert!(
+        arkade_asm(&out, "issue").contains(OP_DIV),
+        "issue must bound amount by 2.1e15 / cap"
+    );
+}
+
+#[test]
+fn test_paired_mint_is_identity_gated() {
+    let out = compile(VAULT_CODE).unwrap();
+    let asm = arkade_asm(&out, "issue");
+    assert!(
+        asm.contains(OP_FINDASSETGROUPBYASSETID),
+        "issue must inspect asset groups"
+    );
+    assert!(
+        asm.contains(OP_INSPECTASSETGROUPCTRL),
+        "issue mint must be identity-controlled"
+    );
+    assert!(
+        asm.contains(OP_INSPECTOUTASSETLOOKUP),
+        "issue must check leg delivery and identity retention"
+    );
+}

--- a/tests/examples/mining_margin.rs
+++ b/tests/examples/mining_margin.rs
@@ -9,14 +9,52 @@ use crate::common::{arkade_asm, arkade_asm_tokens, arkade_inputs};
 const VAULT_CODE: &str = include_str!("../../examples/mining_margin/mining_margin_vault.ark");
 
 #[test]
-fn test_compiles_with_4_groups() {
-    // 4 covenant functions, each with a synthesized cooperative leaf.
+fn test_disabled_vault_compiles_with_stateful_schema() {
+    // State transitions are commented out pending dynamic taproot
+    // reconstruction; only the `disabled` placeholder compiles today, but the
+    // stateful constructor schema is the contract's public interface.
     let out = compile(VAULT_CODE).expect("compile");
     assert_eq!(out.name, "MiningMarginVault");
-    assert_eq!(out.functions.len(), 4);
+    assert_eq!(out.functions.len(), 1);
+    assert_eq!(out.functions[0].name, "disabled");
+
+    let names: Vec<&str> = out.parameters.iter().map(|p| p.name.as_str()).collect();
+    for param in [
+        "oraclePk",
+        "hashTicker",
+        "powerTicker",
+        "cap",
+        "maturity",
+        "settleWindow",
+        "settled",
+        "rigShares",
+        "gridShares",
+        "rigPot",
+        "gridPot",
+        "exit",
+    ] {
+        assert!(names.contains(&param), "missing {param}, got: {names:?}");
+    }
+    for id in ["rigId", "gridId", "contractId"] {
+        assert!(
+            names.contains(&format!("{id}Txid").as_str())
+                && names.contains(&format!("{id}Gidx").as_str()),
+            "{id} not present as explicit Txid/Gidx params, got: {names:?}"
+        );
+    }
 }
 
 #[test]
+#[ignore = "dynamic contract reconstruction is temporarily disabled"]
+fn test_compiles_with_5_groups() {
+    // issue, burnPair, settle, redeemRig, redeemGrid — each with a
+    // synthesized cooperative leaf.
+    let out = compile(VAULT_CODE).expect("compile");
+    assert_eq!(out.functions.len(), 5);
+}
+
+#[test]
+#[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_issue_and_burn_are_amount_only() {
     // Collateral operations are permissionless and carry no oracle material.
     let out = compile(VAULT_CODE).unwrap();
@@ -34,40 +72,54 @@ fn test_issue_and_burn_are_amount_only() {
 }
 
 #[test]
-fn test_redeems_verify_both_fixings() {
-    // Settlement is per-redemption: hashprice + power fixings, both checked.
+#[ignore = "dynamic contract reconstruction is temporarily disabled"]
+fn test_settle_verifies_both_fixings() {
+    // The margin is fixed once from two windowed attestations.
     let out = compile(VAULT_CODE).unwrap();
-    for fn_name in ["redeemRig", "redeemGrid"] {
-        assert_eq!(
-            arkade_inputs(&out, fn_name),
-            vec!["amount", "hashPrice", "hashSig", "powerCost", "powerSig"],
-            "{fn_name} witness shape"
-        );
-        let csfs = arkade_asm_tokens(&out, fn_name)
-            .iter()
-            .filter(|t| t.as_str() == OP_CHECKSIGFROMSTACK)
-            .count();
-        assert_eq!(csfs, 2, "{fn_name} must verify exactly 2 attestations");
-    }
-}
-
-#[test]
-fn test_settlement_is_exact_no_division() {
-    // Payouts are amount × margin — no pro-rata pots, so no OP_DIV outside
-    // the issue-time overflow guard.
-    let out = compile(VAULT_CODE).unwrap();
-    for fn_name in ["burnPair", "redeemRig", "redeemGrid"] {
-        let asm = arkade_asm(&out, fn_name);
-        assert!(!asm.contains(OP_DIV), "{fn_name} must not divide");
-        assert!(asm.contains(OP_MUL), "{fn_name} must scale by amount");
-    }
+    assert_eq!(
+        arkade_inputs(&out, "settle"),
+        vec![
+            "hashPrice",
+            "hashTime",
+            "hashSig",
+            "powerCost",
+            "powerTime",
+            "powerSig"
+        ],
+        "settle witness shape"
+    );
+    let csfs = arkade_asm_tokens(&out, "settle")
+        .iter()
+        .filter(|t| t.as_str() == OP_CHECKSIGFROMSTACK)
+        .count();
+    assert_eq!(csfs, 2, "settle must verify exactly 2 attestations");
     assert!(
-        arkade_asm(&out, "issue").contains(OP_DIV),
-        "issue must bound amount by 2.1e15 / cap"
+        !arkade_asm(&out, "settle").contains(OP_DIV),
+        "settle split is exact — no division"
     );
 }
 
 #[test]
+#[ignore = "dynamic contract reconstruction is temporarily disabled"]
+fn test_redeems_are_pro_rata_without_oracle() {
+    // Post-settlement redemption drains pot and supply together.
+    let out = compile(VAULT_CODE).unwrap();
+    for fn_name in ["redeemRig", "redeemGrid"] {
+        let asm = arkade_asm(&out, fn_name);
+        assert_eq!(arkade_inputs(&out, fn_name), vec!["amount"]);
+        assert!(
+            asm.contains(OP_MUL) && asm.contains(OP_DIV),
+            "{fn_name} must compute amount × pot / shares"
+        );
+        assert!(
+            !asm.contains(OP_CHECKSIGFROMSTACK),
+            "{fn_name} must not invoke the oracle"
+        );
+    }
+}
+
+#[test]
+#[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_paired_mint_is_identity_gated() {
     let out = compile(VAULT_CODE).unwrap();
     let asm = arkade_asm(&out, "issue");

--- a/tests/examples/mining_margin.rs
+++ b/tests/examples/mining_margin.rs
@@ -12,34 +12,101 @@ const VAULT_CODE: &str = include_str!("../../examples/mining_margin/mining_margi
 fn test_disabled_vault_compiles_with_stateful_schema() {
     // State transitions are commented out pending dynamic taproot
     // reconstruction; only the `disabled` placeholder compiles today, but the
-    // stateful constructor schema is the contract's public interface.
+    // stateful constructor schema is the contract's public interface. The
+    // assertion is order-sensitive: the commented recreations hard-code this
+    // positional order, so a reorder must fail here, not at restoration.
     let out = compile(VAULT_CODE).expect("compile");
     assert_eq!(out.name, "MiningMarginVault");
     assert_eq!(out.functions.len(), 1);
     assert_eq!(out.functions[0].name, "disabled");
 
     let names: Vec<&str> = out.parameters.iter().map(|p| p.name.as_str()).collect();
-    for param in [
-        "oraclePk",
-        "hashTicker",
-        "powerTicker",
-        "cap",
-        "maturity",
-        "settleWindow",
-        "settled",
-        "rigShares",
-        "gridShares",
-        "rigPot",
-        "gridPot",
-        "exit",
-    ] {
-        assert!(names.contains(&param), "missing {param}, got: {names:?}");
+    assert_eq!(
+        names,
+        vec![
+            "oraclePk",
+            "hashTicker",
+            "powerTicker",
+            "cap",
+            "maturity",
+            "rigIdTxid",
+            "rigIdGidx",
+            "gridIdTxid",
+            "gridIdGidx",
+            "contractIdTxid",
+            "contractIdGidx",
+            "settled",
+            "rigShares",
+            "gridShares",
+            "rigPot",
+            "gridPot",
+            "exit",
+        ],
+        "constructor schema must match the commented recreations positionally"
+    );
+}
+
+/// CI guard over the commented design: mechanically uncomment the five
+/// state-transition functions, drop the placeholder, and compile. The result
+/// must fail with EXACTLY the dynamic-recreation validation errors — nothing
+/// else — proving the commented bodies stay valid code as the file evolves.
+/// The day dynamic contract transitions are restored, the compile succeeds
+/// and this test fails loudly: that is the restoration tripwire.
+#[test]
+fn test_commented_design_fails_only_on_dynamic_recreation() {
+    let mut in_body = false;
+    let mut uncommented = String::new();
+    for line in VAULT_CODE.lines() {
+        if line.starts_with("contract MiningMarginVault(") {
+            in_body = true;
+        }
+        // Commented-out code sits at column 0; prose comments in the body are
+        // indented, so this transformation touches only the design code.
+        if in_body && line.starts_with("//") {
+            uncommented.push_str("  ");
+            uncommented.push_str(&line[2..]);
+        } else {
+            uncommented.push_str(line);
+        }
+        uncommented.push('\n');
     }
-    for id in ["rigId", "gridId", "contractId"] {
+    let placeholder =
+        "  function disabled() {\n    require(0 == 1, \"temporarily disabled\");\n  }\n";
+    assert!(
+        uncommented.contains(placeholder),
+        "disabled() placeholder not found in expected form"
+    );
+    let uncommented = uncommented.replace(placeholder, "");
+
+    let err = match compile(&uncommented) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!(
+            "uncommented design COMPILED: dynamic contract transitions are back. \
+             Restore the design now: uncomment the functions in the .ark, delete \
+             the disabled() placeholder, un-ignore the five design tests, and \
+             delete this guard test."
+        ),
+    };
+
+    let runtime_value_errors = err.matches("is a runtime value").count();
+    assert_eq!(
+        runtime_value_errors, 10,
+        "expected exactly 10 dynamic-recreation errors, got {runtime_value_errors}: {err}"
+    );
+    for fn_name in ["issue", "burnPair", "settle", "redeemRig", "redeemGrid"] {
         assert!(
-            names.contains(&format!("{id}Txid").as_str())
-                && names.contains(&format!("{id}Gidx").as_str()),
-            "{id} not present as explicit Txid/Gidx params, got: {names:?}"
+            err.contains(&format!("function '{fn_name}'")),
+            "no dynamic-recreation error for {fn_name}: {err}"
+        );
+    }
+    for other in [
+        "Parse error",
+        "computed contract arguments",
+        "type mismatch",
+    ] {
+        assert!(
+            !err.contains(other),
+            "commented design has rotted beyond the dynamic-recreation gate ({other}): {err}"
         );
     }
 }
@@ -48,9 +115,14 @@ fn test_disabled_vault_compiles_with_stateful_schema() {
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_compiles_with_5_groups() {
     // issue, burnPair, settle, redeemRig, redeemGrid — each with a
-    // synthesized cooperative leaf.
+    // synthesized cooperative leaf (the disabled() placeholder is deleted at
+    // restoration).
     let out = compile(VAULT_CODE).expect("compile");
     assert_eq!(out.functions.len(), 5);
+    let names: Vec<&str> = out.functions.iter().map(|g| g.name.as_str()).collect();
+    for f in ["issue", "burnPair", "settle", "redeemRig", "redeemGrid"] {
+        assert!(names.contains(&f), "missing group {f}, got {names:?}");
+    }
 }
 
 #[test]
@@ -73,19 +145,13 @@ fn test_issue_and_burn_are_amount_only() {
 
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
-fn test_settle_verifies_both_fixings() {
-    // The margin is fixed once from two windowed attestations.
+fn test_settle_verifies_two_maturity_stamped_fixings() {
+    // The margin is fixed once from two attestations signed over exactly
+    // `maturity` — no timestamp witnesses, no window to shop in.
     let out = compile(VAULT_CODE).unwrap();
     assert_eq!(
         arkade_inputs(&out, "settle"),
-        vec![
-            "hashPrice",
-            "hashTime",
-            "hashSig",
-            "powerCost",
-            "powerTime",
-            "powerSig"
-        ],
+        vec!["hashPrice", "hashSig", "powerCost", "powerSig"],
         "settle witness shape"
     );
     let csfs = arkade_asm_tokens(&out, "settle")


### PR DESCRIPTION
## Summary

Adds `examples/mining_margin/` — a market price for the economics of running a machine. Hashprice alone already trades (NDF markets exist); the **mining margin** — hashprice minus power, the actual P&L line of a machine — has no non-custodial, fully-collateralized, fungible instrument. This is that instrument, following the stateful two-token range-vault design of the hashprice option vaults (#57): shares and pots are constructor state, updated by dynamic recreation on every spend.

```
margin = clamp(hashPrice − powerCost, 0, cap)
```

Depositing `cap` sats mints a paired **RIG** (long a call spread on the margin) + **GRID** (a cap-sat escrow claim short the same spread), fungible Arkade Assets under identity-gated mint. RIG + GRID always equals cap, so the vault is exactly collateralized at every fixing — no margin calls, no liquidations, and settlement splits the pot with no division.

**What it can and cannot do (framing revised after a dialectical review of the thesis):** a cash-settled derivative cannot reduce aggregate energy burn — difficulty re-pins mining spend to protocol revenue whoever holds the paper. What a margin price does deliver: it prices the keep-vs-scrap decision for old-gen fleets (traded RIG at a fleet's efficiency is the market-implied option time value, the number that rationally decides decommissioning against carrying cost); it turns idle-hot fleets into price-responsive dispatch (a margin-locked miner curtails through negative spreads and runs the spikes); it accelerates efficiency turnover (same revenue-pinned security spend, fewer joules); and it lets AI-pivoting power owners stay financially long mining economics. The flagship position is the producer hedge — mint, sell RIG, keep GRID, keep operating — not "sell and unplug" (a seller who unplugs holds a naked short via GRID). The natural short base is merchant-power miners; fixed-price-PPA miners already own the power leg. The doc states the legs honestly (GRID is a bond minus the margin spread, not "watts sold elsewhere"; single-series RIG is not a machine — replication takes a strip, with known one-sided Jensen basis) and documents the hard-cap and sats-quanto trade-offs against #57's USD-vault alternative.

## Settlement design (hardened after adversarial code review)

- **Averaged (Asian) fixings, maturity-stamped.** Both tickers are defined as period-averaged indices over a window stated in the oracle spec and ending at maturity — the settlement form physical power markets use — and both are signed over exactly `maturity` (`sha256(ticker ‖ price(8) ‖ maturity(8))`). One message slot per (ticker, maturity): no timestamp window for a permissionless settler to shop in (the previous ±settleWindow design let a settler pair max-hashprice with min-power across the window), no cross-series fixing replay, and equivocation is provable. `settleWindow` is deleted.
- **Wall-clock settle gate** (`tx.offchainTime >= maturity`): an early oracle print cannot fix the margin or freeze issuance ahead of schedule; settle also requires non-zero supply, so an empty series cannot be griefed shut.
- **Negative power fixings admitted** (routine at volatile hubs; the old `powerCost >= 0` guard made an ordinary ERCOT-West condition unsettleable), range-bounded to keep all arithmetic in int64.
- **Oracle-death recovery:** `burnPair` is gated only on `settled == 0` — a matched pair is worth exactly cap under every fixing, so pairs recover escrow 1:1 even if the oracle never publishes; only single-sided legs bear liveness.
- **Every function pins the vault at input 0** (two vault inputs can't share one recreation if the identity-singleton assumption ever fails), **value accounting is input-relative** (incidental balance above backing is preserved, not claimable), and issue restores the `amount ≤ 2.1e15 / cap` bound so pairs × cap stays inside total sat supply.

## Compiler status

Dynamic contract transitions are disabled (the symbolic-stack validator rejects runtime values as contract-instance arguments), so the five state-transition functions ship commented out with a `disabled()` placeholder, as in the other stateful examples — the compiled artifact has no satisfiable spend path and must not be deployed (stated in the doc). Two safeguards new in this round:

- **CI guard test** (`test_commented_design_fails_only_on_dynamic_recreation`, runs live): mechanically uncomments the design, drops the placeholder, compiles, and asserts failure with *exactly* the 10 dynamic-recreation errors and nothing else — so the commented design cannot rot silently, and the test fails loudly the day transitions are restored (restoration tripwire).
- **Restore checklist** in the contract source (uncomment functions → delete placeholder → un-ignore design tests → retire guard test), plus an order-sensitive constructor-schema test so a parameter reorder cannot silently corrupt the five hard-coded recreations.

## Files

- `examples/mining_margin/mining_margin_vault.ark` — the vault (full stateful design in source; placeholder compiles today)
- `examples/mining_margin/mining_margin.md` — honest framing: what a margin price can and cannot do, the primitive, positions, trade-offs, trust assumptions
- `tests/examples/mining_margin.rs` — live schema + guard tests, five `#[ignore]`d design tests, roundtrip entry
- `playground/main.js` — dedicated **Mining Margin** playground project, with the disabled-status caveat in its description

## Verification

Full workspace suite green (389 passed), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `./playground/build.sh` end to end (WASM into `playground/pkg/`, `contracts.js` regenerated). The uncommented design was probe-compiled: it fails on exactly the ten runtime-value contract-instance arguments across the five functions — no parse, type, or other validation errors.

https://claude.ai/code/session_01UtS4WKhQbHTypH5mQbWWfM