### PR TITLE
Support internal helper functions with statement inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ contract MyContract(pubkey user, int exit) {
 
 Functions without a modifier define arkade covenants. `tapscript` functions define L1 tapleaves. A covenant function with no matching or tweaked tapleaf receives a synthesized collaborative leaf using `server` and `tweak(emulator, functionName)`.
 
+`internal` functions are helpers, not spending paths. Calling one as a statement (`verify();`) inlines its body at the call site, so its requires run in the caller's covenant. Helpers take no parameters and can be declared before or after their callers; a helper may call only helpers declared above it.
+
 ```solidity
 // Arkade covenant.
 function spend(signature userSig) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,6 +2,7 @@ use crate::models::{Contract, Function, Parameter, Statement, StructDefinition};
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
 use pest_derive::Parser;
+use std::collections::HashMap;
 
 /// Pest parser generated from grammar.pest
 #[derive(Parser)]
@@ -124,23 +125,53 @@ fn parse_contract(contract: &mut Contract, pair: Pair<Rule>) -> Result<(), Strin
 
     // Functions (covenant) and tapscript declarations share the `function` rule;
     // a tapscript carries a `tapscript_block` body.
-    for func_pair in inner_pairs {
-        if func_pair.as_rule() != Rule::function {
-            continue;
+    let func_pairs: Vec<_> = inner_pairs
+        .filter(|p| p.as_rule() == Rule::function)
+        .collect();
+
+    // Internal helpers are parsed first so callers can inline them regardless
+    // of declaration order. A helper may call helpers declared above it only.
+    let mut helpers: HashMap<String, Vec<Statement>> = HashMap::new();
+    for func_pair in func_pairs.iter().filter(|p| function_pair_is_internal(p)) {
+        let func = parse_function(func_pair.clone(), &helpers)?;
+        if !func.parameters.is_empty() {
+            return Err(format!(
+                "Parse error: internal function '{}' cannot declare parameters",
+                func.name
+            ));
         }
+        helpers.insert(func.name.clone(), func.statements.clone());
+        contract.functions.push(func);
+    }
+
+    for func_pair in func_pairs
+        .into_iter()
+        .filter(|p| !function_pair_is_internal(p))
+    {
         if function_pair_is_tapscript(&func_pair) {
             let ts = parse_named_tapscript(func_pair)?;
             contract.tapscripts.push(ts);
         } else {
-            let func = parse_function(func_pair)?;
+            let func = parse_function(func_pair, &helpers)?;
             contract.functions.push(func);
         }
     }
     Ok(())
 }
 
-/// Parse a function definition
-fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
+/// Whether a `function` pair carries the `internal` modifier.
+fn function_pair_is_internal(pair: &Pair<Rule>) -> bool {
+    pair.clone()
+        .into_inner()
+        .any(|p| p.as_rule() == Rule::function_modifier)
+}
+
+/// Parse a function definition. `helpers` maps internal function names to
+/// their statements, which are inlined at each call site.
+fn parse_function(
+    pair: Pair<Rule>,
+    helpers: &HashMap<String, Vec<Statement>>,
+) -> Result<Function, String> {
     let mut func = Function {
         name: String::new(),
         parameters: Vec::new(),
@@ -166,12 +197,12 @@ fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
         if next_pair.as_rule() == Rule::function_modifier {
             func.is_internal = true;
             for req_pair in inner_pairs {
-                parse_function_body(&mut func, req_pair)?;
+                parse_function_body(&mut func, req_pair, helpers)?;
             }
         } else {
-            parse_function_body(&mut func, next_pair)?;
+            parse_function_body(&mut func, next_pair, helpers)?;
             for req_pair in inner_pairs {
-                parse_function_body(&mut func, req_pair)?;
+                parse_function_body(&mut func, req_pair, helpers)?;
             }
         }
     }
@@ -180,7 +211,11 @@ fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
 }
 
 /// Parse a statement in a function body (require, let binding, function call, variable declaration)
-fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), String> {
+fn parse_function_body(
+    func: &mut Function,
+    pair: Pair<Rule>,
+    helpers: &HashMap<String, Vec<Statement>>,
+) -> Result<(), String> {
     match pair.as_rule() {
         Rule::require_stmt => {
             let mut inner = pair.into_inner();
@@ -247,10 +282,10 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
             let then_block = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing then block in if statement".to_string())?;
-            let then_body = parse_block(then_block)?;
+            let then_body = parse_block(then_block, helpers)?;
 
             let else_body = if let Some(else_block) = inner.next() {
-                Some(parse_block(else_block)?)
+                Some(parse_block(else_block, helpers)?)
             } else {
                 None
             };
@@ -281,7 +316,7 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
             let body_block = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing body in for loop".to_string())?;
-            let body = parse_block(body_block)?;
+            let body = parse_block(body_block, helpers)?;
 
             func.statements.push(Statement::ForIn {
                 index_var,
@@ -292,7 +327,24 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
             Ok(())
         }
         Rule::function_call_stmt => {
-            // Function calls to internal helpers — not yet fully supported
+            // Calls to internal helpers are inlined. Helpers take no
+            // parameters today; supporting them needs expression
+            // substitution in the inlined body.
+            let mut inner = pair.into_inner();
+            let name = inner
+                .next()
+                .ok_or_else(|| "Parse error: Missing function name in call".to_string())?
+                .as_str()
+                .to_string();
+            if inner.next().is_some() {
+                return Err(format!(
+                    "Parse error: internal function '{name}' cannot take arguments"
+                ));
+            }
+            let body = helpers.get(&name).ok_or_else(|| {
+                format!("Parse error: call to unknown internal function '{name}'")
+            })?;
+            func.statements.extend(body.iter().cloned());
             Ok(())
         }
         Rule::variable_declaration => {
@@ -326,7 +378,10 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
 // ─── Expression Parsing ────────────────────────────────────────────────────────
 
 // Parse a block of statements
-fn parse_block(pair: Pair<Rule>) -> Result<Vec<Statement>, String> {
+fn parse_block(
+    pair: Pair<Rule>,
+    helpers: &HashMap<String, Vec<Statement>>,
+) -> Result<Vec<Statement>, String> {
     let mut statements = Vec::new();
 
     for inner in pair.into_inner() {
@@ -338,7 +393,7 @@ fn parse_block(pair: Pair<Rule>) -> Result<Vec<Statement>, String> {
             is_internal: false,
         };
 
-        parse_function_body(&mut temp_func, inner)?;
+        parse_function_body(&mut temp_func, inner, helpers)?;
         statements.extend(temp_func.statements);
     }
 

--- a/tests/examples/fuji_safe.rs
+++ b/tests/examples/fuji_safe.rs
@@ -1,6 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_CHECKSIGVERIFY, OP_LESSTHAN,
+    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_CHECKSIGVERIFY,
+    OP_INSPECTOUTPUTVALUE, OP_LESSTHAN,
 };
 
 #[test]
@@ -59,6 +60,12 @@ fn test_fuji_safe_contract() {
         "claim covenant should verify treasury sig: {}",
         claim_asm
     );
+    // Inlined verifyTreasuryFujiBurning helper
+    assert!(
+        claim_asm.contains(OP_INSPECTOUTPUTVALUE),
+        "claim covenant should run the inlined burn check: {}",
+        claim_asm
+    );
 
     // claim leaf carries server + emulator cosig
     let claim_leaf = crate::common::leaf_asm(&output, "claim", "claim");
@@ -88,6 +95,11 @@ fn test_fuji_safe_contract() {
     assert!(
         liquidate_asm.contains(OP_CHECKSIG),
         "liquidate covenant should verify treasury sig: {}",
+        liquidate_asm
+    );
+    assert!(
+        liquidate_asm.contains(OP_INSPECTOUTPUTVALUE),
+        "liquidate covenant should run the inlined burn check: {}",
         liquidate_asm
     );
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -20,6 +20,8 @@ mod epoch_limiter;
 mod general_comparisons;
 #[path = "features/group_properties.rs"]
 mod group_properties;
+#[path = "features/internal_functions.rs"]
+mod internal_functions;
 #[path = "features/io_introspection.rs"]
 mod io_introspection;
 #[path = "features/no_shadowing.rs"]

--- a/tests/features/internal_functions.rs
+++ b/tests/features/internal_functions.rs
@@ -1,0 +1,100 @@
+use arkade_compiler::compile;
+use arkade_compiler::opcodes::{OP_CHECKSIG, OP_INSPECTNUMOUTPUTS};
+
+/// A call to an internal helper inlines the helper's statements into the
+/// caller's covenant.
+#[test]
+fn internal_call_inlines_helper_requires() {
+    let code = r#"
+        contract Helper(pubkey owner) {
+            function checkOutputs() internal {
+                require(tx.numOutputs >= 1);
+            }
+
+            function spend(signature ownerSig) {
+                checkOutputs();
+                require(checkSig(ownerSig, owner));
+            }
+        }
+    "#;
+
+    let output = compile(code).expect("compile");
+    let asm = crate::common::arkade_asm(&output, "spend");
+    assert!(
+        asm.contains(OP_INSPECTNUMOUTPUTS),
+        "helper require missing from caller ASM: {asm}"
+    );
+    assert!(asm.contains(OP_CHECKSIG), "caller require missing: {asm}");
+    assert_eq!(
+        output.functions.len(),
+        1,
+        "internal helper must not become a spend group"
+    );
+}
+
+/// Helpers may be declared after their callers.
+#[test]
+fn internal_call_resolves_helper_declared_later() {
+    let code = r#"
+        contract Helper(pubkey owner) {
+            function spend(signature ownerSig) {
+                checkOutputs();
+                require(checkSig(ownerSig, owner));
+            }
+
+            function checkOutputs() internal {
+                require(tx.numOutputs >= 1);
+            }
+        }
+    "#;
+
+    let output = compile(code).expect("compile");
+    let asm = crate::common::arkade_asm(&output, "spend");
+    assert!(
+        asm.contains(OP_INSPECTNUMOUTPUTS),
+        "helper require missing from caller ASM: {asm}"
+    );
+}
+
+#[test]
+fn call_to_unknown_helper_is_an_error() {
+    let code = r#"
+        contract Helper(pubkey owner) {
+            function spend(signature ownerSig) {
+                missing();
+                require(checkSig(ownerSig, owner));
+            }
+        }
+    "#;
+
+    let err = compile(code)
+        .map(|_| ())
+        .expect_err("unknown helper must fail");
+    assert!(
+        err.to_string()
+            .contains("unknown internal function 'missing'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn helper_call_with_arguments_is_an_error() {
+    let code = r#"
+        contract Helper(pubkey owner) {
+            function checkOutputs() internal {
+                require(tx.numOutputs >= 1);
+            }
+
+            function spend(signature ownerSig) {
+                checkOutputs(1);
+                require(checkSig(ownerSig, owner));
+            }
+        }
+    "#;
+
+    let err = compile(code).map(|_| ()).expect_err("arguments must fail");
+    assert!(
+        err.to_string().contains("cannot take arguments"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary
Add support for `internal` function declarations that act as reusable helpers. Internal functions can be called as statements within other functions, and their bodies are inlined at each call site. This allows code reuse without creating additional spending paths.

## Key Changes
- **Parser enhancement**: Modified `parse_contract()` to collect internal helpers before parsing regular functions, enabling forward references and declaration order independence
- **Helper inlining**: Implemented statement inlining in `parse_function_body()` for `function_call_stmt` rule, where calls to internal helpers expand to their full statement bodies
- **Validation**: Added checks to ensure:
  - Internal functions cannot declare parameters (parameters would need expression substitution)
  - Internal function calls cannot pass arguments
  - Calls to undefined internal functions are rejected with clear error messages
- **Test coverage**: Added comprehensive test suite covering:
  - Basic helper inlining with require statements
  - Forward references (helpers declared after callers)
  - Error cases (unknown helpers, helpers with arguments)
- **Documentation**: Updated README to explain internal functions as non-spending helpers

## Implementation Details
- Internal helpers are parsed in a first pass and stored in a `HashMap<String, Vec<Statement>>` before regular functions
- This allows callers to reference helpers regardless of declaration order
- Helper bodies are cloned and extended into the caller's statement list during parsing
- The `is_internal` flag prevents internal functions from becoming spend groups in the output
- Updated existing test (`fuji_safe`) to verify inlined helper behavior in real contracts

https://claude.ai/code/session_01RYGDrWM3QUPomaJJHCqZy6