### PR TITLE
Fix array type widening

### DIFF
--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -768,6 +768,11 @@ fn binding_types_compatible(expected: &ArkType, actual: &ArkType) -> bool {
             (expected, actual),
             (ArkType::Bytes, ArkType::Bytes20 | ArkType::Bytes32)
         )
+        || matches!(
+            (expected, actual),
+            (ArkType::Array(expected, expected_len), ArkType::Array(actual, actual_len))
+                if expected_len == actual_len && binding_types_compatible(expected, actual)
+        )
 }
 
 fn check_binding_semantics(contract: &Contract, issues: &mut Vec<ValidationIssue>) {

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -401,6 +401,21 @@ contract Local(bytes32 h) {
 }
 
 #[test]
+fn array_elements_use_scalar_type_widening() {
+    compile(
+        r#"
+contract Local(bytes32 first, bytes32 second) {
+    function spend(bytes expected) {
+        bytes[2] values = [first, second];
+        require(values[0] == expected);
+    }
+}
+"#,
+    )
+    .expect("bytes32 array elements must widen to bytes");
+}
+
+#[test]
 fn local_array_elements_are_assignable_at_a_nonzero_literal_index() {
     let output = compile(
         r#"


### PR DESCRIPTION
## Summary

- apply existing scalar type widening recursively to equal-length arrays
- cover bytes32 array elements widening to bytes

## Verification

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array type compatibility checks when array lengths match.
  * Enabled compatible wider scalar values, such as `bytes32`, to initialize `bytes` arrays successfully.

* **Tests**
  * Added coverage validating compilation of arrays initialized with compatible widened element types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->