### PR TITLE
Rewrite README with playground-first guide and language tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,160 +1,31 @@
 # Arkade Compiler
 
-Arkade Language is a high-level contract language that compiles down to Arkade Script, an extended version of Bitcoin Script designed for the Arkade OS. Arkade Language lets developers write expressive, stateful smart contracts that compile to scripts executable by Arkade's Virtual Machine.
+Arkade Language is a contract language for Bitcoin. You write a contract as a set of spend functions over constructor state. The compiler, `arkadec`, turns it into a JSON artifact with two kinds of script: Arkade covenants, which the Arkade VM executes offchain, and L1 tapscript leaves, which give every party a unilateral exit on Bitcoin. Arkade libraries consume the artifact directly, and `arkade-bindgen` turns it into typed TypeScript or Go stubs.
 
-Arkade Script supports advanced primitives for arithmetic, introspection, and asset flows across Virtual Transaction Outputs (VTXOs), enabling rich offchain transaction logic with unilateral onchain exit guarantees. Contracts are verified and executed inside secure Trusted Execution Environments (TEEs) and signed by the Arkade Signer, ensuring verifiable and tamper-proof execution.
+The language covers signature and multisig checks, absolute and relative timelocks, transaction introspection, Arkade Assets and asset groups, byte-string parsing, fixed-size arrays, structs, and recursive contract instantiation with `new`.
 
-This language significantly lowers the barrier for Bitcoin-native app development, allowing contracts to be written in a structured, Ivy-like syntax and compiled into Arkade-native scripts.
-
-## Development Setup
-- Setup pre-commit checks
-  ```bash
-  cp ./scripts/pre-commit .git/hooks 
-  ```
-
-## Emulator E2E Tests
-
-The self-contained E2E suite builds the compiler and runs the counter, HTLC, symbolic-stack and static-array artifacts through the Arkade VM and btcd tapscript interpreter.
-
-```bash
-./scripts/e2e.sh -v
-```
-
-Dependencies are pinned in `tests/e2e/go.mod`; no Docker stack or local emulator checkout is required.
-
-## Playground
-
-Try Arkade Script in your browser — no installation required:
+## Try it in the browser
 
 **[arkade-os.github.io/compiler](https://arkade-os.github.io/compiler)**
 
-### Run the Playground Locally
+The playground runs the real compiler as WebAssembly. Nothing is installed and nothing leaves your browser. Pick a contract from the Explorer, edit it, and press **Ctrl+Enter** (or **Ctrl+S**). The right panel shows four tabs:
 
-**Prerequisites:**
+| Tab | What you get |
+|---|---|
+| JSON Output | The full artifact, the same bytes `arkadec` writes to disk |
+| Assembly | Every spend group: the Arkade covenant ASM and each tapscript leaf, opcodes and `<placeholders>` highlighted |
+| Bindings | Generated TypeScript or Go client code for the artifact, switchable per target |
+| Errors | Parse, type, and validation errors; the offending line is selected in the editor |
 
-- [Rust](https://rustup.rs/) toolchain
-- [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/):
+The Explorer ships the single-file examples (SingleSig, HTLC, FujiSafe, StructVault, NonInteractiveSwap) and the multi-file projects (Stability, LayerZero / USDT0, Options, Bonds). You can add files and folders, rename, drag between folders, and everything persists in `localStorage`. The link button copies a URL with your current source compressed into the hash, so a contract can be shared without a backend.
 
-  ```bash
-  cargo install wasm-pack
-  # or
-  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-  ```
+Every pull request gets its own build at `https://arkade-os.github.io/compiler/pr-previews/pr-<number>/`, posted as a comment on the PR.
 
-**Build and serve:**
+## A tour by example
 
-```bash
-# Build the WASM package and set up the playground
-./playground/build.sh
+Every snippet below compiles on `master`. Paste any of them into the playground.
 
-# Serve locally (default port 8080)
-./playground/serve.sh
-
-# Or specify a custom port
-./playground/serve.sh 3000
-```
-
-Then open [http://localhost:8080](http://localhost:8080) in your browser.
-
-**What the build script does:**
-
-1. Generates `contracts.js` from the `.ark` example files in `examples/`
-2. Compiles the Rust compiler to WebAssembly using `wasm-pack`
-3. Outputs the WASM package to `playground/pkg/`
-
-## Basic Usage
-
-```bash
-  arkadec contract.ark
-```
-
-This compiles your Arkade Language contract to a JSON artifact for use with Arkade libraries.
-
-```bash
-# Specify output file
-arkadec contract.ark -o contract.json
-```
-
-## Compilation Artifacts
-
-The compiler produces a JSON file containing:
-
-- Contract metadata (name, version, etc.)
-- Constructor parameters
-- Spend groups in `functions[]`
-- Optional `arkade` covenant assembly per function-backed group
-- One or more L1 tapleaves per group, each with witness metadata and ASM
-
-Example — `SingleSig` compiled output:
-
-```json
-{
-  "contractName": "SingleSig",
-  "constructorInputs": [
-    { "name": "user", "type": "pubkey" },
-    { "name": "exit", "type": "int" }
-  ],
-  "functions": [
-    {
-      "name": "spend",
-      "arkade": {
-        "inputs": [{ "name": "userSig", "type": "signature" }],
-        "asm": [
-          "<exit>",
-          "<user>",
-          "OP_2",
-          "OP_PICK",
-          "OP_1",
-          "OP_PICK",
-          "OP_CHECKSIG",
-          "OP_VERIFY",
-          "OP_1",
-          "OP_NIP",
-          "OP_NIP",
-          "OP_NIP"
-        ]
-      },
-      "leaves": [
-        {
-          "name": "spend",
-          "witness": [
-            {
-              "name": "serverSig",
-              "type": "signature",
-              "encoding": "schnorr-64",
-              "injected": true
-            },
-            {
-              "name": "emulatorSig",
-              "type": "signature",
-              "encoding": "schnorr-64",
-              "injected": true
-            }
-          ],
-          "asm": [
-            "<SERVER_KEY>",
-            "OP_CHECKSIGVERIFY",
-            "<EMULATOR_KEY:spend>",
-            "OP_CHECKSIG"
-          ]
-        }
-      ]
-    }
-  ],
-  "source": "...",
-  "compiler": {
-    "name": "arkade-compiler",
-    "version": "0.1.0"
-  },
-  "updatedAt": "2024-01-01T00:00:00Z"
-}
-```
-
-## Examples
-
-### SingleSig — Bare VTXO
-
-The simplest VTXO: a single public key controls spending.
+### One key, one exit
 
 ```solidity
 contract SingleSig(pubkey user, int exit) {
@@ -169,9 +40,9 @@ contract SingleSig(pubkey user, int exit) {
 }
 ```
 
-The covenant function emits arkade ASM. The `unilateral` tapscript is a pure L1 CSV exit leaf.
+`spend` has no modifier, so it is an Arkade covenant: the body compiles to covenant ASM that the Arkade VM runs. Because `spend` declares no tapscript of its own, the compiler synthesizes the collaborative L1 leaf `<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:spend> OP_CHECKSIG` for it. `unilateral` is marked `tapscript`, so it is a pure L1 leaf: a CSV delay followed by the user's key.
 
-### HTLC — Hash Time-Locked Contract
+### Hash and time locks
 
 ```solidity
 contract HTLC(
@@ -204,36 +75,9 @@ contract HTLC(
 }
 ```
 
-### Recursive VTXO — Contract Instantiation
+A covenant and a tapscript with the same name form one spend group. The covenant enforces the payout; the leaf with the same name is the L1 shape for that path. `server` and `emulator` are reserved key roles that Arkade infrastructure signs for, so their signatures are marked `injected` in the artifact.
 
-Use `import` and `new ContractName(args)` to enforce that a transaction output carries a specific VTXO contract. This is how VTXOs are forwarded or transformed on-chain.
-
-```solidity
-import "single_sig.ark";
-
-contract RecursiveVtxo(pubkey ownerPk, int exit) {
-  // Forward ownership to output 0, maintaining the SingleSig VTXO shape.
-  function send() {
-    require(tx.outputs[0].scriptPubKey == new SingleSig(ownerPk, exit));
-  }
-}
-```
-
-The `new SingleSig(ownerPk, exit)` expression compiles to a `<VTXO:SingleSig(<ownerPk>,<exit>)>` placeholder. At runtime the Arkade Operator resolves this placeholder to the actual Taproot scriptPubKey of the child contract, so the introspection check is pure Bitcoin Script.
-
-**Arkade covenant ASM:**
-
-```text
-0 OP_INSPECTOUTPUTSCRIPTPUBKEY <VTXO:SingleSig(<ownerPk>,<exit>)> OP_EQUAL
-```
-
-If no matching tapscript is declared for `send`, the compiler synthesizes a default collaborative leaf:
-
-```text
-<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:send> OP_CHECKSIG
-```
-
-#### Splitting to two outputs
+### Recursive VTXOs with `new`
 
 ```solidity
 import "single_sig.ark";
@@ -246,56 +90,40 @@ contract Splitter(pubkey alicePk, pubkey bobPk, int exit) {
 }
 ```
 
-#### Self-referential covenant (renew pattern)
+`new SingleSig(alicePk, exit)` compiles to the opaque placeholder `<VTXO:SingleSig(<alicePk>,<exit>)>`. The Arkade runtime resolves it to the child contract's Taproot scriptPubKey at instantiation, so the check itself is a plain `OP_INSPECTOUTPUTSCRIPTPUBKEY ... OP_EQUAL`. Arguments must be constructor parameters or literals; function inputs only exist at spend time and cannot be baked into a placeholder. A contract can instantiate itself with `import "self.ark";` to enforce state continuation (see `examples/fuji_safe`).
+
+### Assets
 
 ```solidity
-import "self.ark";
-
-contract FujiSafe(
-  bytes assetCommitmentHash,
-  int borrowAmount,
-  pubkey borrowerPk,
-  pubkey treasuryPk,
-  int expirationTimeout,
-  int priceLevel,
-  int setupTimestamp,
-  pubkey oraclePk,
-  bytes assetPair,
+contract TokenVault(
+  pubkey ownerPk,
+  bytes32 tokenAssetIdTxid,
+  int tokenAssetIdGidx,
+  bytes32 ctrlAssetIdTxid,
+  int ctrlAssetIdGidx,
   int exit
 ) {
-  // Treasury can renew the VTXO without changing any parameters.
-  function renew(signature treasurySig) {
-    int currentValue = tx.input.current.value;
-
+  function deposit(signature ownerSig) {
+    require(tx.inputs[0].assets.lookup(ctrlAssetIdTxid, ctrlAssetIdGidx) > 0, "no ctrl in input");
+    require(tx.outputs[0].assets.lookup(ctrlAssetIdTxid, ctrlAssetIdGidx) > 0, "no ctrl in output");
     require(
-      tx.outputs[0].scriptPubKey == new FujiSafe(
-        assetCommitmentHash, borrowAmount, borrowerPk, treasuryPk,
-        expirationTimeout, priceLevel, setupTimestamp, oraclePk, assetPair
-      ),
-      "contract mismatch"
+      tx.outputs[0].assets.lookup(tokenAssetIdTxid, tokenAssetIdGidx) >=
+        tx.inputs[0].assets.lookup(tokenAssetIdTxid, tokenAssetIdGidx),
+      "token balance decreased"
     );
-    require(tx.outputs[0].value == currentValue, "Value mismatch");
-    require(checkSig(treasurySig, treasuryPk), "Invalid treasury signature");
+    require(checkSig(ownerSig, ownerPk), "invalid owner signature");
+  }
+
+  function unilateral(signature ownerSig) tapscript {
+    require(older(exit));
+    require(checkSig(ownerSig, ownerPk));
   }
 }
 ```
 
-## Language Reference
+An Asset ID is a `(bytes32 txid, int gidx)` pair. `assets.lookup` asserts the asset is present on that input or output and yields its amount; `assets.has` is the boolean form. For supply accounting across the whole transaction, `tx.assetGroups.find(txid, gidx)` returns a group with `sumInputs`, `sumOutputs`, `delta`, `controlIs(txid, gidx)`, and friends (see `examples/controlled_mint`).
 
-### Data Types
-
-- `pubkey`: Bitcoin public key (32-byte x-only, BIP340)
-- `signature`: Bitcoin signature (64-byte BIP340 Schnorr)
-- `bytes`: Arbitrary byte array
-- `bytes20`: 20-byte array
-- `bytes32`: 32-byte array
-- `int`: Integer value (CScriptNum)
-- `bool`: Boolean value
-- `asset`: Asset identifier (for asset-aware contracts)
-
-Any type can be declared as a fixed-size array by appending a size: `pubkey[5] oracles`, `signature[5] sigs`. The size is part of the type and must be a positive integer literal; there is no unsized array type. Array parameters are flattened into one input per element (`oracles.0` … `oracles.4`), `for` loops over them unroll once per element, and each element is one stack item — so large sizes grow the compiled script proportionally. Arrays are allowed in constructor and covenant function parameters; `tapscript` function inputs must be scalars.
-
-Named structs are declared before the contract. Their scalar leaves occupy separate stack items and may include nested structs or fixed arrays of scalar types:
+### Arrays, structs, loops
 
 ```solidity
 struct Signer {
@@ -306,204 +134,247 @@ struct Signer {
 struct Policy {
   Signer primary;
   int[2] limits;
+  int exitDelay;
 }
 
-contract Vault(Policy policy) {
-  function spend(int expected) {
+contract StructVault(Policy policy) {
+  function update(Policy next, signature sig, bytes32 message) {
+    require(checkSigFromStack(sig, policy.primary.key, message));
+
+    int total = 0;
+    for (i, limit) in next.limits {
+      total = total + limit;
+    }
+    require(total >= policy.primary.weight);
+
     Policy local = {
-      primary: { key: policy.primary.key, weight: expected },
-      limits: [1, 2]
+      primary: { key: next.primary.key, weight: total },
+      limits: [next.limits[0], next.limits[1]],
+      exitDelay: policy.exitDelay
     };
-    local.primary.weight = local.limits[1];
-    require(local.primary.weight == expected);
+    require(local.primary.weight == total);
+  }
+
+  function unilateral(signature sig) tapscript {
+    require(older(policy.exitDelay));
+    require(checkSig(sig, policy.primary.key));
   }
 }
 ```
 
-Struct literals require an explicit type and every named field exactly once. Scalar leaves may be read and assigned, while whole-struct assignment and comparison are unsupported. Structs can contain scalar arrays, but arrays of structs and struct-valued `tapscript` inputs are not supported.
+Arrays are fixed-size and part of the type. Loops unroll at compile time, one copy per element, so script size grows with the declared size. Structs flatten to their scalar leaves; the artifact keeps the declaration so clients can flatten the same way. `examples/threshold_oracle` shows the same machinery counting `checkSigFromStack` successes over `pubkey[3] oracles` to enforce a quorum.
 
-Fixed-width builtins that return multiple stack items expose native result structs. Their types and fields are `AssetId { bytes32 txid; int gidx; }`, `Outpoint { bytes32 txid; int vout; }`, and `ECPoint { int x; int y; }`. The type may be explicit or inferred with `let`:
+### More in `examples/`
 
-```solidity
-let assetId = tx.outputs[0].assets[0].assetId;
-Outpoint previous = tx.inputs[0].outpoint;
-ECPoint sum = ecAdd(x1, y1, x2, y2, curveId);
+| Directory | Shows |
+|---|---|
+| `single_sig`, `htlc` | Minimum viable VTXO and hash/time locks |
+| `non_interactive_swap` | Atomic asset swap with `new SingleSig(...)` payout and CLTV cancel |
+| `payment_auth` | Introspection-driven payout splits with `if`/`else` and `tx.input.current.value` |
+| `token_vault`, `controlled_mint`, `nft_mint` | Asset lookups, asset groups, control assets |
+| `struct_vault`, `threshold_oracle` | Structs, arrays, loops, oracle quorum |
+| `fuji_safe`, `stability`, `bonds`, `options` | Stateful contracts that recreate themselves with `new` |
+| `layerzero` | Packet introspection, `substr`/`cat`/`bin2num`, cross-input binding via `arkadeScriptHash` |
+| `arkade_kitties` | NFT breeding with asset-group introspection |
 
-require(assetId.gidx >= 0);
-require(previous.txid == expectedTxid);
-require(sum.x >= 0);
+The `.md` files next to those contracts explain the economics and transaction layouts.
+
+## Install and run
+
+Requires a Rust toolchain ([rustup.rs](https://rustup.rs/)).
+
+```bash
+cargo install --path .              # installs arkadec
+arkadec contract.ark                # writes contract.json in the current directory
+arkadec contract.ark -o out.json
 ```
 
-`AssetId` is returned by indexed asset and asset-group `.assetId` access, `Outpoint` by input `.outpoint` access, and `ECPoint` by `ecAdd` and `ecMul`. They are also valid constructor and covenant function parameter types, flattening to their scalar leaves like any other struct; whole-struct comparison remains unsupported. Because their layouts are fixed, they are not repeated in the artifact's `structs` list.
+Type-check warnings go to stderr; errors abort with a non-zero exit. From a checkout, `cargo run -- examples/htlc/htlc.ark -o /tmp/htlc.json` is the fastest way to inspect output.
 
-### Contract Structure
+Generate client bindings from one artifact or a directory of them:
 
-An Arkade Language file may start with zero or more `import` declarations, followed by a `contract` declaration:
+```bash
+cargo run -p arkade-bindgen -- contract.json --lang typescript,go -o ./generated/
+cargo run -p arkade-bindgen -- --list-targets
+```
+
+`--embed` inlines the artifact JSON into the generated file; `--package` sets the module or namespace name.
+
+Use the compiler as a library with `arkade_compiler::compile(source) -> Result<ContractJson, _>`. The `wasm` feature exposes `compile`, `validate`, and `version` through `wasm-bindgen`; that is what the playground calls.
+
+### Run the playground locally
+
+```bash
+cargo install wasm-pack
+./playground/build.sh     # regenerates contracts.js from examples/ and builds pkg/ with wasm-pack
+./playground/serve.sh     # http://localhost:8080, pass a port to override
+```
+
+`playground/contracts.js` and `playground/pkg/` are generated and git-ignored. Add a contract to the playground by adding a `.ark` file under `examples/` and registering it in `playground/main.js`.
+
+### Tests
+
+```bash
+cargo test --workspace                                   # unit, feature, and example tests
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --check
+./scripts/e2e.sh -v                                      # builds arkadec, runs artifacts through the Arkade VM and btcd (Go)
+cp ./scripts/pre-commit .git/hooks                       # fmt + test before every commit
+```
+
+The E2E suite pins its dependencies in `tests/e2e/go.mod`; no Docker or emulator checkout is needed.
+
+## Language reference
+
+### File layout
 
 ```solidity
-import "other_contract.ark";   // optional — imports for contract instantiation
-
-contract MyContract(pubkey user, int exit) {
-  function spend(signature userSig) {
-    require(checkSig(userSig, user));
-  }
-
-  function unilateral(signature userSig) tapscript {
-    require(older(exit));
-    require(checkSig(userSig, user));
-  }
+import "other.ark";          // zero or more; declares contracts usable in `new`
+struct Name { ... }          // zero or more, before the contract
+contract Name(<params>) {    // exactly one
+  function ...
 }
 ```
+
+Comments use `//`. Identifiers start with a letter and contain letters, digits, and underscores. Number literals are decimal integers; string literals appear only in `import` and as `require` messages.
+
+### Types
+
+| Type | Meaning |
+|---|---|
+| `pubkey` | BIP340 x-only public key |
+| `signature` | 64-byte BIP340 Schnorr signature |
+| `bytes`, `bytes20`, `bytes32` | Byte arrays, unsized or fixed |
+| `int` | CScriptNum integer |
+| `bool` | Boolean |
+| `asset` | Asset identifier |
+| `T[n]` | Fixed-size array of a scalar type, `n` a positive literal |
+| `struct` | User-declared, nested structs and scalar arrays allowed |
+| `AssetId`, `Outpoint`, `ECPoint` | Native result structs: `{txid, gidx}`, `{txid, vout}`, `{x, y}` |
+
+Arrays and structs are allowed in constructor and covenant parameters and as locals. Tapscript inputs must be scalars. Arrays of structs, whole-struct assignment, and whole-struct comparison are not supported.
 
 ### Functions
 
-Functions without a modifier define arkade covenants. `tapscript` functions define L1 tapleaves. A covenant function with no matching or tweaked tapleaf receives a synthesized collaborative leaf using `server` and `tweak(emulator, functionName)`.
-
 ```solidity
-// Arkade covenant.
-function spend(signature userSig) {
-  require(checkSig(userSig, user));
-}
-
-// L1 CSV exit leaf.
-function unilateral(signature userSig) tapscript {
-  require(older(exit));
-  require(checkSig(userSig, user));
-}
-
-// Helper — not a spending path, inlined into callers
-function verify() internal {
-  require(tx.outputs[0].value > 0);
-}
+function name(<params>) { ... }             // Arkade covenant, run by the Arkade VM
+function name(<params>) tapscript { ... }   // L1 tapleaf, plain Bitcoin Script
 ```
 
-### Imports and Contract Instantiation
+A covenant with no tapscript of the same name gets a synthesized `server` + `tweak(emulator, name)` leaf. A covenant and a tapscript that share a name form one spend group. A tapscript with no matching covenant is a standalone leaf, which is how unilateral exits are written.
 
-Use `import` to declare which contracts may appear in `new` expressions:
+The `internal` modifier parses and excludes the function from the spend surface, but call statements to it are currently dropped by the parser rather than inlined. Do not rely on `internal` for enforcement until that lands; write the checks in the calling function.
 
-```solidity
-import "single_sig.ark";
-import "htlc.ark";
-```
+Every spend path must contain at least one `require`. An `if` without `else`, or an `else` branch without a `require`, is rejected as a bare path.
 
-Use `new ContractName(arg1, arg2, ...)` as the right-hand side of a `scriptPubKey` comparison to enforce the shape of an output or input VTXO:
+### Statements (covenant bodies)
 
 ```solidity
-// Output enforcement
-require(tx.outputs[0].scriptPubKey == new SingleSig(ownerPk));
-
-// Input enforcement
-require(tx.inputs[0].scriptPubKey == new HTLC(sender, receiver, hash, refundTime));
-
-// Current input enforcement (recursive covenant)
-require(tx.input.current.scriptPubKey == new SingleSig(ownerPk));
+require(<expr>);
+require(<expr>, "message");
+let x = <expr>;                    // inferred type
+int fee = amount / 100;            // declared type
+Policy p = { primary: {...}, limits: [1, 2], exitDelay: 10 };
+int[3] scale = [1, 2, 3];
+x = <expr>;                        // reassignment keeps the declared type
+scale[1] = 10;                     // literal index only on master, see Upcoming
+p.primary.weight = 5;
+if (<expr>) { ... } else { ... }
+for (i, item) in arr { ... }       // unrolled at compile time
 ```
 
-**Zero-argument constructors** are supported:
-
-```solidity
-require(tx.outputs[0].scriptPubKey == new StaticContract());
-```
-
-Pure L1 exits are expressed as explicit `tapscript` functions, usually with `older(exit)`.
+Shadowing a live name is an error. Constructor parameters cannot be reassigned.
 
 ### Expressions
 
-#### Signature Verification
+Arithmetic `+ - * /` and unary `-` on `int`. Comparison `== != < <= > >=`. `+` on byte operands is concatenation; mixing an `int` into a byte concatenation is an error until you widen it with `num2bin(value, width)`, because the width is consensus-visible. `arr.length` folds to the declared size. Array indices may be any `int` expression when reading; a runtime index emits a bounds check.
 
-```solidity
-require(checkSig(userSig, user));
-require(checkMultisig([user, admin], [userSig, adminSig]));
-require(checkSigFromStack(oracleSig, oraclePk, message));
+### Built-ins
+
+**Signatures.** `checkSig(sig, key)`, `checkMultisig([keys], [sigs], threshold?)` with N-of-N when the threshold is omitted (covenants accept any threshold, via `OP_CHECKSIGADD`), `checkSigFromStack(sig, key, message)` and its `Verify` form. `tweak(emulator, fn)` is a key expression usable only inside tapscripts.
+
+**Hashes.** `sha256`, `hash160`, `hash256`, `ripemd160` as `require(hashFn(preimage) == hash)`. `sha256(expr)` also works as a value, including over concatenations and `substr` results. Streaming: `sha256Initialize`, `sha256Update`, `sha256Finalize`. Runtime-selected: `digest(data, hashType)`, `sighash(hashType)`.
+
+**Time.** In covenants, `tx.time` is the transaction locktime as an `int`, so `require(tx.time >= deadline)` is a CLTV check. In tapscripts, `older(n)` emits CSV and `after(n)` or `tx.time >= n` emits CLTV. `after(...)` is tapscript-only.
+
+**Transaction.** `tx.version`, `tx.locktime`, `tx.numInputs`, `tx.numOutputs`, `tx.weight`, `tx.id`, `this.activeInputIndex`, `this.activeBytecode`.
+
+**Inputs and outputs.** `tx.inputs[i].value | scriptPubKey | sequence | outpoint | arkadeScriptHash | arkadeWitnessHash`, `tx.outputs[o].value | scriptPubKey`, and `tx.input.current.value | scriptPubKey | sequence | outpoint` for the input being spent.
+
+**Assets.** On any input or output: `.assets.lookup(txid, gidx)` (asserts presence, yields amount), `.assets.has(txid, gidx)`, `.assets.length`, `.assets[t].assetId`, `.assets[t].amount`. Groups: `tx.assetGroups.find(txid, gidx)`, `.has(txid, gidx)`, `.length`, and per group `numInputs`, `numOutputs`, `sumInputs`, `sumOutputs`, `delta`, `hasControl`, `controlIs(txid, gidx)`, `metadataHash`, `assetId`, `isFresh`.
+
+**Bytes.** `substr(data, offset, size)`, `cat(a, b)`, `bin2num(bytes)`, `num2bin(value, size)`, `reverseBytes(bytes)`, `size(bytes)`.
+
+**Packets.** `tx.packet(type)` and `tx.inputs[i].packet(type)` return the raw extension packet bytes and assert presence.
+
+**Arithmetic and curves.** `modExp(base, exp, mod)`, `ecAdd(x1, y1, x2, y2, curve)` and `ecMul(x, y, k, curve)` returning `ECPoint`, `ecPairing(...)`, `ecMulScalarVerify(k, P, Q)`, `tweakVerify(P, k, Q)`.
+
+**Instantiation.** `new Contract(args...)` on either side of a `scriptPubKey` comparison against `tx.outputs[o]`, `tx.inputs[i]`, or `tx.input.current`. Zero-argument constructors are allowed. Array arguments flatten element by element.
+
+### Tapscript bodies
+
+A tapscript body is `require` statements only, and must follow the closure template in source order: an optional single hash condition, then an optional single timelock, then exactly one `checkSig` or `checkMultisig`. Hash plus CSV is a recognized shape; hash plus CLTV is not, so split it into two leaves. arkd accepts only N-of-N leaves, so a `checkMultisig` threshold, if written, must equal the key count, and each signature must be a declared `signature` input aligned 1:1 with its key.
+
+Keys resolve to constructor `pubkey` parameters, declared `pubkey` inputs, or the roles `server` and `emulator`. Any leaf without a CSV delay is a forfeit path and must include `server`. A leaf whose name matches a covenant must include bare `emulator`, which the compiler tweaks with that covenant's hash. A leaf with no matching covenant may not use bare `emulator`; it either stays standalone or binds to one covenant with `tweak(emulator, fn)`. Inputs named `server` or `emulator` are rejected.
+
+## Artifact format
+
+```json
+{
+  "contractName": "HTLC",
+  "constructorInputs": [{ "name": "sender", "type": "pubkey" }, ...],
+  "structs": [],
+  "functions": [
+    {
+      "name": "claim",
+      "arkade": { "inputs": [], "asm": ["<exit>", "<refundTime>", "..."] },
+      "leaves": [
+        {
+          "name": "claim",
+          "witness": [
+            { "name": "preimage", "type": "bytes", "encoding": "raw" },
+            { "name": "serverSig", "type": "signature", "encoding": "schnorr-64", "injected": true },
+            { "name": "emulatorSig", "type": "signature", "encoding": "schnorr-64", "injected": true }
+          ],
+          "asm": ["OP_HASH160", "<preimageHash>", "OP_EQUAL", "OP_VERIFY", "<SERVER_KEY>", "OP_CHECKSIGVERIFY", "<EMULATOR_KEY:claim>", "OP_CHECKSIG"]
+        }
+      ]
+    },
+    { "name": "unilateral", "leaves": [ ... ] }
+  ],
+  "source": "...",
+  "compiler": { "name": "arkade-compiler", "version": "0.1.0" },
+  "updatedAt": "2026-01-01T00:00:00Z"
+}
 ```
 
-The signature array in `checkMultisig` is required. It must contain one explicitly named `signature` binding for each key, in the same order as the key array. The threshold remains optional.
+| Field | Meaning |
+|---|---|
+| `constructorInputs` | One entry per source parameter, declaration order; arrays keep their size in the type, structs keep their type name |
+| `structs` | User struct layouts, so clients can flatten parameters the way the compiler does |
+| `functions[]` | Spend groups: `{ name, arkade?, leaves[] }` |
+| `arkade` | `{ inputs, asm }`; absent for groups made only of standalone leaves |
+| `leaves[]` | `{ name, witness, asm }`; `witness` lists spend-time values in source order, `injected: true` marks infrastructure signatures |
+| `warnings` | Type-check warnings, omitted when empty |
 
-#### Hash Verification
+Witness `encoding` values: `compressed-33`, `schnorr-64`, `raw`, `raw-20`, `raw-32`, `scriptnum`. `updatedAt` changes on every compile; ignore it when diffing artifacts.
 
-```solidity
-require(sha256(preimage) == hash);
-```
+### Covenant stack ABI
 
-#### Timelock
+`constructorInputs`, `arkade.inputs`, and `witness` describe the source ABI, not the physical stack. Clients expand an array entry `oracles` of type `pubkey[3]` into `oracles.0`, `oracles.1`, `oracles.2`, and a struct entry into its scalar leaves in field order, recursively, using dotted paths such as `policy.primary.key`.
 
-```solidity
-require(tx.time >= expirationTime);   // absolute (CHECKLOCKTIMEVERIFY)
-```
+Clients serialize covenant inputs in reverse `arkade.inputs` order. Every covenant `asm` opens with one `<name>` placeholder per expanded constructor input, also reversed, which instantiation replaces with data pushes before the covenant hash is computed. The VM installs the function witness first, so constructor values sit above function inputs; the body reaches everything through `OP_PICK` and friends and never emits function inputs as placeholders. After instantiation the only remaining placeholders are `<VTXO:Contract(<a>,<b>)>` tokens, which the runtime resolves to the child contract's scriptPubKey.
 
-#### Transaction Introspection
+## Upcoming
 
-```solidity
-// Outputs
-require(tx.outputs[0].value == amount);
-require(tx.outputs[0].scriptPubKey == new SingleSig(ownerPk));
+The README tracks `master`. These are in review and will change what compiles:
 
-// Indexed inputs
-require(tx.inputs[0].value == amount);
-require(tx.inputs[0].scriptPubKey == script);
+**Expression-indexed element writes ([#82](https://github.com/arkade-os/compiler/pull/82)).** `scale[writeIndex + 1] = 10;` and `state.values[i + 1] = next;` become legal with any `int` index expression, with lower and upper bound checks emitted at runtime. Reassignment of scalars and elements moves to `OP_PUT`, which shortens the emitted covenant. On `master` an element write needs a literal index.
 
-// Current input (self-reference)
-require(tx.input.current.value == amount);
-require(tx.input.current.scriptPubKey == script);
-```
+**Artifact static analysis ([#81](https://github.com/arkade-os/compiler/pull/81)).** A public `arkade_compiler::analysis::analyze_output(&ContractJson)` re-derives each leaf's closure from its ASM and re-runs the tapscript rules against the emitted artifact, so consumers can validate artifacts they did not compile themselves.
 
-`tx.input.current` properties: `value`, `scriptPubKey`, `sequence`, `outpoint`.
+**Wall-clock time.** Several draft example PRs reference `tx.offchainTime`, the TEE introspector's unix-seconds clock, as distinct from `tx.time` block height. It is not a recognized binding on `master` yet, so those examples keep it in comments.
 
-### Variable Declarations
+## Security
 
-```solidity
-bytes message = sha256(timestamp + currentPrice + assetPair);
-int currentValue = tx.input.current.value;
-```
-
-### Error Messages
-
-```solidity
-require(tx.time >= expirationTimeout, "Expiration timeout not reached");
-```
-
-## Artifact Format
-
-Arkade Language compiles to Arkade Script and produces a JSON artifact for use with Arkade libraries.
-
-### Key Fields
-
-| Field                 | Description                                                                               |
-|-----------------------|-------------------------------------------------------------------------------------------|
-| `contractName`        | Contract identifier                                                                       |
-| `constructorInputs`   | Constructor parameters in source declaration order, one entry per parameter               |
-| `structs`             | User-defined struct layouts in source declaration order                                   |
-| `functions`           | Spend groups: `{ name, arkade?, leaves[] }`                                               |
-| `arkade`              | Optional emulator-run covenant `{ inputs, asm }`                                          |
-| `arkade.inputs`       | Function parameters in source declaration order, one entry per parameter                  |
-| `leaves`              | L1 tapleaf objects `{ name, witness, asm }`                                               |
-| `witness`             | Spend-time tapleaf witness fields, with `injected: true` for infrastructure signatures    |
-| `asm`                 | Assembly tokens, including the explicit constructor prologue and covenant body            |
-
-### Arkade Covenant Stack ABI
-
-`constructorInputs`, `arkade.inputs` and each leaf's `witness` describe the source ABI: one entry per source parameter, in declaration order. They do not describe the physical VM stack order.
-
-An array parameter stays one entry carrying its size in the type (`{ "name": "oracles", "type": "pubkey[3]" }`). Each array element is a separate stack item and a separate `<name.i>` placeholder, so clients expand an array entry into `name.0` … `name.{N-1}` in index order.
-
-A struct parameter also stays grouped under its named type. Clients use the artifact's `structs` declarations to flatten its scalar leaves recursively in field declaration order. For example, `Policy policy` above expands to `policy.primary.key`, `policy.primary.weight`, `policy.limits.0`, and `policy.limits.1`. Period-separated path segments are unambiguous because source identifiers cannot contain periods.
-
-Clients serialize covenant function inputs in reverse `arkade.inputs` order. For example, source inputs `[amount, sig]` produce the physical bottom-to-top witness `[sig, amount]`.
-
-Every covenant `asm` begins with one constructor placeholder per expanded constructor input — arrays contribute one placeholder per element — also in reverse order. Contract instantiation resolves these placeholders to concrete data pushes before the covenant hash is computed. For source constructor inputs `[limit, owner]`, the prologue is `["<owner>", "<limit>"]`, leaving `limit` nearest the top within the constructor frame.
-
-The VM installs the function witness before executing the covenant, so the reversed constructor prologue leaves constructor values above function inputs. Covenant body expressions access constructor parameters, function inputs, and local variables through stack operations such as `OP_PICK`; function inputs are not emitted as `<name>` body placeholders.
-
-After instantiation, ordinary `<name>` placeholders occur only in the constructor prologue. `<VTXO:...>` tokens remain opaque contract-instantiation placeholders as described below.
-
-Contract-instantiation arguments are limited to literals and constructor parameters. Function inputs and computed locals exist only at spend time and cannot be resolved inside an opaque `<VTXO:...>` placeholder.
-
-### VTXO Placeholder Format
-
-Contract instantiation expressions in ASM use the format:
-
-```text
-<VTXO:ContractName(<arg1>,<arg2>)>
-```
-
-The Arkade runtime resolves this placeholder to the Taproot scriptPubKey of the named contract instantiated with the given arguments.
+See [SECURITY.md](SECURITY.md) for the disclosure process.


### PR DESCRIPTION
This PR completely rewrites the README to prioritize the browser playground and provide a practical language tour through examples, replacing the previous architecture-focused documentation.

## Summary

The README has been restructured from a 160-line architecture and setup guide into a 350-line playground-first document that leads with the browser experience, then teaches the language through annotated examples from the `examples/` directory, and finally covers installation and testing.

## Key changes

- **Playground-first introduction**: Moved the browser playground to the top with a clear description of what each output tab shows (JSON, Assembly, Bindings, Errors)
- **Language tour by example**: Replaced abstract language reference sections with concrete, runnable examples:
  - `SingleSig` for basic VTXO structure
  - `HTLC` for hash and time locks
  - `Splitter` and `FujiSafe` for recursive VTXOs with `new`
  - `TokenVault` for asset introspection
  - `StructVault` for arrays, structs, and loops
- **Reorganized reference material**: Consolidated the language reference into concise tables and inline descriptions rather than separate sections
- **Removed setup boilerplate**: Eliminated detailed playground build instructions (moved to a subsection) and pre-commit hook setup, keeping only the essential `cargo install` and `arkadec` usage
- **Added example directory guide**: New table mapping `examples/` subdirectories to their teaching purpose
- **Clarified artifact format**: Simplified the JSON artifact example and added a reference table explaining each field
- **Expanded upcoming features**: Added a dedicated "Upcoming" section tracking in-review PRs that will change what compiles

## Notable details

- All code examples are verified to compile on `master` (as stated in the new text)
- The playground description now explains the Explorer, localStorage persistence, and PR preview URLs
- Tapscript closure rules and key role semantics (`server`, `emulator`, `tweak`) are explained in context rather than in isolation
- The artifact format section now includes a complete JSON example with all major fields

https://claude.ai/code/session_016Bu37cgMFbupKeTLmYZZXU