### PR TITLE
Add OracleCoveredCall contract for oracle-settled BTC options

### DIFF
--- a/examples/options/options.md
+++ b/examples/options/options.md
@@ -18,6 +18,8 @@ Two paired contracts for selling and buying volatility on Bitcoin, faithful to R
 | `CoveredCall` | `btcSats` BTC | `strikeAmount` stablecoin | spot > strike (buyer wants to buy BTC at the cheaper strike) |
 | `CashSecuredPut` | `stableAmount` stablecoin | `btcSats` BTC | spot < strike (buyer wants to sell BTC at the higher strike) |
 
+A third contract, [`OracleCoveredCall`](#oraclecoveredcall), implements the oracle-settled, BTC-cash-settled "Covered Call (CC)" type of the Arkade Options functional specification — no stablecoin, no buyer liveness requirement, settlement is a permissionless crank against a designated oracle set.
+
 The premium is paid MM→seller upfront, off-contract, in the same atomic funding transaction. Same model as Rysk pays premium in USD upfront.
 
 ### Terminology
@@ -103,6 +105,46 @@ output[0]:  SingleSig(sellerPk)      (btcSats BTC)
 output[1]:  SingleSig(buyerPk)       (stableAmount of stableAssetId)
 output[2+]: buyer's BTC change       (unconstrained)
 ```
+
+---
+
+## OracleCoveredCall
+
+The "Covered Call (CC)" type from the Arkade Options high-level functional specification: fully collateralized, **cash-settled in BTC**, settled against a designated oracle set instead of by buyer action. Terminology follows the spec: **Writer (W)** locks the notional, **Holder (H)** paid the premium.
+
+Constructor: `writerPk, holderPk, writerScript, holderScript, oracles[5], tickerHash, strike, expiry, priceWindow, refundAt, notional, coopExit, exit`
+
+Payoff with `ST` the settlement reference price and `Q = notional`, `K = strike`:
+
+```
+ST <= K:  PH = 0                  PW = Q
+ST  > K:  PH = Q * (1 - K / ST)   PW = Q - PH
+```
+
+### Functions
+
+**`settle(oracleIdx[3], prices[3], timestamps[3], oracleSigs[3])`** — permissionless crank, valid from `expiry`. Anyone (holder, writer, operator, or a third party) supplies 3 prices signed by 3 **distinct** oracles of the designated 5, each timestamped inside `[expiry - priceWindow, expiry]`. `ST` is the median of the 3. The covenant recomputes each attestation digest — `sha256(tickerHash || price_le8 || ts_le8)` — verifies the signatures via `OP_CHECKSIGFROMSTACK`, and enforces the payoff split to the fixed `holderScript` / `writerScript` payout programs. A payout leg under 330 sats is routed into the counterparty's output. `tx.numInputs == 1` guards against multi-vault double-satisfaction, and the vault input must hold **exactly** `notional` (only outputs 0/1 are inspected, so any surplus would otherwise be claimable by whoever cranks — a mis-funded vault is refund-only by design).
+
+**`refund(writerSig, serverSig)`** — CLTV leaf at `refundAt`: the writer reclaims if nobody settled (oracle outage or abandoned OTM position).
+
+**`coop(holderSig, writerSig)`** — CSV leaf: both parties unwind early without oracles or operator.
+
+**`unilateral(writerSig)`** — CSV leaf: writer's L1 safety valve.
+
+### Settle transaction layout
+
+```
+input[0]:   OracleCoveredCall vault  (notional sats)
+ST > K:     output[0] holderScript   (PH)      output[1] writerScript (PW)
+ST <= K:    output[0] writerScript   (notional)
+```
+
+### Notes
+
+- The narrow pre-expiry `priceWindow` (spec: 1 minute) pins `ST` to the expiry spot; residual intra-window cherry-picking is bounded by the window. The spec's target version replaces the median with a half-hour TWAP.
+- Oracle attestations encode numeric fields as 8-byte little-endian binary (the language has no string values), displayed off-chain as `BTCUSD|PRICE_IN_CENTS|UNIXTIMESTAMP`.
+- The only product in the payoff math is `notional * strike`, which must stay below 2^63 — enforce `Qmax` at inception accordingly.
+- Compared to the buyer-exercised `CoveredCall` above: the holder makes no exercise *decision* and any party can crank settlement, at the cost of an oracle trust assumption. Liveness is not fully eliminated: if nobody cranks before `refundAt`, the writer + operator can reclaim the full notional of an ITM vault — size the `refundAt` grace window so that at least one interested cranker is expected to show up within it.
 
 ---
 

--- a/examples/options/oracle_covered_call.ark
+++ b/examples/options/oracle_covered_call.ark
@@ -1,0 +1,202 @@
+// OracleCoveredCall Contract
+//
+// Bitcoin-native, fully collateralized, cash-settled (in BTC) European
+// covered call, settled against a designated oracle set. Implements the
+// "Covered Call (CC)" contract type of the Arkade Options functional
+// specification:
+//
+//   - Writer (W) locks `notional` sats of BTC. The pledged collateral
+//     fully covers the writer's maximum delivery obligation; there is
+//     no margin call.
+//   - Holder (H) locks nothing in this contract. The premium flows
+//     holder->writer off-contract during the RFQ/issuance flow.
+//   - At settlement, with ST the oracle median reference price:
+//       ST <= K:  PH = 0,                    PW = Q
+//       ST  > K:  PH = Q * (1 - K / ST),     PW = Q - PH
+//     (Q = notional in sats, K = strike, both prices in USD cents.)
+//
+// Settlement reference price (ST):
+//   Five oracles are designated at inception. Anyone (holder, writer,
+//   operator, or an unrelated third party) may settle after expiry by
+//   supplying 3 prices signed by 3 DISTINCT oracles, each timestamped
+//   within [expiry - priceWindow, expiry]. ST is the median of the 3.
+//   The narrow pre-expiry window keeps ST pinned to the expiry spot;
+//   residual intra-window cherry-picking is bounded by `priceWindow`
+//   (a TWAP-based ST would remove it and would justify replacing this).
+//
+// Oracle attestation encoding (no strings-as-values in this language,
+// so numeric fields are binary, not ASCII decimals):
+//   msg = sha256(tickerHash || num2bin(priceCents, 8) || num2bin(unixTs, 8))
+//   sig = BIP-340 Schnorr over msg with the oracle key
+//   where tickerHash = sha256("BTCUSD") and both ints are 8-byte
+//   little-endian. Displayed off-chain as "BTCUSD|PRICE_IN_CENTS|UNIXTS".
+//
+// Transaction layout for settle (single input enforced):
+//   input[0]:  this OracleCoveredCall vault   (exactly notional sats)
+//   ST > K:    output[0] holder PH, output[1] writer PW
+//              (a sub-330-sat leg is routed into the other party's
+//               output instead of creating a non-viable output)
+//   ST <= K:   output[0] writer Q
+//
+// Payout destinations are fixed at inception as 32-byte taproot witness
+// programs (`holderScript`, `writerScript`), not rebuilt dynamically.
+//
+// Overflow ceiling: the only product is notional * strike, which must
+// stay below 2^63 (e.g. strike $10M in cents caps notional at ~92 BTC).
+// Enforce Qmax at inception accordingly.
+
+contract OracleCoveredCall(
+  pubkey    writerPk,     // W: authorizes refund / coop / unilateral exit
+  pubkey    holderPk,     // H: authorizes the coop path
+  bytes     writerScript, // W settlement payout: 32-byte witness program
+  bytes     holderScript, // H settlement payout: 32-byte witness program
+  pubkey[5] oracles,      // designated oracle set, fixed at inception
+  bytes32   tickerHash,   // sha256("BTCUSD")
+  int       strike,       // K: USD cents per BTC, > 0
+  int       expiry,       // T: unix seconds; settlement opens here
+  int       priceWindow,  // seconds: oracle ts in [T - priceWindow, T]
+  int       refundAt,     // unix seconds > T: writer+server reclaim opens
+  int       notional,     // Q: sats locked (notional * strike < 2^63)
+  int       coopExit,     // CSV blocks: holder+writer cooperative L1 path
+  int       exit          // CSV blocks: writer unilateral L1 exit
+) {
+
+  // -------------------------------------------------------------------------
+  // SETTLE (permissionless crank)
+  // Anyone provides 3 prices signed by 3 distinct designated oracles with
+  // timestamps in the pre-expiry window. The covenant computes ST as their
+  // median and enforces the CC payoff split to the fixed payout scripts.
+  // -------------------------------------------------------------------------
+  function settle(
+    int[3]       oracleIdx,   // indices into `oracles`, pairwise distinct
+    int[3]       prices,      // USD cents, one per attestation
+    int[3]       timestamps,  // unix seconds, one per attestation
+    signature[3] oracleSigs   // BIP-340 sigs over the attestation digests
+  ) {
+    // Fixed output indices below make multi-vault spends unsafe
+    // (one payout pair could satisfy several vault covenants at once).
+    require(tx.numInputs == 1, "single vault only");
+    // Settlement is permissionless and only outputs 0/1 are inspected, so any
+    // input surplus would be claimable by whoever cranks. Pin the vault to
+    // exactly the notional: a mis-funded vault is refund-only by design.
+    require(tx.inputs[0].value == notional, "vault must hold the notional");
+    require(tx.time >= expiry, "before expiry");
+    require(strike > 0, "zero strike");
+
+    int i0 = oracleIdx[0];
+    int i1 = oracleIdx[1];
+    int i2 = oracleIdx[2];
+    require(i0 != i1, "duplicate oracle");
+    require(i0 != i2, "duplicate oracle");
+    require(i1 != i2, "duplicate oracle");
+
+    int windowStart = expiry - priceWindow;
+
+    int p0 = prices[0];
+    int t0 = timestamps[0];
+    require(t0 >= windowStart, "price 0 too old");
+    require(t0 <= expiry, "price 0 after expiry");
+    let m0 = sha256(tickerHash + num2bin(p0, 8) + num2bin(t0, 8));
+    require(checkSigFromStack(oracleSigs[0], oracles[i0], m0), "bad sig 0");
+
+    int p1 = prices[1];
+    int t1 = timestamps[1];
+    require(t1 >= windowStart, "price 1 too old");
+    require(t1 <= expiry, "price 1 after expiry");
+    let m1 = sha256(tickerHash + num2bin(p1, 8) + num2bin(t1, 8));
+    require(checkSigFromStack(oracleSigs[1], oracles[i1], m1), "bad sig 1");
+
+    int p2 = prices[2];
+    int t2 = timestamps[2];
+    require(t2 >= windowStart, "price 2 too old");
+    require(t2 <= expiry, "price 2 after expiry");
+    let m2 = sha256(tickerHash + num2bin(p2, 8) + num2bin(t2, 8));
+    require(checkSigFromStack(oracleSigs[2], oracles[i2], m2), "bad sig 2");
+
+    // ST = median of the three signed prices.
+    int st = 0;
+    if (p0 > p1) {
+      if (p1 > p2) {
+        st = p1;
+      } else {
+        if (p0 > p2) {
+          st = p2;
+        } else {
+          st = p0;
+        }
+      }
+    } else {
+      if (p0 > p2) {
+        st = p0;
+      } else {
+        if (p1 > p2) {
+          st = p2;
+        } else {
+          st = p1;
+        }
+      }
+    }
+
+    if (st > strike) {
+      // In the money: PW = floor(Q * K / ST), PH = Q - PW.
+      int writerSats = notional * strike / st;
+      int holderSats = notional - writerSats;
+      if (holderSats < 330) {
+        // Holder leg below the 330-sat output floor: route it to the writer.
+        require(tx.outputs[0].value >= notional, "writer underpaid");
+        require(tx.outputs[0].scriptPubKey == writerScript, "output 0 not writer");
+      } else {
+        if (writerSats < 330) {
+          // Writer residual below the output floor: route it to the holder.
+          require(tx.outputs[0].value >= notional, "holder underpaid");
+          require(tx.outputs[0].scriptPubKey == holderScript, "output 0 not holder");
+        } else {
+          require(tx.outputs[0].value >= holderSats, "holder underpaid");
+          require(tx.outputs[0].scriptPubKey == holderScript, "output 0 not holder");
+          require(tx.outputs[1].value >= writerSats, "writer underpaid");
+          require(tx.outputs[1].scriptPubKey == writerScript, "output 1 not writer");
+        }
+      }
+    } else {
+      // Out of the money: the whole notional returns to the writer.
+      require(tx.outputs[0].value >= notional, "writer underpaid");
+      require(tx.outputs[0].scriptPubKey == writerScript, "output 0 not writer");
+    }
+  }
+
+  // Settlement leaf: operator + covenant-tweaked emulator, gated by CLTV so
+  // spenders carry nLockTime >= expiry (which the covenant reads as tx.time).
+  function settle(signature serverSig, signature emulatorSig) tapscript {
+    require(after(expiry));
+    require(checkMultisig([server, emulator], [serverSig, emulatorSig]));
+  }
+
+  // -------------------------------------------------------------------------
+  // REFUND
+  // Writer reclaims the notional once the settlement grace window is over
+  // (nobody settled: oracle outage, or an abandoned OTM position).
+  // -------------------------------------------------------------------------
+  function refund(signature writerSig, signature serverSig) tapscript {
+    require(after(refundAt));
+    require(checkMultisig([writerPk, server], [writerSig, serverSig]));
+  }
+
+  // -------------------------------------------------------------------------
+  // COOP (early unwind)
+  // Holder and writer jointly release the vault after the CSV delay,
+  // without oracles or operator.
+  // -------------------------------------------------------------------------
+  function coop(signature holderSig, signature writerSig) tapscript {
+    require(older(coopExit));
+    require(checkMultisig([holderPk, writerPk], [holderSig, writerSig]));
+  }
+
+  // -------------------------------------------------------------------------
+  // UNILATERAL EXIT (CSV)
+  // Writer recovers the notional after the exit delay (operator offline).
+  // -------------------------------------------------------------------------
+  function unilateral(signature writerSig) tapscript {
+    require(older(exit));
+    require(checkSig(writerSig, writerPk));
+  }
+}

--- a/playground/main.js
+++ b/playground/main.js
@@ -26,10 +26,11 @@ const projects = {
     },
     options: {
         name: 'Options',
-        description: 'European covered call + cash-secured put, physically settled, oracle-triggered',
+        description: 'European covered call + cash-secured put (physically settled, buyer-exercised) and an oracle-settled covered call (cash-settled in BTC, 3-of-5 oracle median, permissionless settlement)',
         files: {
             'covered_call.ark': contracts.covered_call,
             'cash_secured_put.ark': contracts.cash_secured_put,
+            'oracle_covered_call.ark': contracts.oracle_covered_call,
         }
     },
     bonds: {

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -24,6 +24,8 @@ mod fuji_safe;
 mod htlc;
 #[path = "examples/layerzero.rs"]
 mod layerzero;
+#[path = "examples/oracle_covered_call.rs"]
+mod oracle_covered_call;
 #[path = "examples/repayment_pool.rs"]
 mod repayment_pool;
 #[path = "examples/stability_vault.rs"]

--- a/tests/examples/oracle_covered_call.rs
+++ b/tests/examples/oracle_covered_call.rs
@@ -1,0 +1,182 @@
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{
+    OP_CAT, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK,
+    OP_CHECKSIGVERIFY, OP_DIV, OP_INSPECTINPUTVALUE, OP_INSPECTNUMINPUTS,
+    OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE, OP_MUL, OP_NUM2BIN, OP_SHA256,
+};
+
+use crate::common::{
+    arkade_asm, arkade_inputs, group, leaf_asm, opcode_count_in_arkade, user_signatures,
+    witness_names,
+};
+
+/// Oracle-settled covered call: 3-of-5 distinct-oracle attestations, median
+/// settlement price, covenant-enforced payoff split.
+const CODE: &str = include_str!("../../examples/options/oracle_covered_call.ark");
+
+#[test]
+fn test_oracle_covered_call_parses() {
+    let result = compile(CODE);
+    assert!(result.is_ok(), "Compilation failed: {:?}", result.err());
+}
+
+#[test]
+fn test_oracle_covered_call_structure() {
+    let output = compile(CODE).unwrap();
+
+    assert_eq!(output.name, "OracleCoveredCall");
+    let names: Vec<&str> = output.functions.iter().map(|g| g.name.as_str()).collect();
+    assert_eq!(names, vec!["settle", "coop", "refund", "unilateral"]);
+
+    // Only settle carries a covenant; the other three are pure leaves.
+    assert!(group(&output, "settle").arkade.is_some());
+    for name in ["coop", "refund", "unilateral"] {
+        assert!(
+            group(&output, name).arkade.is_none(),
+            "{name} must be a pure tapscript leaf"
+        );
+    }
+}
+
+#[test]
+fn test_settle_witness_abi() {
+    let output = compile(CODE).unwrap();
+
+    // Spender-supplied covenant witness, in declared order, arrays grouped.
+    assert_eq!(
+        arkade_inputs(&output, "settle"),
+        vec!["oracleIdx", "prices", "timestamps", "oracleSigs"]
+    );
+    // Settlement is a permissionless crank: no user tx-signature involved.
+    assert!(user_signatures(&output, "settle").is_empty());
+
+    // Leaf witness holds only the injected cosigners.
+    assert_eq!(
+        witness_names(&output, "settle", "settle"),
+        vec!["serverSig", "emulatorSig"]
+    );
+}
+
+#[test]
+fn test_settle_covenant_verifies_three_attestations() {
+    let output = compile(CODE).unwrap();
+
+    // One signature check and one digest rebuild per attestation.
+    assert_eq!(
+        opcode_count_in_arkade(&output, "settle", OP_CHECKSIGFROMSTACK),
+        3
+    );
+    assert_eq!(opcode_count_in_arkade(&output, "settle", OP_SHA256), 3);
+    // Each digest concatenates tickerHash || price(8) || timestamp(8).
+    assert_eq!(opcode_count_in_arkade(&output, "settle", OP_NUM2BIN), 6);
+    assert_eq!(opcode_count_in_arkade(&output, "settle", OP_CAT), 6);
+}
+
+#[test]
+fn test_settle_covenant_guards() {
+    let output = compile(CODE).unwrap();
+    let asm = arkade_asm(&output, "settle");
+
+    // Double-satisfaction guard: exactly one vault input per settle tx.
+    assert!(asm.contains(OP_INSPECTNUMINPUTS), "ASM: {asm}");
+    // Surplus guard: the vault input must hold exactly the notional, so a
+    // permissionless cranker cannot route excess value to themselves.
+    assert!(asm.contains(OP_INSPECTINPUTVALUE), "ASM: {asm}");
+    // Settlement opens at expiry (covenant reads nLockTime).
+    assert!(asm.contains(OP_CHECKLOCKTIMEVERIFY), "ASM: {asm}");
+    // Payoff math: PW = notional * strike / ST.
+    assert!(asm.contains(OP_MUL), "ASM: {asm}");
+    assert!(asm.contains(OP_DIV), "ASM: {asm}");
+}
+
+#[test]
+fn test_settle_covenant_payout_branches() {
+    let output = compile(CODE).unwrap();
+
+    // Output assertions across the payoff branches: ITM split (2 outputs),
+    // ITM sub-dust holder leg, ITM sub-dust writer leg, OTM (1 output).
+    assert_eq!(
+        opcode_count_in_arkade(&output, "settle", OP_INSPECTOUTPUTVALUE),
+        5
+    );
+    assert_eq!(
+        opcode_count_in_arkade(&output, "settle", OP_INSPECTOUTPUTSCRIPTPUBKEY),
+        5
+    );
+}
+
+#[test]
+fn test_settle_leaf_is_cltv_server_emulator() {
+    let output = compile(CODE).unwrap();
+    let asm = leaf_asm(&output, "settle", "settle");
+
+    // CLTV gate so the SDK stamps nLockTime >= expiry on the virtual tx,
+    // then operator + function-tweaked emulator cosign.
+    assert_eq!(
+        asm,
+        format!(
+            "<expiry> {OP_CHECKLOCKTIMEVERIFY} OP_DROP <SERVER_KEY> {OP_CHECKSIGVERIFY} \
+             <EMULATOR_KEY:settle> {OP_CHECKSIG}"
+        )
+    );
+}
+
+#[test]
+fn test_refund_leaf_is_cltv_writer_server() {
+    let output = compile(CODE).unwrap();
+    let asm = leaf_asm(&output, "refund", "refund");
+
+    assert_eq!(
+        asm,
+        format!(
+            "<refundAt> {OP_CHECKLOCKTIMEVERIFY} OP_DROP <writerPk> {OP_CHECKSIGVERIFY} \
+             <SERVER_KEY> {OP_CHECKSIG}"
+        )
+    );
+}
+
+#[test]
+fn test_coop_and_unilateral_are_csv_leaves() {
+    let output = compile(CODE).unwrap();
+
+    let coop = leaf_asm(&output, "coop", "coop");
+    assert_eq!(
+        coop,
+        format!(
+            "<coopExit> {OP_CHECKSEQUENCEVERIFY} OP_DROP <holderPk> {OP_CHECKSIGVERIFY} \
+             <writerPk> {OP_CHECKSIG}"
+        )
+    );
+
+    let unilateral = leaf_asm(&output, "unilateral", "unilateral");
+    assert_eq!(
+        unilateral,
+        format!("<exit> {OP_CHECKSEQUENCEVERIFY} OP_DROP <writerPk> {OP_CHECKSIG}")
+    );
+}
+
+#[test]
+fn test_oracle_array_abi_stays_grouped() {
+    let output = compile(CODE).unwrap();
+
+    let oracles = output
+        .parameters
+        .iter()
+        .find(|p| p.name == "oracles")
+        .expect("constructorInputs keeps one entry per source parameter");
+    assert_eq!(oracles.param_type, "pubkey[5]");
+
+    // The asm prologue pushes one placeholder per element; oracles[idx] is a
+    // runtime bounds-checked pick, so no literal <oracles_N> reads appear
+    // beyond the prologue pushes.
+    let asm = arkade_asm(&output, "settle");
+    for placeholder in [
+        "<oracles_0>",
+        "<oracles_1>",
+        "<oracles_2>",
+        "<oracles_3>",
+        "<oracles_4>",
+    ] {
+        assert!(asm.contains(placeholder), "missing {placeholder}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `OracleCoveredCall` contract implementing the oracle-settled, BTC-cash-settled "Covered Call (CC)" type from the Arkade Options functional specification. This complements the existing buyer-exercised `CoveredCall` and `CashSecuredPut` contracts with a permissionless settlement model.

## Key Changes

- **New contract**: `examples/options/oracle_covered_call.ark` — a fully collateralized European covered call where:
  - Writer locks notional BTC as collateral
  - Settlement is permissionless: any party supplies 3 oracle prices (from a designated 5-oracle set) to trigger payout
  - Payoff is computed as median of the 3 prices and enforced by covenant
  - Includes fallback paths: cooperative early exit (CSV), refund after grace window (CLTV), and unilateral writer exit (CSV)

- **Comprehensive test suite**: `tests/examples/oracle_covered_call.rs` covering:
  - Compilation and structural validation
  - Witness ABI for the permissionless settle function and three tapscript leaves
  - Covenant opcode usage (signature verification, digest reconstruction, payoff math, output validation)
  - Payout branch logic (in-the-money split, out-of-the-money, sub-dust leg handling)
  - Leaf script assembly for CLTV/CSV gates and cosigner requirements
  - Oracle array parameter handling

- **Documentation**: Updated `examples/options/options.md` with detailed `OracleCoveredCall` section including:
  - Constructor parameters and payoff formula
  - Function descriptions (settle, refund, coop, unilateral)
  - Transaction layout and settlement mechanics
  - Implementation notes on oracle attestation encoding, overflow safety, and liveness guarantees

- **Playground**: Updated `playground/main.js` to include the new contract in the options project description

## Notable Implementation Details

- **Oracle attestation**: Numeric fields (price, timestamp) encoded as 8-byte little-endian binary; digest is `sha256(tickerHash || price_le8 || ts_le8)` verified via `OP_CHECKSIGFROMSTACK`
- **Double-satisfaction guard**: Enforces exactly one vault input per settle tx to prevent multi-vault attacks
- **Surplus guard**: Vault input must hold exactly the notional; permissionless cranker cannot claim excess
- **Sub-dust handling**: Payout legs under 330 sats are routed into the counterparty's output instead of creating non-viable outputs
- **Overflow safety**: Product `notional * strike` must stay below 2^63; enforced at inception
- **Settlement window**: Pre-expiry `priceWindow` (e.g., 1 minute) pins settlement price to expiry spot; residual cherry-picking bounded by window width

https://claude.ai/code/session_0122ehUKH4vtrb4bqCjTtWny