### PR TITLE
feat: add OP_PUT reassignment

### DIFF
--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -78,13 +78,22 @@ impl ConcatPass {
                     &self.structs,
                 );
             }
-            Statement::VarAssign { name, value } => {
+            Statement::VarAssign { target, value } => {
+                if let AssignmentTarget::ArrayIndex { index, .. } = target {
+                    let (new_index, _) = self.rewrite_expression_concat(
+                        std::mem::replace(index.as_mut(), Expression::Literal(String::new())),
+                        scope,
+                    );
+                    **index = new_index;
+                }
                 let (new_expr, t) = self.rewrite_expression_concat(
                     std::mem::replace(value, Expression::Literal(String::new())),
                     scope,
                 );
                 *value = new_expr;
-                scope.insert(name.clone(), t);
+                if let AssignmentTarget::Binding(name) = target {
+                    scope.insert(name.clone(), t);
+                }
             }
             Statement::IfElse {
                 condition,

--- a/src/compiler/loops.rs
+++ b/src/compiler/loops.rs
@@ -44,8 +44,16 @@ pub(crate) fn substitute_statement(
             declared_type: declared_type.clone(),
             value: substitute_expression(value, index_var, value_var, k, array_name),
         },
-        Statement::VarAssign { name, value } => Statement::VarAssign {
-            name: name.clone(),
+        Statement::VarAssign { target, value } => Statement::VarAssign {
+            target: match target {
+                AssignmentTarget::Binding(name) => AssignmentTarget::Binding(name.clone()),
+                AssignmentTarget::ArrayIndex { array, index } => AssignmentTarget::ArrayIndex {
+                    array: array.clone(),
+                    index: Box::new(substitute_expression(
+                        index, index_var, value_var, k, array_name,
+                    )),
+                },
+            },
             value: substitute_expression(value, index_var, value_var, k, array_name),
         },
         Statement::IfElse {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,24 +1,24 @@
 use crate::models::{
-    ArkadeCovenant, CompilerInfo, ContractJson, Expression, Function, FunctionInput, Parameter,
-    Requirement, Statement,
+    ArkadeCovenant, AssignmentTarget, CompilerInfo, ContractJson, Expression, Function,
+    FunctionInput, Parameter, Requirement, Statement,
 };
 use crate::opcodes::{
     OP_0, OP_1, OP_ADD, OP_BIN2NUM, OP_BOOLAND, OP_CAT, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG,
-    OP_CHECKSIGADD, OP_CHECKSIGFROMSTACK, OP_DIGEST, OP_DIV, OP_DROP, OP_ECADD, OP_ECMUL,
+    OP_CHECKSIGADD, OP_CHECKSIGFROMSTACK, OP_DIGEST, OP_DIV, OP_DROP, OP_DUP, OP_ECADD, OP_ECMUL,
     OP_ECMULSCALARVERIFY, OP_ECPAIRING, OP_ELSE, OP_ENDIF, OP_EQUAL, OP_EQUALVERIFY,
-    OP_FINDASSETGROUPBYASSETID, OP_FROMALTSTACK, OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_IF,
-    OP_INSPECTASSETGROUP, OP_INSPECTASSETGROUPASSETID, OP_INSPECTASSETGROUPCTRL,
-    OP_INSPECTASSETGROUPMETADATAHASH, OP_INSPECTASSETGROUPNUM, OP_INSPECTASSETGROUPSUM,
-    OP_INSPECTINASSETAT, OP_INSPECTINASSETCOUNT, OP_INSPECTINASSETLOOKUP,
-    OP_INSPECTINPUTARKADESCRIPTHASH, OP_INSPECTINPUTARKADEWITNESSHASH, OP_INSPECTINPUTOUTPOINT,
-    OP_INSPECTINPUTPACKET, OP_INSPECTINPUTSCRIPTPUBKEY, OP_INSPECTINPUTSEQUENCE,
-    OP_INSPECTINPUTVALUE, OP_INSPECTLOCKTIME, OP_INSPECTNUMASSETGROUPS, OP_INSPECTNUMINPUTS,
-    OP_INSPECTNUMOUTPUTS, OP_INSPECTOUTASSETAT, OP_INSPECTOUTASSETCOUNT, OP_INSPECTOUTASSETLOOKUP,
-    OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE, OP_INSPECTPACKET, OP_INSPECTVERSION,
-    OP_LESSTHAN, OP_LESSTHANOREQUAL, OP_MODEXP, OP_MUL, OP_NEGATE, OP_NIP, OP_NOT, OP_NUM2BIN,
-    OP_NUMEQUAL, OP_PICK, OP_PUSHCURRENTINPUTINDEX, OP_REVERSEBYTES, OP_ROLL, OP_SHA256,
-    OP_SHA256FINALIZE, OP_SHA256INITIALIZE, OP_SHA256UPDATE, OP_SIGHASH, OP_SIZE, OP_SUB,
-    OP_SUBSTR, OP_SWAP, OP_TOALTSTACK, OP_TWEAKVERIFY, OP_TXID, OP_TXWEIGHT, OP_VERIFY,
+    OP_FINDASSETGROUPBYASSETID, OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_IF, OP_INSPECTASSETGROUP,
+    OP_INSPECTASSETGROUPASSETID, OP_INSPECTASSETGROUPCTRL, OP_INSPECTASSETGROUPMETADATAHASH,
+    OP_INSPECTASSETGROUPNUM, OP_INSPECTASSETGROUPSUM, OP_INSPECTINASSETAT, OP_INSPECTINASSETCOUNT,
+    OP_INSPECTINASSETLOOKUP, OP_INSPECTINPUTARKADESCRIPTHASH, OP_INSPECTINPUTARKADEWITNESSHASH,
+    OP_INSPECTINPUTOUTPOINT, OP_INSPECTINPUTPACKET, OP_INSPECTINPUTSCRIPTPUBKEY,
+    OP_INSPECTINPUTSEQUENCE, OP_INSPECTINPUTVALUE, OP_INSPECTLOCKTIME, OP_INSPECTNUMASSETGROUPS,
+    OP_INSPECTNUMINPUTS, OP_INSPECTNUMOUTPUTS, OP_INSPECTOUTASSETAT, OP_INSPECTOUTASSETCOUNT,
+    OP_INSPECTOUTASSETLOOKUP, OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE,
+    OP_INSPECTPACKET, OP_INSPECTVERSION, OP_LESSTHAN, OP_LESSTHANOREQUAL, OP_MODEXP, OP_MUL,
+    OP_NEGATE, OP_NIP, OP_NOT, OP_NUM2BIN, OP_NUMEQUAL, OP_PICK, OP_PUSHCURRENTINPUTINDEX, OP_PUT,
+    OP_REVERSEBYTES, OP_SHA256, OP_SHA256FINALIZE, OP_SHA256INITIALIZE, OP_SHA256UPDATE,
+    OP_SIGHASH, OP_SIZE, OP_SUB, OP_SUBSTR, OP_SWAP, OP_TWEAKVERIFY, OP_TXID, OP_TXWEIGHT,
+    OP_VERIFY,
 };
 use crate::parser;
 use crate::typechecker::{self};
@@ -68,7 +68,6 @@ struct Generator {
     asm: Vec<String>,
     stack: Vec<StackItem>,
     scopes: Vec<usize>,
-    alt_depth: usize,
     constructor_array_expansions: Vec<(String, String)>,
     structs: Vec<crate::models::StructDefinition>,
 }
@@ -123,18 +122,9 @@ impl Generator {
             asm,
             stack,
             scopes: Vec::new(),
-            alt_depth: 0,
             constructor_array_expansions,
             structs: structs.to_vec(),
         })
-    }
-
-    fn push_depth(&mut self, depth: usize) {
-        self.asm.push(if depth <= 16 {
-            format!("OP_{depth}")
-        } else {
-            depth.to_string()
-        });
     }
 
     fn push_temporary(&mut self, token: impl Into<String>) {
@@ -203,10 +193,8 @@ impl Generator {
             .binding_index(name)
             .ok_or_else(|| format!("undefined binding '{name}'"))?;
         let depth = self.stack.len() - 1 - index;
-        self.push_depth(depth);
-        self.asm.push(OP_PICK.to_string());
-        self.stack.push(StackItem::Temporary);
-        Ok(())
+        self.push_integer_temporary(depth);
+        self.apply(OP_PICK, 1, 1)
     }
 
     fn push_integer_temporary(&mut self, value: usize) {
@@ -222,30 +210,38 @@ impl Generator {
         self.select_indexed_value(array)
     }
 
+    fn check_array_index(&mut self, array: &str) -> Result<(), String> {
+        self.apply(OP_DUP, 1, 2)?;
+        self.push_integer_temporary(0);
+        self.apply(OP_GREATERTHANOREQUAL, 2, 1)?;
+        self.apply(OP_VERIFY, 1, 0)?;
+
+        self.apply(OP_DUP, 1, 2)?;
+        self.push_integer_temporary(self.array_length(array));
+        self.apply(OP_LESSTHAN, 2, 1)?;
+        self.apply(OP_VERIFY, 1, 0)
+    }
+
     fn select_indexed_value(&mut self, array: &str) -> Result<(), String> {
         let first_element = internal_array_binding_name(array, "0");
         let first_index = self
             .binding_index(&first_element)
             .ok_or_else(|| format!("undefined array binding '{array}'"))?;
-        let first_depth = self.stack.len() - 1 - first_index;
-        let first_depth_without_index = first_depth.checked_sub(1).ok_or_else(|| {
-            format!("internal compiler error: array index for '{array}' is not on the stack")
-        })?;
+        let first_depth_without_index =
+            self.stack
+                .len()
+                .checked_sub(first_index + 2)
+                .ok_or_else(|| {
+                    format!(
+                        "internal compiler error: array index for '{array}' is not on the stack"
+                    )
+                })?;
 
-        self.push_integer_temporary(0);
-        self.apply(OP_PICK, 1, 1)?;
-        self.push_integer_temporary(0);
-        self.apply(OP_GREATERTHANOREQUAL, 2, 1)?;
-        self.apply(OP_VERIFY, 1, 0)?;
-
-        self.push_integer_temporary(0);
-        self.apply(OP_PICK, 1, 1)?;
-        self.push_integer_temporary(self.array_length(array));
-        self.apply(OP_LESSTHAN, 2, 1)?;
-        self.apply(OP_VERIFY, 1, 0)?;
-
-        self.push_integer_temporary(first_depth_without_index);
-        self.apply(OP_ADD, 2, 1)?;
+        self.check_array_index(array)?;
+        if first_depth_without_index != 0 {
+            self.push_integer_temporary(first_depth_without_index);
+            self.apply(OP_ADD, 2, 1)?;
+        }
         self.apply(OP_PICK, 1, 1)
     }
 
@@ -507,21 +503,24 @@ impl Generator {
         Ok(())
     }
 
-    fn assign(&mut self, name: &str) -> Result<(), String> {
-        if let Some((array, element)) = name.strip_suffix(']').and_then(|n| n.split_once('[')) {
-            if element.parse::<usize>().is_err() {
-                // Writing at a runtime depth needs a write-at-depth opcode
-                // (see docs: OP_PUT); emulating it costs one guarded write per
-                // element. Lift this once the VM provides that primitive.
-                return Err(format!(
-                    "assignment to '{array}' at a runtime index is not supported; use a literal index"
-                ));
-            }
+    fn assign(&mut self, target: &AssignmentTarget) -> Result<(), String> {
+        match target {
+            AssignmentTarget::Binding(name) => self.assign_static_binding(name, name),
+            AssignmentTarget::ArrayIndex { array, index } => match index.as_ref() {
+                Expression::Literal(index) => self.assign_static_binding(
+                    &internal_array_binding_name(array, index),
+                    &format!("{array}[{index}]"),
+                ),
+                index => self.assign_indexed_binding(array, index),
+            },
         }
-        let name = &Self::internal_binding_name(name);
+    }
+
+    fn assign_static_binding(&mut self, name: &str, display_name: &str) -> Result<(), String> {
+        let name = Self::internal_binding_name(name);
         let index = self
-            .binding_index(name)
-            .ok_or_else(|| format!("assignment to undeclared binding '{name}'"))?;
+            .binding_index(&name)
+            .ok_or_else(|| format!("assignment to undeclared binding '{display_name}'"))?;
         if matches!(
             self.stack[index],
             StackItem::Binding {
@@ -530,37 +529,55 @@ impl Generator {
             }
         ) {
             return Err(format!(
-                "cannot assign to constructor parameter '{name}'; constructor parameters are immutable"
+                "cannot assign to constructor parameter '{display_name}'; constructor parameters are immutable"
             ));
         }
         if !matches!(self.stack.last(), Some(StackItem::Temporary)) {
             return Err("internal compiler error: assignment has no result value".to_string());
         }
-        let depth = self.stack.len() - 1 - index;
-        self.push_depth(depth);
-        self.asm.push(OP_ROLL.to_string());
-        self.asm.push(OP_DROP.to_string());
-        for step in 0..depth.saturating_sub(1) {
-            self.asm.push(OP_SWAP.to_string());
-            if step + 1 < depth - 1 {
-                self.asm.push(OP_TOALTSTACK.to_string());
-                self.alt_depth += 1;
+        let depth = self.stack.len().checked_sub(index + 2).ok_or_else(|| {
+            format!("internal compiler error: invalid assignment target '{display_name}'")
+        })?;
+        self.push_integer_temporary(depth);
+        self.apply(OP_PUT, 2, 0)
+    }
+
+    fn assign_indexed_binding(&mut self, array: &str, index: &Expression) -> Result<(), String> {
+        let first_element = internal_array_binding_name(array, "0");
+        let first_index = self
+            .binding_index(&first_element)
+            .ok_or_else(|| format!("undefined array binding '{array}'"))?;
+        if matches!(
+            self.stack[first_index],
+            StackItem::Binding {
+                kind: BindingKind::Constructor,
+                ..
             }
+        ) {
+            return Err(format!(
+                "cannot assign to constructor parameter '{array}'; constructor parameters are immutable"
+            ));
         }
-        for _ in 0..depth.saturating_sub(2) {
-            self.asm.push(OP_FROMALTSTACK.to_string());
-            self.alt_depth = self.alt_depth.checked_sub(1).ok_or_else(|| {
-                "internal compiler error: assignment alternate-stack underflow".to_string()
-            })?;
+        if !matches!(self.stack.last(), Some(StackItem::Temporary)) {
+            return Err("internal compiler error: assignment has no result value".to_string());
         }
-        self.stack.pop();
-        if self.alt_depth != 0 {
-            return Err(
-                "internal compiler error: assignment left values on the alternate stack"
-                    .to_string(),
-            );
+
+        self.emit_expression(index)?;
+        let first_depth_without_operands =
+            self.stack
+                .len()
+                .checked_sub(first_index + 3)
+                .ok_or_else(|| {
+                    format!(
+                        "internal compiler error: array assignment operands for '{array}' are not on the stack"
+                    )
+                })?;
+        self.check_array_index(array)?;
+        if first_depth_without_operands != 0 {
+            self.push_integer_temporary(first_depth_without_operands);
+            self.apply(OP_ADD, 2, 1)?;
         }
-        Ok(())
+        self.apply(OP_PUT, 2, 0)
     }
 
     fn enter_scope(&mut self) {
@@ -593,11 +610,10 @@ impl Generator {
     }
 
     fn assert_statement_boundary(&self) -> Result<(), String> {
-        if self.alt_depth != 0
-            || self
-                .stack
-                .iter()
-                .any(|item| matches!(item, StackItem::Temporary))
+        if self
+            .stack
+            .iter()
+            .any(|item| matches!(item, StackItem::Temporary))
         {
             return Err(
                 "internal compiler error: statement left a temporary stack value".to_string(),
@@ -607,7 +623,7 @@ impl Generator {
     }
 
     fn finish(mut self) -> Result<Vec<String>, String> {
-        if !self.scopes.is_empty() || self.alt_depth != 0 {
+        if !self.scopes.is_empty() {
             return Err("internal compiler error: unbalanced generator scope".to_string());
         }
         self.push_temporary(OP_1);
@@ -924,9 +940,9 @@ fn generate_asm_from_statements_recursive(
                     generator.bind_local(name)?;
                 }
             },
-            Statement::VarAssign { name, value } => {
+            Statement::VarAssign { target, value } => {
                 generator.emit_expression(value)?;
-                generator.assign(name)?;
+                generator.assign(target)?;
             }
         }
         generator.assert_statement_boundary()?;
@@ -1175,7 +1191,7 @@ mod symbolic_stack_tests {
     use super::*;
 
     #[test]
-    fn deep_assignment_replaces_the_original_slot_and_restores_the_alt_stack() {
+    fn deep_assignment_uses_put_at_the_remaining_stack_depth() {
         let inputs = ["a", "b", "c", "d"]
             .into_iter()
             .map(|name| Parameter {
@@ -1186,25 +1202,11 @@ mod symbolic_stack_tests {
         let mut generator = Generator::new(&inputs, &[], &[]).expect("scalar test inputs");
 
         generator.push_temporary("9");
-        generator.assign("d").expect("deep assignment");
+        generator
+            .assign(&AssignmentTarget::Binding("d".to_string()))
+            .expect("deep assignment");
 
-        assert_eq!(
-            generator.asm,
-            [
-                "9",
-                "OP_4",
-                "OP_ROLL",
-                "OP_DROP",
-                "OP_SWAP",
-                "OP_TOALTSTACK",
-                "OP_SWAP",
-                "OP_TOALTSTACK",
-                "OP_SWAP",
-                "OP_FROMALTSTACK",
-                "OP_FROMALTSTACK",
-            ]
-        );
-        assert_eq!(generator.alt_depth, 0);
+        assert_eq!(generator.asm, ["9", "OP_3", "OP_PUT"]);
         assert_eq!(
             generator.stack,
             ["d", "c", "b", "a"]
@@ -1214,6 +1216,98 @@ mod symbolic_stack_tests {
                     kind: BindingKind::FunctionInput,
                 })
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn shallow_assignment_uses_zero_depth_put() {
+        let inputs = ["a", "b"]
+            .into_iter()
+            .map(|name| Parameter {
+                name: name.to_string(),
+                param_type: "int".to_string(),
+            })
+            .collect::<Vec<_>>();
+        let mut generator = Generator::new(&inputs, &[], &[]).expect("scalar test inputs");
+
+        generator.push_temporary("9");
+        generator
+            .assign(&AssignmentTarget::Binding("a".to_string()))
+            .expect("shallow assignment");
+
+        assert_eq!(generator.asm, ["9", "OP_0", "OP_PUT"]);
+        assert_eq!(
+            generator.stack,
+            ["b", "a"]
+                .into_iter()
+                .map(|name| StackItem::Binding {
+                    name: name.to_string(),
+                    kind: BindingKind::FunctionInput,
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn expression_index_assignment_checks_bounds_and_uses_put() {
+        let inputs = [
+            Parameter {
+                name: "values".to_string(),
+                param_type: "int[3]".to_string(),
+            },
+            Parameter {
+                name: "i".to_string(),
+                param_type: "int".to_string(),
+            },
+        ];
+        let mut generator = Generator::new(&inputs, &[], &[]).expect("array test inputs");
+        generator.push_temporary("7");
+        generator.bind_local("above").expect("local above array");
+
+        generator.push_temporary("9");
+        generator
+            .assign(&AssignmentTarget::ArrayIndex {
+                array: "values".to_string(),
+                index: Box::new(Expression::BinaryOp {
+                    left: Box::new(Expression::Variable("i".to_string())),
+                    op: "+".to_string(),
+                    right: Box::new(Expression::Literal("1".to_string())),
+                }),
+            })
+            .expect("expression index assignment");
+
+        assert_eq!(
+            generator.asm,
+            [
+                "7",
+                "9",
+                "OP_5",
+                "OP_PICK",
+                "1",
+                "OP_ADD",
+                "OP_DUP",
+                "OP_0",
+                "OP_GREATERTHANOREQUAL",
+                "OP_VERIFY",
+                "OP_DUP",
+                "OP_3",
+                "OP_LESSTHAN",
+                "OP_VERIFY",
+                "OP_1",
+                "OP_ADD",
+                "OP_PUT",
+            ]
+        );
+        assert!(generator
+            .stack
+            .iter()
+            .all(|item| !matches!(item, StackItem::Temporary)));
+        assert_eq!(
+            generator.stack.last(),
+            Some(&StackItem::Binding {
+                name: "above".to_string(),
+                kind: BindingKind::Local,
+            })
         );
     }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1249,6 +1249,47 @@ mod symbolic_stack_tests {
     }
 
     #[test]
+    fn indexed_assignment_without_offset_preserves_bindings() {
+        let inputs = [
+            Parameter {
+                name: "values".into(),
+                param_type: "int[3]".into(),
+            },
+            Parameter {
+                name: "i".into(),
+                param_type: "int".into(),
+            },
+        ];
+        let mut generator = Generator::new(&inputs, &[], &[]).expect("array test inputs");
+        let bindings = generator.stack.clone();
+        generator.push_temporary("9");
+        generator
+            .assign(&AssignmentTarget::ArrayIndex {
+                array: "values".into(),
+                index: Box::new(Expression::Variable("i".into())),
+            })
+            .expect("indexed assignment");
+        assert_eq!(
+            generator.asm,
+            [
+                "9",
+                "OP_4",
+                "OP_PICK",
+                "OP_DUP",
+                "OP_0",
+                "OP_GREATERTHANOREQUAL",
+                "OP_VERIFY",
+                "OP_DUP",
+                "OP_3",
+                "OP_LESSTHAN",
+                "OP_VERIFY",
+                "OP_PUT",
+            ]
+        );
+        assert_eq!(generator.stack, bindings);
+    }
+
+    #[test]
     fn expression_index_assignment_checks_bounds_and_uses_put() {
         let inputs = [
             Parameter {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -293,8 +293,11 @@ pub enum Statement {
         declared_type: Option<String>,
         value: Expression,
     },
-    /// name = expr; (variable reassignment)
-    VarAssign { name: String, value: Expression },
+    /// name = expr; or name[index] = expr; (variable reassignment)
+    VarAssign {
+        target: AssignmentTarget,
+        value: Expression,
+    },
     /// if (condition) { then_body } else { else_body }
     IfElse {
         condition: Expression,
@@ -307,6 +310,16 @@ pub enum Statement {
         value_var: String,
         iterable: Expression,
         body: Vec<Statement>,
+    },
+}
+
+/// A binding or array element on the left-hand side of an assignment.
+#[derive(Debug, Clone)]
+pub enum AssignmentTarget {
+    Binding(String),
+    ArrayIndex {
+        array: String,
+        index: Box<Expression>,
     },
 }
 

--- a/src/opcodes/mod.rs
+++ b/src/opcodes/mod.rs
@@ -106,6 +106,7 @@ pub const OP_DUP: &str = "OP_DUP";
 pub const OP_ROT: &str = "OP_ROT";
 pub const OP_OVER: &str = "OP_OVER";
 pub const OP_PICK: &str = "OP_PICK";
+pub const OP_PUT: &str = "OP_PUT";
 pub const OP_ROLL: &str = "OP_ROLL";
 pub const OP_TUCK: &str = "OP_TUCK";
 pub const OP_IFDUP: &str = "OP_IFDUP";

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -82,7 +82,11 @@ let_binding = {
 // Variable assignment (reassignment without let keyword)
 // Must check for = but not == or >= or <=
 var_assign = {
-    (identifier_property_access | array_index_access | identifier) ~ "=" ~ !("=") ~ general_expression ~ ";"
+    assignment_target ~ "=" ~ !("=") ~ general_expression ~ ";"
+}
+
+assignment_target = {
+    identifier ~ ("." ~ identifier)* ~ ("[" ~ general_expression ~ "]")?
 }
 
 // Require statement

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,4 @@
-use crate::models::{Contract, Function, Parameter, Statement, StructDefinition};
+use crate::models::{AssignmentTarget, Contract, Function, Parameter, Statement, StructDefinition};
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
 use pest_derive::Parser;
@@ -223,18 +223,17 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
         }
         Rule::var_assign => {
             let mut inner = pair.into_inner();
-            let name = inner
-                .next()
-                .ok_or_else(|| "Parse error: Missing variable name in assignment".to_string())?
-                .as_str()
-                .split_whitespace()
-                .collect::<String>();
+            let target = parse_assignment_target(
+                inner
+                    .next()
+                    .ok_or_else(|| "Parse error: Missing assignment target".to_string())?,
+            )?;
             let value_pair = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing value in assignment".to_string())?;
             let value = parse_general_expression(value_pair)?;
 
-            func.statements.push(Statement::VarAssign { name, value });
+            func.statements.push(Statement::VarAssign { target, value });
             Ok(())
         }
         Rule::if_stmt => {
@@ -323,6 +322,29 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
     }
 }
 
+fn parse_assignment_target(pair: Pair<Rule>) -> Result<AssignmentTarget, String> {
+    let mut path = Vec::new();
+    let mut index = None;
+    for part in pair.into_inner() {
+        match part.as_rule() {
+            Rule::identifier => path.push(part.as_str().to_string()),
+            Rule::general_expression => index = Some(parse_general_expression(part)?),
+            rule => return Err(format!("Unexpected rule in assignment target: {rule:?}")),
+        }
+    }
+    let name = path.join(".");
+    if name.is_empty() {
+        return Err("Parse error: Missing assignment target".to_string());
+    }
+    Ok(match index {
+        Some(index) => AssignmentTarget::ArrayIndex {
+            array: name,
+            index: Box::new(index),
+        },
+        None => AssignmentTarget::Binding(name),
+    })
+}
+
 // ─── Expression Parsing ────────────────────────────────────────────────────────
 
 // Parse a block of statements
@@ -385,7 +407,53 @@ pub(crate) fn parse_parameters(params: Pair<Rule>) -> Result<Vec<Parameter>, Str
 #[cfg(test)]
 mod tests {
     use super::parse;
-    use crate::models::{Requirement, Statement};
+    use crate::models::{AssignmentTarget, Expression, Requirement, Statement};
+
+    #[test]
+    fn parses_structured_assignment_targets() {
+        let contract = parse(
+            r#"
+struct State {
+    bool enabled;
+    int[3] values;
+}
+
+contract Demo() {
+    function spend(State state, int index) {
+        state.enabled = true;
+        state.values[index + 1] = 9;
+        index = 0;
+        require(true);
+    }
+}
+"#,
+        )
+        .expect("contract should parse");
+
+        let statements = &contract.functions[0].statements;
+        assert!(matches!(
+            &statements[0],
+            Statement::VarAssign {
+                target: AssignmentTarget::Binding(name),
+                ..
+            } if name == "state.enabled"
+        ));
+        assert!(matches!(
+            &statements[1],
+            Statement::VarAssign {
+                target: AssignmentTarget::ArrayIndex { array, index },
+                ..
+            } if array == "state.values"
+                && matches!(index.as_ref(), Expression::BinaryOp { op, .. } if op == "+")
+        ));
+        assert!(matches!(
+            &statements[2],
+            Statement::VarAssign {
+                target: AssignmentTarget::Binding(name),
+                ..
+            } if name == "index"
+        ));
+    }
 
     #[test]
     fn retains_declared_local_types_and_multisig_signatures() {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -9,7 +9,7 @@
 ///   decides how to surface them)
 use std::collections::HashMap;
 
-use crate::models::{Contract, Expression, Function, Requirement, Statement};
+use crate::models::{AssignmentTarget, Contract, Expression, Function, Requirement, Statement};
 
 // ─── Type Enum ────────────────────────────────────────────────────────────────
 
@@ -256,7 +256,12 @@ fn resolve_statements(
                     .unwrap_or_else(|| infer_type(value, scope));
                 bind_local_type(scope, name, declared_type.as_deref(), binding_type, structs);
             }
-            Statement::VarAssign { value, .. } => resolve_expression(value, scope),
+            Statement::VarAssign { target, value } => {
+                if let AssignmentTarget::ArrayIndex { index, .. } = target {
+                    resolve_expression(index, scope);
+                }
+                resolve_expression(value, scope);
+            }
             Statement::IfElse {
                 condition,
                 then_body,
@@ -570,14 +575,23 @@ fn check_statement(
                 .unwrap_or(inferred);
             bind_local_type(scope, name, declared_type.as_deref(), t, structs);
         }
-        Statement::VarAssign { name, value } => {
-            let original_type = scope.get(name.as_str()).cloned();
-            if original_type.is_none() {
-                errors.push(TypeError::new(format!(
-                    "fn {}: assignment to undeclared variable '{}'",
-                    fn_name, name
-                )));
-            }
+        Statement::VarAssign { target, value } => {
+            let (target_name, original_type) = match target {
+                AssignmentTarget::Binding(name) => {
+                    let original_type = scope.get(name.as_str()).cloned();
+                    if original_type.is_none() {
+                        errors.push(TypeError::new(format!(
+                            "fn {}: assignment to undeclared variable '{}'",
+                            fn_name, name
+                        )));
+                    }
+                    (format!("'{name}'"), original_type)
+                }
+                AssignmentTarget::ArrayIndex { array, index } => (
+                    format!("an element of '{array}'"),
+                    check_array_index(array, index, scope, errors, fn_name),
+                ),
+            };
             check_expression(value, scope, errors, fn_name);
             let assigned_type = infer_type(value, scope);
             if let Some(original_type) = original_type {
@@ -586,9 +600,9 @@ fn check_statement(
                     && original_type != assigned_type
                 {
                     errors.push(TypeError::new(format!(
-                        "fn {}: assignment to '{}' changes its type from '{}' to '{}'",
+                        "fn {}: assignment to {} changes its type from '{}' to '{}'",
                         fn_name,
-                        name,
+                        target_name,
                         original_type.as_str(),
                         assigned_type.as_str()
                     )));
@@ -711,14 +725,7 @@ fn check_requirement(req: &Requirement, scope: &Scope, errors: &mut Vec<TypeErro
 fn check_expression(expr: &Expression, scope: &Scope, errors: &mut Vec<TypeError>, fn_name: &str) {
     match expr {
         Expression::ArrayIndex { array, index } => {
-            check_expression(index, scope, errors, fn_name);
-            let index_type = infer_type(index, scope);
-            if !matches!(index_type, ArkType::Int | ArkType::Unknown) {
-                errors.push(TypeError::new(format!(
-                    "fn {fn_name}: array index for '{array}' has type '{}', expected 'int'",
-                    index_type.as_str()
-                )));
-            }
+            check_array_index(array, index, scope, errors, fn_name);
         }
         Expression::BinaryOp { left, op, right } => {
             check_expression(left, scope, errors, fn_name);
@@ -746,6 +753,38 @@ fn check_expression(expr: &Expression, scope: &Scope, errors: &mut Vec<TypeError
             );
         }
         _ => {}
+    }
+}
+
+fn check_array_index(
+    array: &str,
+    index: &Expression,
+    scope: &Scope,
+    errors: &mut Vec<TypeError>,
+    fn_name: &str,
+) -> Option<ArkType> {
+    check_expression(index, scope, errors, fn_name);
+    let index_type = infer_type(index, scope);
+    if !matches!(index_type, ArkType::Int | ArkType::Unknown) {
+        errors.push(TypeError::new(format!(
+            "fn {fn_name}: array index for '{array}' has type '{}', expected 'int'",
+            index_type.as_str()
+        )));
+    }
+    match scope.get(array) {
+        Some(ArkType::Array(element, _)) => Some((**element).clone()),
+        _ => None,
+    }
+}
+
+pub(crate) fn literal_index(expression: &Expression) -> Option<(bool, &str)> {
+    match expression {
+        Expression::Literal(value) => Some((false, value)),
+        Expression::Negate { value } => match value.as_ref() {
+            Expression::Literal(value) => Some((true, value)),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -19,8 +19,8 @@
 //! Issues are returned as a `Vec<ValidationIssue>`.  Use [`has_errors`] to check
 //! whether any are fatal.
 
-use crate::models::{Contract, ContractJson, Expression, Requirement, Statement};
-use crate::typechecker::{build_scope_with_structs, infer_type, ArkType, Scope};
+use crate::models::{AssignmentTarget, Contract, ContractJson, Expression, Requirement, Statement};
+use crate::typechecker::{build_scope_with_structs, infer_type, literal_index, ArkType, Scope};
 use std::collections::{HashMap, HashSet};
 
 // ─── Issue types ──────────────────────────────────────────────────────────────
@@ -485,10 +485,15 @@ fn walk_asset_id_stmts(
                     structs,
                 );
             }
-            Statement::VarAssign { name, value } => {
+            Statement::VarAssign { target, value } => {
+                if let AssignmentTarget::ArrayIndex { index, .. } = target {
+                    check_asset_id_expr(index, scope, fname, issues);
+                }
                 check_asset_id_expr(value, scope, fname, issues);
-                let t = infer_type(value, scope);
-                scope.insert(name.clone(), t);
+                if let AssignmentTarget::Binding(name) = target {
+                    let t = infer_type(value, scope);
+                    scope.insert(name.clone(), t);
+                }
             }
             Statement::IfElse {
                 condition,
@@ -942,37 +947,63 @@ fn validate_binding_statements(
                     );
                 }
             }
-            Statement::VarAssign { name, value } => {
+            Statement::VarAssign { target, value } => {
                 validate_binding_expression(value, function_name, scopes, issues, true);
                 let inferred = resolved_expression_type(value, scopes);
-                match find_binding(scopes, name) {
-                    None => issues.push(ValidationIssue::error(format!(
-                        "function '{}': assignment to undeclared variable '{}'",
-                        function_name, name
-                    ))),
-                    Some(binding) if binding.source == BindingSource::Constructor => {
-                        // The existing shadowing walk owns the constructor-mutation diagnostic.
-                    }
-                    Some(binding) if binding.source == BindingSource::Loop => {
-                        issues.push(ValidationIssue::error(format!(
-                            "function '{}': cannot assign to compile-time loop variable '{}'",
+                match target {
+                    AssignmentTarget::Binding(name) => match find_binding(scopes, name) {
+                        None => issues.push(ValidationIssue::error(format!(
+                            "function '{}': assignment to undeclared variable '{}'",
                             function_name, name
-                        )));
+                        ))),
+                        Some(binding) if binding.source == BindingSource::Constructor => {
+                            // The shadowing walk owns the constructor-mutation diagnostic.
+                        }
+                        Some(binding) if binding.source == BindingSource::Loop => {
+                            issues.push(ValidationIssue::error(format!(
+                                "function '{}': cannot assign to compile-time loop variable '{}'",
+                                function_name, name
+                            )));
+                        }
+                        Some(binding)
+                            if inferred != ArkType::Unknown
+                                && binding.binding_type != ArkType::Unknown
+                                && !binding_types_compatible(&binding.binding_type, &inferred) =>
+                        {
+                            issues.push(ValidationIssue::error(format!(
+                                "function '{}': assignment to '{}' changes its type from '{}' to '{}'",
+                                function_name,
+                                name,
+                                binding.binding_type.as_str(),
+                                inferred.as_str()
+                            )));
+                        }
+                        Some(_) => {}
+                    },
+                    AssignmentTarget::ArrayIndex { array, index } => {
+                        if let Some((element_type, source)) =
+                            validate_array_index(array, index, function_name, scopes, issues)
+                        {
+                            if source == BindingSource::Loop {
+                                issues.push(ValidationIssue::error(format!(
+                                    "function '{}': cannot assign to compile-time loop variable '{}'",
+                                    function_name, array
+                                )));
+                            } else if inferred != ArkType::Unknown
+                                && element_type != ArkType::Unknown
+                                && !binding_types_compatible(&element_type, &inferred)
+                            {
+                                issues.push(ValidationIssue::error(format!(
+                                    "function '{}': assignment to an element of '{}' changes its type from '{}' to '{}'",
+                                    function_name,
+                                    array,
+                                    element_type.as_str(),
+                                    inferred.as_str()
+                                )));
+                            }
+                        }
+                        validate_binding_expression(index, function_name, scopes, issues, true);
                     }
-                    Some(binding)
-                        if inferred != ArkType::Unknown
-                            && binding.binding_type != ArkType::Unknown
-                            && !binding_types_compatible(&binding.binding_type, &inferred) =>
-                    {
-                        issues.push(ValidationIssue::error(format!(
-                            "function '{}': assignment to '{}' changes its type from '{}' to '{}'",
-                            function_name,
-                            name,
-                            binding.binding_type.as_str(),
-                            inferred.as_str()
-                        )));
-                    }
-                    Some(_) => {}
                 }
             }
             Statement::IfElse {
@@ -1409,39 +1440,7 @@ fn validate_binding_expression(
             validate_named_binding(name, None, "binding", function_name, scopes, issues);
         }
         Expression::ArrayIndex { array, index } => {
-            let mut length = None;
-            match find_binding(scopes, array) {
-                None => issues.push(ValidationIssue::error(format!(
-                    "function '{}': array '{}' is undefined",
-                    function_name, array
-                ))),
-                Some(BindingInfo {
-                    binding_type: ArkType::Array(_, declared_length),
-                    ..
-                }) => length = Some(*declared_length),
-                Some(_) => {
-                    issues.push(ValidationIssue::error(format!(
-                        "function '{}': binding '{}' is not an array",
-                        function_name, array
-                    )));
-                }
-            }
-            let index_type = resolved_expression_type(index, scopes);
-            if !matches!(index_type, ArkType::Int | ArkType::Unknown) {
-                issues.push(ValidationIssue::error(format!(
-                    "function '{}': array index has type '{}', expected 'int'",
-                    function_name,
-                    index_type.as_str()
-                )));
-            }
-            if let (Expression::Literal(index), Some(length)) = (index.as_ref(), length) {
-                if index.parse::<usize>().map_or(true, |i| i >= length) {
-                    issues.push(ValidationIssue::error(format!(
-                        "function '{}': array index '{}' is out of range for '{}[{}]'",
-                        function_name, index, array, length
-                    )));
-                }
-            }
+            validate_array_index(array, index, function_name, scopes, issues);
         }
         Expression::Property(name) if name.contains('[') => {
             validate_named_binding(name, None, "binding", function_name, scopes, issues);
@@ -1557,6 +1556,62 @@ fn validate_binding_expression(
             !matches!(expression, Expression::ContractInstance { .. }),
         );
     }
+}
+
+fn validate_array_index(
+    array: &str,
+    index: &Expression,
+    function_name: &str,
+    scopes: &BindingScopes,
+    issues: &mut Vec<ValidationIssue>,
+) -> Option<(ArkType, BindingSource)> {
+    let array_info = match find_binding(scopes, array) {
+        None => {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': array '{}' is undefined",
+                function_name, array
+            )));
+            None
+        }
+        Some(BindingInfo {
+            binding_type: ArkType::Array(element, length),
+            source,
+        }) => Some(((**element).clone(), *length, *source)),
+        Some(_) => {
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': binding '{}' is not an array",
+                function_name, array
+            )));
+            None
+        }
+    };
+
+    let index_type = resolved_expression_type(index, scopes);
+    if !matches!(index_type, ArkType::Int | ArkType::Unknown) {
+        issues.push(ValidationIssue::error(format!(
+            "function '{}': array index has type '{}', expected 'int'",
+            function_name,
+            index_type.as_str()
+        )));
+    }
+    if let (Some((negative, literal)), Some((_, length, _))) =
+        (literal_index(index), array_info.as_ref())
+    {
+        let in_bounds = if negative {
+            literal == "0"
+        } else {
+            literal.parse::<usize>().is_ok_and(|index| index < *length)
+        };
+        if !in_bounds {
+            let sign = if negative { "-" } else { "" };
+            issues.push(ValidationIssue::error(format!(
+                "function '{}': array index '{}{}' is out of range for '{}[{}]'",
+                function_name, sign, literal, array, length
+            )));
+        }
+    }
+
+    array_info.map(|(element_type, _, source)| (element_type, source))
 }
 
 /// Validate one `(asset_txid, asset_gidx)` pair.
@@ -1681,8 +1736,8 @@ fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     }
 }
 
-/// Reject `name = expr;` where `name` is a constructor parameter; constructor
-/// parameters are immutable. Recurses into branch and loop bodies.
+/// Reject assignments to constructor parameters or their flattened children.
+/// Recurses into branch and loop bodies.
 fn check_ctor_assignment(
     stmts: &[Statement],
     fname: &str,
@@ -1691,8 +1746,13 @@ fn check_ctor_assignment(
 ) {
     for stmt in stmts {
         match stmt {
-            Statement::VarAssign { name, .. } => {
-                if ctor_names.contains(name.as_str()) {
+            Statement::VarAssign { target, .. } => {
+                let name = match target {
+                    AssignmentTarget::Binding(name) => name,
+                    AssignmentTarget::ArrayIndex { array, .. } => array,
+                };
+                let root = name.split('.').next().unwrap_or(name);
+                if ctor_names.contains(root) {
                     issues.push(ValidationIssue::error(format!(
                         "cannot assign to constructor parameter '{}' in function '{}'; \
                          constructor parameters are immutable",
@@ -1908,6 +1968,78 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
 mod tests {
     use super::*;
     use crate::models::{AbiFunctionGroup, AbiLeaf, Contract, Function, Parameter, WitnessElement};
+
+    fn parse_and_validate(source: &str) -> Vec<ValidationIssue> {
+        validate_ast(&crate::parser::parse(source).expect("contract should parse"))
+    }
+
+    #[test]
+    fn validates_dynamic_array_assignment_target() {
+        let issues = parse_and_validate(
+            r#"
+contract Demo() {
+    function spend(int offset) {
+        int[3] values = [1, 2, 3];
+        values[offset + 1] = 4;
+        require(values[0] == 1);
+    }
+}
+"#,
+        );
+        assert!(!has_errors(&issues), "{issues:?}");
+    }
+
+    #[test]
+    fn rejects_invalid_array_assignment_targets_once() {
+        for (target, expected) in [
+            ("value[0]", "binding 'value' is not an array"),
+            ("missing[0]", "array 'missing' is undefined"),
+            ("values[flag]", "array index has type 'bool'"),
+            ("values[missing]", "binding 'missing' is undefined"),
+            ("values[3]", "array index '3' is out of range"),
+            ("values[-1]", "array index '-1' is out of range"),
+        ] {
+            let source = format!(
+                r#"
+contract Demo() {{
+    function spend(bool flag) {{
+        int value = 1;
+        int[3] values = [1, 2, 3];
+        {target} = 4;
+        require(true);
+    }}
+}}
+"#
+            );
+            let issues = parse_and_validate(&source);
+            assert_eq!(
+                issues
+                    .iter()
+                    .filter(|issue| issue.message.contains(expected))
+                    .count(),
+                1,
+                "{issues:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_array_assignment_with_wrong_element_type() {
+        let issues = parse_and_validate(
+            r#"
+contract Demo() {
+    function spend() {
+        int[2] values = [1, 2];
+        values[0] = true;
+        require(true);
+    }
+}
+"#,
+        );
+        assert!(issues.iter().any(|issue| issue
+            .message
+            .contains("assignment to an element of 'values' changes its type")));
+    }
 
     fn make_contract(name: &str) -> Contract {
         Contract {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1974,6 +1974,29 @@ mod tests {
     }
 
     #[test]
+    fn rejects_undefined_bindings_in_array_indices_once() {
+        for statement in [
+            "require(values[missing] == 1);",
+            "require(values[missing + 1] == 1);",
+            "values[missing] = 1;",
+            "values[missing + 1] = 1;",
+        ] {
+            let issues = parse_and_validate(&format!(
+                "contract C() {{ function spend(int[3] values) {{ {statement} require(true); }} }}"
+            ));
+            assert_eq!(
+                issues
+                    .iter()
+                    .filter(|issue| issue.message.contains("'missing'"))
+                    .count(),
+                1,
+                "{statement}: {issues:?}"
+            );
+            assert!(has_errors(&issues), "{issues:?}");
+        }
+    }
+
+    #[test]
     fn validates_dynamic_array_assignment_target() {
         let issues = parse_and_validate(
             r#"

--- a/tests/e2e/contracts/static_arrays.ark
+++ b/tests/e2e/contracts/static_arrays.ark
@@ -1,6 +1,6 @@
 // Static array coverage for the emulator VM: sized constructor and function
 // arrays, literal and runtime indexing, per-array loop unrolling, `.length`,
-// and a local array with one element reassigned.
+// and a local array with an expression-indexed element reassigned.
 
 contract StaticArrays(
   int[4] weights,
@@ -8,7 +8,7 @@ contract StaticArrays(
 ) {
   function spend(
     int index,
-    int scaleIndex,
+    int writeIndex,
     int expected,
     int[5] samples,
     signature ownerSig
@@ -16,9 +16,9 @@ contract StaticArrays(
     require(weights.length + samples.length == 9, "declared sizes");
 
     int[3] scale = [1, 2, 3];
-    scale[1] = 10;
+    scale[writeIndex + 1] = 10;
 
-    int total = (samples[index] * scale[scaleIndex]) + scale[0];
+    int total = (samples[index] * scale[writeIndex + 1]) + scale[0];
 
     for (i, weight) in weights {
       total = total + (weight * (i + 1));

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,10 +1,10 @@
 module github.com/arkade-os/compiler/tests/e2e
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70
-	github.com/arkade-os/emulator/pkg/arkade v0.0.0-20260728084232-b2c7d853d267
+	github.com/arkade-os/emulator/pkg/arkade v0.0.0-20260901100544-9502589bb7d5
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.9

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -5,8 +5,8 @@ github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70 h1:qL
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260318170839-137daaec3a70/go.mod h1:VpyqrRS8Qk3uAhUTiH417gyC52caAfan/o8aVPDO528=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea h1:x9ZwZL+F2b9E0uBZYBVjCLGtlqIE4zahDOY4C89h3X4=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea/go.mod h1:NYGE+baj57ynbXNwjISJddMDpMqAWOX27dV22xqFm2A=
-github.com/arkade-os/emulator/pkg/arkade v0.0.0-20260728084232-b2c7d853d267 h1:ycK+v+qyFEE6sb4nzinMP7ylKULuakaAkeXvyHL+W0A=
-github.com/arkade-os/emulator/pkg/arkade v0.0.0-20260728084232-b2c7d853d267/go.mod h1:JMzA6P2i+VItxD8nqGfO4cunhW22Z/6100gCv/hVyEE=
+github.com/arkade-os/emulator/pkg/arkade v0.0.0-20260901100544-9502589bb7d5 h1:4AJnxm/UoNoNLNV7VbAGnhLgKeL+9L86RzvUkYgwio8=
+github.com/arkade-os/emulator/pkg/arkade v0.0.0-20260901100544-9502589bb7d5/go.mod h1:6bE/WOZwfQE6fs+fmJiniRY+YtLk9GphI4QK4Ea9MzU=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/tests/e2e/static_arrays_test.go
+++ b/tests/e2e/static_arrays_test.go
@@ -2,16 +2,17 @@ package e2e
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 )
 
 // Mirrors contracts/static_arrays.ark, computed independently of the compiler.
-// scale is [1, 2, 3] with element 1 reassigned to 10.
-func expectedTotal(weights [4]int64, samples [5]int64, index, scaleIndex int64) int64 {
-	scale := [3]int64{1, 10, 3}
-	total := samples[index]*scale[scaleIndex] + scale[0]
+func expectedTotal(weights [4]int64, samples [5]int64, index, writeIndex int64) int64 {
+	scale := [3]int64{1, 2, 3}
+	scale[writeIndex+1] = 10
+	total := samples[index]*scale[writeIndex+1] + scale[0]
 	for i, weight := range weights {
 		total += weight * int64(i+1)
 	}
@@ -19,7 +20,7 @@ func expectedTotal(weights [4]int64, samples [5]int64, index, scaleIndex int64) 
 		if sample > 0 {
 			total += sample * int64(j+1)
 		} else {
-			total -= 3
+			total -= scale[2]
 		}
 	}
 	return total
@@ -36,6 +37,9 @@ func TestStaticArrays(t *testing.T) {
 		t.Fatalf("constructor input 0 = %+v, want weights int[4]", got)
 	}
 	group := covenantGroup(t, contract, "spend")
+	if !slices.Contains(group.Arkade.ASM, "OP_PUT") {
+		t.Fatalf("covenant does not contain OP_PUT: %v", group.Arkade.ASM)
+	}
 	if got := group.Arkade.Inputs[3]; got.Name != "samples" || got.Type != "int[5]" {
 		t.Fatalf("covenant input 3 = %+v, want samples int[5]", got)
 	}
@@ -55,16 +59,15 @@ func TestStaticArrays(t *testing.T) {
 	testCases := []struct {
 		name       string
 		index      int64
-		scaleIndex int64
+		writeIndex int64
 		samples    [5]int64
 		total      int64
 		wantErr    string
 	}{
-		// scaleIndex indexes the local array at runtime, so these also pin the
-		// order its elements are pushed in.
-		{name: "first element", index: 0, scaleIndex: 0, samples: [5]int64{4, 6, 8, 1, 2}},
-		{name: "middle element", index: 2, scaleIndex: 1, samples: [5]int64{5, -1, 7, 0, 9}},
-		{name: "last element", index: 4, scaleIndex: 2, samples: [5]int64{1, 2, 3, 4, 5}},
+		// writeIndex + 1 targets each local-array element and pins its stack order.
+		{name: "first element", index: 0, writeIndex: -1, samples: [5]int64{4, 6, 8, 1, 2}},
+		{name: "middle element", index: 2, writeIndex: 0, samples: [5]int64{5, -1, 7, 0, 9}},
+		{name: "last element", index: 4, writeIndex: 1, samples: [5]int64{1, 2, 3, 4, 5}},
 		{
 			name:    "index past the declared size is rejected",
 			index:   5,
@@ -80,9 +83,17 @@ func TestStaticArrays(t *testing.T) {
 			wantErr: "OP_VERIFY failed",
 		},
 		{
-			name:       "local array index past its declared size is rejected",
+			// Without the array upper bound, OP_PUT could overwrite an adjacent slot.
+			name:       "computed write index past the array is rejected",
 			index:      1,
-			scaleIndex: 3,
+			writeIndex: 2,
+			samples:    [5]int64{1, 2, 3, 4, 5},
+			wantErr:    "OP_VERIFY failed",
+		},
+		{
+			name:       "negative computed write index fails the bound check",
+			index:      1,
+			writeIndex: -2,
 			samples:    [5]int64{1, 2, 3, 4, 5},
 			wantErr:    "OP_VERIFY failed",
 		},
@@ -103,16 +114,16 @@ func TestStaticArrays(t *testing.T) {
 				if index < 0 || index >= int64(len(testCase.samples)) {
 					index = 0
 				}
-				scaleIndex := testCase.scaleIndex
-				if scaleIndex < 0 || scaleIndex > 2 {
-					scaleIndex = 0
+				writeIndex := testCase.writeIndex
+				if writeIndex < -1 || writeIndex > 1 {
+					writeIndex = 0
 				}
-				total = expectedTotal(weights, testCase.samples, index, scaleIndex)
+				total = expectedTotal(weights, testCase.samples, index, writeIndex)
 			}
 
 			values := map[string][]byte{
 				"index":      scriptInt(t, testCase.index),
-				"scaleIndex": scriptInt(t, testCase.scaleIndex),
+				"writeIndex": scriptInt(t, testCase.writeIndex),
 				"expected":   scriptInt(t, total),
 				"ownerSig":   nil,
 			}

--- a/tests/features/static_arrays.rs
+++ b/tests/features/static_arrays.rs
@@ -1,6 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_CAT, OP_CHECKSIGFROMSTACK, OP_DROP, OP_LESSTHAN, OP_ROLL, OP_SWAP,
+    OP_ADD, OP_CAT, OP_CHECKSIGFROMSTACK, OP_DUP, OP_GREATERTHANOREQUAL, OP_LESSTHAN, OP_PUT,
+    OP_VERIFY,
 };
 
 fn contains_tokens(asm: &[String], expected: &[&str]) -> bool {
@@ -220,28 +221,42 @@ contract Local() {
 
     let asm = crate::common::arkade_asm_tokens(&output, "spend");
     assert!(
-        contains_tokens(&asm, &["4", "OP_1", OP_ROLL, OP_DROP]),
+        contains_tokens(&asm, &["4", "OP_0", OP_PUT]),
         "assignment overwrites the element in place: {asm:?}"
     );
 }
 
 #[test]
-fn assignment_at_a_runtime_index_is_rejected() {
-    let error = compile(
+fn array_element_assignment_accepts_runtime_index_expressions() {
+    let output = compile(
         r#"
 contract Local() {
     function spend(int amount, int index) {
         int[2] weights = [1, 2];
-        weights[index] = 4;
+        weights[index + 1] = 4;
         require(amount >= weights[0]);
     }
 }
 "#,
     )
-    .expect_err("runtime-index assignment must be rejected")
-    .to_string();
+    .expect("runtime expression-index assignment must compile");
 
-    assert!(error.contains("runtime index"), "unexpected error: {error}");
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(
+        contains_tokens(
+            &asm,
+            &[OP_ADD, OP_DUP, "OP_0", OP_GREATERTHANOREQUAL, OP_VERIFY]
+        ),
+        "assignment must check the computed index's lower bound: {asm:?}"
+    );
+    assert!(
+        contains_tokens(&asm, &[OP_DUP, "OP_2", OP_LESSTHAN, OP_VERIFY, OP_PUT]),
+        "assignment must check the computed index against the array size: {asm:?}"
+    );
+    assert!(
+        asm.iter().any(|token| token == OP_PUT),
+        "assignment must write the computed stack depth with {OP_PUT}: {asm:?}"
+    );
 }
 
 #[test]
@@ -431,10 +446,8 @@ contract Local() {
     .expect("element assignment at a non-zero index must compile");
 
     let asm = crate::common::arkade_asm_tokens(&output, "spend");
-    // Index 0 sits directly under the pushed value (depth 1, no walk-back);
-    // index 1 is one deeper and must be swapped back into place.
     assert!(
-        contains_tokens(&asm, &["9", "OP_2", OP_ROLL, OP_DROP, OP_SWAP]),
-        "the write must roll the element at its own depth, not index 0's: {asm:?}"
+        contains_tokens(&asm, &["9", "OP_1", OP_PUT]),
+        "the write must replace the element at its own depth, not index 0's: {asm:?}"
     );
 }

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,7 +1,8 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_EQUAL, OP_INSPECTASSETGROUPASSETID,
-    OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN, OP_PICK, OP_SWAP,
+    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_EQUAL, OP_GREATERTHANOREQUAL,
+    OP_INSPECTASSETGROUPASSETID, OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN, OP_PICK, OP_PUT, OP_SWAP,
+    OP_VERIFY,
 };
 
 #[test]
@@ -284,6 +285,36 @@ contract C(Values values) {
     let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
     assert!(asm.windows(2).any(|tokens| tokens == ["OP_3", OP_LESSTHAN]));
     assert!(asm.iter().filter(|token| token.as_str() == OP_ADD).count() >= 4);
+}
+
+#[test]
+fn local_struct_array_field_supports_expression_index_assignment() {
+    let output = compile(
+        r#"
+struct State { int[3] values; }
+contract C() {
+    function spend(int index, int next) {
+        State state = { values: [1, 2, 3] };
+        state.values[index + 1] = next;
+        require(state.values[index + 1] == next);
+    }
+}
+"#,
+    )
+    .expect("local struct array fields should support expression-indexed assignment");
+
+    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert!(asm.iter().any(|token| token == OP_PUT), "{asm:?}");
+    assert!(
+        asm.windows(4)
+            .any(|tokens| { tokens == [OP_DUP, "OP_0", OP_GREATERTHANOREQUAL, OP_VERIFY] }),
+        "missing lower-bound check: {asm:?}"
+    );
+    assert!(
+        asm.windows(4)
+            .any(|tokens| { tokens == [OP_DUP, "OP_3", OP_LESSTHAN, OP_VERIFY] }),
+        "missing upper-bound check: {asm:?}"
+    );
 }
 
 #[test]

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -303,7 +303,28 @@ contract C() {
     )
     .expect("local struct array fields should support expression-indexed assignment");
 
-    let asm = &output.functions[0].arkade.as_ref().expect("covenant").asm;
+    assert_eq!(output.functions.len(), 1);
+    let group = crate::common::group(&output, "spend");
+    assert_eq!(group.leaves.len(), 1);
+    assert_eq!(group.leaves[0].name, "spend");
+    assert_eq!(
+        crate::common::witness_names(&output, "spend", "spend"),
+        ["serverSig", "emulatorSig"]
+    );
+    assert!(group.leaves[0]
+        .witness
+        .iter()
+        .all(|w| w.elem_type == "signature" && w.injected));
+    assert_eq!(
+        crate::common::leaf_asm(&output, "spend", "spend"),
+        "<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:spend> OP_CHECKSIG"
+    );
+    let covenant = group.arkade.as_ref().expect("spend covenant");
+    assert_eq!(
+        crate::common::arkade_inputs(&output, "spend"),
+        ["index", "next"]
+    );
+    let asm = &covenant.asm;
     assert!(asm.iter().any(|token| token == OP_PUT), "{asm:?}");
     assert!(
         asm.windows(4)

--- a/tests/features/symbolic_stack.rs
+++ b/tests/features/symbolic_stack.rs
@@ -1,7 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_DROP, OP_ELSE, OP_ENDIF, OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_IF, OP_LESSTHAN,
-    OP_MUL, OP_PICK, OP_ROLL,
+    OP_ADD, OP_DROP, OP_DUP, OP_ELSE, OP_ENDIF, OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_IF,
+    OP_LESSTHAN, OP_MUL, OP_PICK, OP_PUT,
 };
 
 fn covenant(source: &str, function: &str) -> arkade_compiler::models::ArkadeCovenant {
@@ -101,8 +101,13 @@ contract Mutate() {
     );
 
     assert!(
-        covenant.asm.iter().any(|token| token == OP_ROLL),
-        "in-place reassignment must roll the old slot into position: {:?}",
+        covenant
+            .asm
+            .iter()
+            .filter(|token| token.as_str() == OP_PUT)
+            .count()
+            >= 3,
+        "each scalar reassignment must replace its existing slot with {OP_PUT}: {:?}",
         covenant.asm
     );
     let if_index = covenant
@@ -173,7 +178,7 @@ contract RuntimeIndex() {
         "spend",
     );
 
-    for opcode in [OP_GREATERTHANOREQUAL, OP_LESSTHAN, OP_ADD, OP_PICK] {
+    for opcode in [OP_GREATERTHANOREQUAL, OP_LESSTHAN, OP_DUP, OP_PICK] {
         assert!(
             covenant.asm.iter().any(|token| token == opcode),
             "runtime index must emit {opcode}: {:?}",
@@ -185,18 +190,14 @@ contract RuntimeIndex() {
         &[
             "OP_3",
             OP_PICK,
-            "OP_0",
-            OP_PICK,
+            OP_DUP,
             "OP_0",
             OP_GREATERTHANOREQUAL,
             "OP_VERIFY",
-            "OP_0",
-            OP_PICK,
+            OP_DUP,
             "OP_3",
             OP_LESSTHAN,
             "OP_VERIFY",
-            "OP_0",
-            OP_ADD,
             OP_PICK,
         ],
     ));

--- a/tests/features/symbolic_stack.rs
+++ b/tests/features/symbolic_stack.rs
@@ -80,7 +80,7 @@ contract Nested() {
 
 #[test]
 fn reassignment_replaces_the_existing_slot_and_scopes_clean_up() {
-    let covenant = covenant(
+    let output = compile(
         r#"
 contract Mutate() {
     function spend(int value, bool choose) {
@@ -97,7 +97,29 @@ contract Mutate() {
     }
 }
 "#,
-        "spend",
+    )
+    .expect("compile");
+
+    assert_eq!(output.functions.len(), 1);
+    let group = crate::common::group(&output, "spend");
+    assert_eq!(group.leaves.len(), 1);
+    assert_eq!(group.leaves[0].name, "spend");
+    assert_eq!(
+        crate::common::witness_names(&output, "spend", "spend"),
+        ["serverSig", "emulatorSig"]
+    );
+    assert!(group.leaves[0]
+        .witness
+        .iter()
+        .all(|w| w.elem_type == "signature" && w.injected));
+    assert_eq!(
+        crate::common::leaf_asm(&output, "spend", "spend"),
+        "<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:spend> OP_CHECKSIG"
+    );
+    let covenant = group.arkade.as_ref().expect("spend covenant");
+    assert_eq!(
+        crate::common::arkade_inputs(&output, "spend"),
+        ["value", "choose"]
     );
 
     assert!(
@@ -167,7 +189,7 @@ contract GroupIndices() {
 
 #[test]
 fn runtime_array_indices_are_bounded_and_pick_by_computed_depth() {
-    let covenant = covenant(
+    let output = compile(
         r#"
 contract RuntimeIndex() {
     function spend(int[3] values, int index) {
@@ -175,7 +197,29 @@ contract RuntimeIndex() {
     }
 }
 "#,
-        "spend",
+    )
+    .expect("compile");
+
+    assert_eq!(output.functions.len(), 1);
+    let group = crate::common::group(&output, "spend");
+    assert_eq!(group.leaves.len(), 1);
+    assert_eq!(group.leaves[0].name, "spend");
+    assert_eq!(
+        crate::common::witness_names(&output, "spend", "spend"),
+        ["serverSig", "emulatorSig"]
+    );
+    assert!(group.leaves[0]
+        .witness
+        .iter()
+        .all(|w| w.elem_type == "signature" && w.injected));
+    assert_eq!(
+        crate::common::leaf_asm(&output, "spend", "spend"),
+        "<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:spend> OP_CHECKSIG"
+    );
+    let covenant = group.arkade.as_ref().expect("spend covenant");
+    assert_eq!(
+        crate::common::arkade_inputs(&output, "spend"),
+        ["values", "index"]
     );
 
     for opcode in [OP_GREATERTHANOREQUAL, OP_LESSTHAN, OP_DUP, OP_PICK] {


### PR DESCRIPTION
## Summary

- use OP_PUT for general binding reassignment and array element writes
- support full expression array indices with static validation and runtime bounds checks
- share array-index validation helpers and reduce indexed-access bytecode
- update the emulator test dependency and end-to-end coverage for OP_PUT

## Testing

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all --check
- ./scripts/e2e.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning values to array elements using literal or computed indices.
  * Added validation for array index types, bounds, and assigned value types.
  * Added runtime bounds checks for indexed array access and assignment.

* **Bug Fixes**
  * Improved assignment handling for deeply nested and computed stack locations.
  * Prevented invalid array assignments, including negative or out-of-range indices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->