### PR TITLE
Omit unused constructor parameters per covenant

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -35,6 +35,7 @@ mod concat;
 mod expr;
 mod introspection;
 mod loops;
+mod references;
 
 pub(crate) use asset::*;
 pub(crate) use comparison::*;
@@ -780,7 +781,13 @@ fn covenant_for(
     structs: &[crate::models::StructDefinition],
 ) -> Result<ArkadeCovenant, String> {
     let inputs = function_inputs(&function.parameters);
-    let mut generator = Generator::new(&function.parameters, constructor_parameters, structs)?;
+    let references = references::referenced_parameters(&function.statements);
+    let retained_parameters = constructor_parameters
+        .iter()
+        .filter(|parameter| references.contains(parameter.name.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut generator = Generator::new(&function.parameters, &retained_parameters, structs)?;
     generate_asm_from_statements_recursive(&function.statements, &mut generator)?;
     let asm = generator.finish()?;
     Ok(ArkadeCovenant { inputs, asm })

--- a/src/compiler/references.rs
+++ b/src/compiler/references.rs
@@ -1,0 +1,122 @@
+use std::collections::HashSet;
+
+use crate::models::{AssignmentTarget, Expression, Requirement, Statement};
+use crate::validator::child_exprs;
+
+// Parameters are retained whole; pruning individual composite fields needs a sparse stack layout.
+pub(super) fn referenced_parameters(statements: &[Statement]) -> HashSet<&str> {
+    let mut names = HashSet::new();
+    collect_statements(statements, &mut names);
+    names
+}
+
+fn collect_name<'a>(name: &'a str, names: &mut HashSet<&'a str>) {
+    names.insert(name.split(['.', '[']).next().unwrap_or(name));
+    // Named crypto operands can carry runtime indices, e.g. keys[index].
+    if let Some((_, index)) = name.strip_suffix(']').and_then(|name| name.split_once('[')) {
+        collect_name(index, names);
+    }
+}
+
+fn collect_expression<'a>(expression: &'a Expression, names: &mut HashSet<&'a str>) {
+    match expression {
+        Expression::Variable(name)
+        | Expression::Property(name)
+        | Expression::ArrayIndex { array: name, .. }
+        | Expression::GroupProperty { group: name, .. }
+        | Expression::GroupControlIs { group: name, .. } => collect_name(name, names),
+        Expression::CheckSigExpr { signature, pubkey } => {
+            collect_name(signature, names);
+            collect_name(pubkey, names);
+        }
+        Expression::CheckSigFromStackExpr {
+            signature,
+            pubkey,
+            message,
+        }
+        | Expression::CheckSigFromStackVerify {
+            signature,
+            pubkey,
+            message,
+        } => {
+            collect_name(signature, names);
+            collect_name(pubkey, names);
+            collect_name(message, names);
+        }
+        _ => {}
+    }
+    for child in child_exprs(expression) {
+        collect_expression(child, names);
+    }
+}
+
+fn collect_requirement<'a>(requirement: &'a Requirement, names: &mut HashSet<&'a str>) {
+    match requirement {
+        Requirement::Expression(expression) => collect_expression(expression, names),
+        Requirement::Comparison { left, right, .. } => {
+            collect_expression(left, names);
+            collect_expression(right, names);
+        }
+        Requirement::CheckSig { signature, pubkey } => {
+            collect_name(signature, names);
+            collect_name(pubkey, names);
+        }
+        Requirement::CheckSigFromStack {
+            signature,
+            pubkey,
+            message,
+        } => {
+            collect_name(signature, names);
+            collect_name(pubkey, names);
+            collect_name(message, names);
+        }
+        Requirement::CheckMultisig {
+            pubkeys,
+            signatures,
+            ..
+        } => {
+            for name in pubkeys.iter().chain(signatures) {
+                collect_name(name, names);
+            }
+        }
+        Requirement::After { timelock_var, .. } => {
+            if let Some(name) = timelock_var {
+                collect_name(name, names);
+            }
+        }
+        Requirement::HashEqual { preimage, hash, .. } => {
+            collect_name(preimage, names);
+            collect_name(hash, names);
+        }
+    }
+}
+
+fn collect_statements<'a>(statements: &'a [Statement], names: &mut HashSet<&'a str>) {
+    for statement in statements {
+        match statement {
+            Statement::Require(requirement) => collect_requirement(requirement, names),
+            Statement::LetBinding { value, .. } => collect_expression(value, names),
+            Statement::VarAssign { target, value } => {
+                if let AssignmentTarget::ArrayIndex { index, .. } = target {
+                    collect_expression(index, names);
+                }
+                collect_expression(value, names);
+            }
+            Statement::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                collect_expression(condition, names);
+                collect_statements(then_body, names);
+                if let Some(body) = else_body {
+                    collect_statements(body, names);
+                }
+            }
+            Statement::ForIn { iterable, body, .. } => {
+                collect_expression(iterable, names);
+                collect_statements(body, names);
+            }
+        }
+    }
+}

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -579,7 +579,7 @@ fn check_asset_id_expr(
 /// [`Expression`] variant will fail to compile here until its nested
 /// expressions — if any — are declared, guaranteeing that walkers built on top
 /// of this (e.g. [`check_asset_id_expr`]) cover every new construct.
-fn child_exprs(expr: &Expression) -> Vec<&Expression> {
+pub(crate) fn child_exprs(expr: &Expression) -> Vec<&Expression> {
     match expr {
         // Leaf nodes: no nested expressions.
         Expression::Variable(_)
@@ -1892,11 +1892,26 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
                     group.name
                 )));
             }
-            // The ABI keeps one entry per source parameter; the prologue pushes
-            // one placeholder per scalar leaf, so compare against the flattened
-            // layout.
+            let prologue = arkade
+                .asm
+                .iter()
+                .take_while(|token| {
+                    token.starts_with('<') && token.ends_with('>') && !token.starts_with("<VTXO:")
+                })
+                .collect::<Vec<_>>();
+            let retained_names = prologue
+                .iter()
+                .map(|token| token[1..token.len() - 1].split('.').next().unwrap())
+                .collect::<HashSet<_>>();
+            let retained_parameters = output
+                .parameters
+                .iter()
+                .filter(|parameter| retained_names.contains(parameter.name.as_str()))
+                .cloned()
+                .collect::<Vec<_>>();
+            // Retained parameters push every scalar leaf in reverse declaration order.
             let expected_prologue = match crate::compiler::expanded_placeholder_params(
-                &output.parameters,
+                &retained_parameters,
                 &output.structs,
             ) {
                 Ok(parameters) => parameters
@@ -1912,18 +1927,15 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
                     continue;
                 }
             };
-            if !arkade.asm.starts_with(&expected_prologue) {
+            if !prologue.iter().copied().eq(expected_prologue.iter()) {
                 issues.push(ValidationIssue::error(format!(
                     "group '{}' arkade covenant has an invalid constructor prologue",
                     group.name
                 )));
             }
-            if arkade.asm[expected_prologue.len().min(arkade.asm.len())..]
-                .iter()
-                .any(|token| {
-                    token.starts_with('<') && token.ends_with('>') && !token.starts_with("<VTXO:")
-                })
-            {
+            if arkade.asm[prologue.len()..].iter().any(|token| {
+                token.starts_with('<') && token.ends_with('>') && !token.starts_with("<VTXO:")
+            }) {
                 issues.push(ValidationIssue::error(format!(
                     "group '{}' arkade covenant has a placeholder outside its constructor prologue",
                     group.name
@@ -1968,6 +1980,27 @@ pub fn validate_output(output: &ContractJson) -> Vec<ValidationIssue> {
 mod tests {
     use super::*;
     use crate::models::{AbiFunctionGroup, AbiLeaf, Contract, Function, Parameter, WitnessElement};
+
+    #[test]
+    fn output_validation_checks_filtered_constructor_layouts() {
+        let output = crate::compile("contract C(int unused, int[2] values, int limit) { function spend() { require(values[0] > limit); } }").unwrap();
+        for prologue in [
+            vec!["<values.1>", "<values.0>", "<limit>"],
+            vec!["<limit>", "<values.0>"],
+            vec!["<limit>", "<limit>"],
+            vec!["<unknown>"],
+            vec!["OP_1", "<limit>"],
+        ] {
+            let mut invalid = output.clone();
+            let asm = &mut invalid.functions[0].arkade.as_mut().unwrap().asm;
+            asm.splice(..3, prologue.into_iter().map(String::from));
+            assert!(
+                has_errors(&validate_output(&invalid)),
+                "{:?}",
+                invalid.functions[0].arkade.as_ref().unwrap().asm
+            );
+        }
+    }
 
     fn parse_and_validate(source: &str) -> Vec<ValidationIssue> {
         validate_ast(&crate::parser::parse(source).expect("contract should parse"))

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -345,7 +345,7 @@ fn dotted_paths_distinguish_underscores_from_nesting() {
 struct Inner { int b; }
 struct Ambiguous { int a_b; Inner a; }
 contract C(Ambiguous value) {
-    function spend() { require(true); }
+    function spend() { require(value.a_b == value.a.b); }
 }
 "#,
     )

--- a/tests/features/symbolic_stack.rs
+++ b/tests/features/symbolic_stack.rs
@@ -345,3 +345,104 @@ contract RuntimeIndex() {
         "unexpected error: {error}"
     );
 }
+
+#[test]
+fn constructor_parameters_are_filtered_per_spending_path() {
+    let output = compile(
+        r#"
+contract Paths(int unused, int left, int right, pubkey exitKey, int delay) {
+    function first(int value) { require(value == left); }
+    function second(int value) { require(value == right); }
+    function neither() { require(true); }
+    function exit(signature ownerSig) tapscript {
+        require(older(delay));
+        require(checkSig(ownerSig, exitKey));
+    }
+}
+"#,
+    )
+    .expect("compile");
+    assert_eq!(output.parameters.len(), 5);
+    assert_eq!(output.functions.len(), 4);
+    for (name, parameter) in [("first", "left"), ("second", "right")] {
+        let group = crate::common::group(&output, name);
+        let covenant = group.arkade.as_ref().unwrap();
+        assert_eq!(
+            covenant.asm,
+            format!(
+                "<{parameter}> OP_1 OP_PICK OP_1 OP_PICK OP_EQUAL OP_VERIFY OP_1 OP_NIP OP_NIP"
+            )
+            .split_whitespace()
+            .map(String::from)
+            .collect::<Vec<_>>()
+        );
+        assert_eq!(crate::common::arkade_inputs(&output, name), ["value"]);
+        assert_eq!(group.leaves.len(), 1);
+        assert_eq!(
+            crate::common::witness_names(&output, name, name),
+            ["serverSig", "emulatorSig"]
+        );
+        assert_eq!(
+            crate::common::leaf_asm(&output, name, name),
+            format!("<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:{name}> OP_CHECKSIG")
+        );
+    }
+    assert_eq!(
+        crate::common::arkade_asm_tokens(&output, "neither"),
+        ["OP_1", "OP_VERIFY", "OP_1"]
+    );
+    assert!(crate::common::group(&output, "exit").arkade.is_none());
+    assert_eq!(
+        crate::common::witness_names(&output, "exit", "exit"),
+        ["ownerSig"]
+    );
+    assert_eq!(
+        crate::common::leaf_asm(&output, "exit", "exit"),
+        "<delay> OP_CHECKSEQUENCEVERIFY OP_DROP <exitKey> OP_CHECKSIG"
+    );
+}
+
+#[test]
+fn constructor_references_cover_nested_bodies_and_named_operands() {
+    for (parameters, inputs, body, expected) in [
+        ("int limit, int alternate, bool choose", "int value",
+         "let total = 0; if (choose) { total = limit; } else { total = alternate; } require(total > value);",
+         vec!["<choose>", "<alternate>", "<limit>"]),
+        ("int[2] values, int limit", "",
+         "for (i, value) in values { require(value > limit); }",
+         vec!["<limit>", "<values.1>", "<values.0>"]),
+        ("int index, int amount", "",
+         "int[2] values = [0, 0]; values[index] = amount; require(values[0] >= 0);",
+         vec!["<amount>", "<index>"]),
+        ("Policy policy", "int index",
+         "require(policy.limits[index] > 0); require(policy.limits.length == 2);",
+         vec!["<policy.limits.1>", "<policy.limits.0>", "<policy.key>"]),
+        ("pubkey[2] keys, int index, bytes32 message", "signature sig",
+         "require(checkSigFromStack(sig, keys[index], message));",
+         vec!["<message>", "<index>", "<keys.1>", "<keys.0>"]),
+        ("pubkey key", "signature sig",
+         "if (checkSig(sig, key)) { require(true); } else { require(false); }",
+         vec!["<key>"]),
+        ("bytes32 digest, int deadline", "bytes preimage",
+         "require(sha256(preimage) == digest); require(tx.time >= deadline);",
+         vec!["<deadline>", "<digest>"]),
+        ("int groupIndex, bytes32 txid, int gidx", "",
+         "require(groupIndex.sumInputs >= 0); require(groupIndex.controlIs(txid, gidx));",
+         vec!["<gidx>", "<txid>", "<groupIndex>"]),
+        ("Policy policy", "",
+         "require(tx.outputs[0].scriptPubKey == new Child(policy));",
+         vec!["<policy.limits.1>", "<policy.limits.0>", "<policy.key>"]),
+    ] {
+        let source = format!(
+            "struct Policy {{ pubkey key; int[2] limits; }} contract C(int unused, Policy unusedPolicy, {parameters}, int unusedTail) {{ function spend({inputs}) {{ {body} }} }}"
+        );
+        let actual = covenant(&source, "spend");
+        let prologue = actual.asm.iter().take_while(|token| token.starts_with('<')).map(String::as_str).collect::<Vec<_>>();
+        assert_eq!(prologue, expected, "{body}");
+        let baseline = covenant(&source.replace("int unused, Policy unusedPolicy, ", "").replace(", int unusedTail", ""), "spend");
+        assert_eq!(actual.asm, baseline.asm, "{body}");
+        if body.contains("new Child") {
+            assert!(actual.asm.contains(&"<VTXO:Child(<policy.key>,<policy.limits.0>,<policy.limits.1>)>".to_string()));
+        }
+    }
+}

--- a/tests/features/threshold_multisig.rs
+++ b/tests/features/threshold_multisig.rs
@@ -64,16 +64,7 @@ fn test_threshold_multisig() {
 
     // Covenant ASM: reversed constructor prologue plus symbolic signature/key reads.
     let tof_tokens = arkade_asm_tokens(&output, "twoOfTwo");
-    assert_eq!(
-        &tof_tokens[..5],
-        [
-            "<signer4>",
-            "<signer3>",
-            "<signer2>",
-            "<signer1>",
-            "<signer>"
-        ]
-    );
+    assert_eq!(&tof_tokens[..2], ["<signer1>", "<signer>"]);
     assert_eq!(
         tof_tokens
             .iter()


### PR DESCRIPTION
Each covenant currently embeds every constructor parameter, including values used only by other spending paths. Filter its constructor prologue to the parameters referenced in that function's body, including nested statements, named crypto operands, arrays, structs, and contract-instance arguments.

Preserve the full constructor ABI, witness layouts, and L1 tapleaves. Referenced composite parameters retain all their scalar leaves. The output validator accepts filtered prologues while rejecting unknown, reordered, duplicated, incomplete, or misplaced placeholders. Private-function call-tree traversal remains outside this change.

Reviewed constructor binding and stack layout, composite expansion, artifact validation, and binding-generator consumers. Regression coverage checks per-path assembly, nested references, tapleaf isolation, and malformed prologues.

Validation:
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
