### PR TITLE
Fix unary negation

### DIFF
--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -349,7 +349,21 @@ impl ConcatPass {
                     Expression::InputPacketInspect { index, packet_type } => {
                         vec![index, packet_type]
                     }
-                    _ => vec![],
+                    // These compound variants are handled above.
+                    Expression::ArrayLiteral(_)
+                    | Expression::StructLiteral(_)
+                    | Expression::ArrayIndex { .. }
+                    | Expression::BinaryOp { .. } => vec![],
+                    Expression::Variable(_)
+                    | Expression::Literal(_)
+                    | Expression::Property(_)
+                    | Expression::CurrentInput(_)
+                    | Expression::TxIntrospection { .. }
+                    | Expression::GroupProperty { .. }
+                    | Expression::AssetGroupsLength
+                    | Expression::CheckSigExpr { .. }
+                    | Expression::CheckSigFromStackExpr { .. }
+                    | Expression::CheckSigFromStackVerify { .. } => vec![],
                 };
                 for child in children {
                     *child = self

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -247,108 +247,118 @@ impl ConcatPass {
                     )
                 }
             }
-            Expression::Sha256 { data } => {
-                let (new_data, _) = self.rewrite_expression_concat(*data, scope);
-                (
-                    Expression::Sha256 {
-                        data: Box::new(new_data),
-                    },
-                    ArkType::Bytes32,
-                )
-            }
-            Expression::Sha256Initialize { data } => {
-                let (new_data, _) = self.rewrite_expression_concat(*data, scope);
-                (
-                    Expression::Sha256Initialize {
-                        data: Box::new(new_data),
-                    },
-                    ArkType::Bytes32,
-                )
-            }
-            Expression::Sha256Update { context, chunk } => {
-                let (new_ctx, _) = self.rewrite_expression_concat(*context, scope);
-                let (new_chunk, _) = self.rewrite_expression_concat(*chunk, scope);
-                (
-                    Expression::Sha256Update {
-                        context: Box::new(new_ctx),
-                        chunk: Box::new(new_chunk),
-                    },
-                    ArkType::Bytes32,
-                )
-            }
-            Expression::Sha256Finalize {
-                context,
-                last_chunk,
-            } => {
-                let (new_ctx, _) = self.rewrite_expression_concat(*context, scope);
-                let (new_chunk, _) = self.rewrite_expression_concat(*last_chunk, scope);
-                (
+            mut other => {
+                let children: Vec<&mut Expression> = match &mut other {
+                    Expression::AssetLookup {
+                        index,
+                        asset_txid,
+                        asset_gidx,
+                        ..
+                    }
+                    | Expression::AssetHas {
+                        index,
+                        asset_txid,
+                        asset_gidx,
+                        ..
+                    } => vec![index, asset_txid, asset_gidx],
+                    Expression::AssetCount { index, .. }
+                    | Expression::InputIntrospection { index, .. }
+                    | Expression::OutputIntrospection { index, .. }
+                    | Expression::GroupSum { index, .. }
+                    | Expression::GroupNumIO { index, .. } => vec![index],
+                    Expression::AssetAt {
+                        io_index,
+                        asset_index,
+                        ..
+                    } => vec![io_index, asset_index],
+                    Expression::GroupFind {
+                        asset_txid,
+                        asset_gidx,
+                    }
+                    | Expression::GroupHas {
+                        asset_txid,
+                        asset_gidx,
+                    }
+                    | Expression::GroupControlIs {
+                        asset_txid,
+                        asset_gidx,
+                        ..
+                    } => vec![asset_txid, asset_gidx],
+                    Expression::GroupIOAccess {
+                        group_index,
+                        io_index,
+                        ..
+                    } => vec![group_index, io_index],
+                    Expression::Sha256 { data }
+                    | Expression::Sha256Initialize { data }
+                    | Expression::Bin2Num { data }
+                    | Expression::ReverseBytes { data }
+                    | Expression::SizeOf { data } => vec![data],
+                    Expression::Sha256Update { context, chunk } => vec![context, chunk],
                     Expression::Sha256Finalize {
-                        context: Box::new(new_ctx),
-                        last_chunk: Box::new(new_chunk),
-                    },
-                    ArkType::Bytes32,
-                )
-            }
-            Expression::Concat { left, right } => {
-                let (new_l, _) = self.rewrite_expression_concat(*left, scope);
-                let (new_r, _) = self.rewrite_expression_concat(*right, scope);
-                (
-                    Expression::Concat {
-                        left: Box::new(new_l),
-                        right: Box::new(new_r),
-                    },
-                    ArkType::Bytes,
-                )
-            }
-            // `data` is parsed as an additive expression, same as Sha256, so a
-            // `+` underneath it still has to be rewritten into a Concat.
-            Expression::Digest { data, hash_type } => {
-                let (new_data, _) = self.rewrite_expression_concat(*data, scope);
-                (
-                    Expression::Digest {
-                        data: Box::new(new_data),
-                        hash_type,
-                    },
-                    ArkType::Bytes,
-                )
-            }
-            Expression::Negate { value } => {
-                let (nv, _) = self.rewrite_expression_concat(*value, scope);
-                (
-                    Expression::Negate {
-                        value: Box::new(nv),
-                    },
-                    ArkType::Int,
-                )
-            }
-            Expression::Not { value } => {
-                let (nv, _) = self.rewrite_expression_concat(*value, scope);
-                (
-                    Expression::Not {
-                        value: Box::new(nv),
-                    },
-                    ArkType::Bool,
-                )
-            }
-            Expression::ContractInstance {
-                contract_name,
-                args,
-            } => {
-                let new_args = args
-                    .into_iter()
-                    .map(|a| self.rewrite_expression_concat(a, scope).0)
-                    .collect();
-                (
-                    Expression::ContractInstance {
-                        contract_name,
-                        args: new_args,
-                    },
-                    ArkType::Bytes,
-                )
-            }
-            // Leaves and other compound expressions: no `+` to rewrite below the surface.
-            other => {
+                        context,
+                        last_chunk,
+                    } => vec![context, last_chunk],
+                    Expression::Sighash { hash_type } => vec![hash_type],
+                    Expression::Digest { data, hash_type } => vec![data, hash_type],
+                    Expression::Negate { value } | Expression::Not { value } => vec![value],
+                    Expression::ModExp {
+                        base,
+                        exponent,
+                        modulus,
+                    } => vec![base, exponent, modulus],
+                    Expression::EcAdd {
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        curve_id,
+                    } => vec![x1, y1, x2, y2, curve_id],
+                    Expression::EcMul {
+                        x,
+                        y,
+                        scalar,
+                        curve_id,
+                    } => vec![x, y, scalar, curve_id],
+                    Expression::EcPairing {
+                        g1_x,
+                        g1_y,
+                        g2_x_c1,
+                        g2_x_c0,
+                        g2_y_c1,
+                        g2_y_c0,
+                        curve_id,
+                    } => vec![g1_x, g1_y, g2_x_c1, g2_x_c0, g2_y_c1, g2_y_c0, curve_id],
+                    Expression::EcMulScalarVerify {
+                        scalar,
+                        point_p,
+                        point_q,
+                    } => vec![scalar, point_p, point_q],
+                    Expression::TweakVerify {
+                        point_p,
+                        tweak,
+                        point_q,
+                    } => vec![point_p, tweak, point_q],
+                    Expression::ContractInstance { args, .. } => args.iter_mut().collect(),
+                    Expression::Substr { data, offset, size } => vec![data, offset, size],
+                    Expression::Concat { left, right } | Expression::Cat { left, right } => {
+                        vec![left, right]
+                    }
+                    Expression::Num2Bin { value, size } => vec![value, size],
+                    Expression::PacketInspect { packet_type } => vec![packet_type],
+                    Expression::InputPacketInspect { index, packet_type } => {
+                        vec![index, packet_type]
+                    }
+                    _ => vec![],
+                };
+                for child in children {
+                    *child = self
+                        .rewrite_expression_concat(
+                            std::mem::replace(child, Expression::Literal(String::new())),
+                            scope,
+                        )
+                        .0;
+                }
                 let t = crate::typechecker::infer_type(&other, scope);
                 (other, t)
             }

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -322,6 +322,15 @@ impl ConcatPass {
                     ArkType::Int,
                 )
             }
+            Expression::Not { value } => {
+                let (nv, _) = self.rewrite_expression_concat(*value, scope);
+                (
+                    Expression::Not {
+                        value: Box::new(nv),
+                    },
+                    ArkType::Bool,
+                )
+            }
             Expression::ContractInstance {
                 contract_name,
                 args,

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -217,6 +217,10 @@ pub(crate) fn emit_expression_asm(expr: &Expression, asm: &mut Vec<String>) {
             emit_expression_asm(value, asm);
             asm.push(OP_NEGATE.to_string());
         }
+        Expression::Not { value } => {
+            emit_expression_asm(value, asm);
+            asm.push(OP_NOT.to_string());
+        }
         Expression::ModExp {
             base,
             exponent,

--- a/src/compiler/loops.rs
+++ b/src/compiler/loops.rs
@@ -292,6 +292,11 @@ pub(crate) fn substitute_expression(
                 value, index_var, value_var, k, array_name,
             )),
         },
+        Expression::Not { value } => Expression::Not {
+            value: Box::new(substitute_expression(
+                value, index_var, value_var, k, array_name,
+            )),
+        },
         Expression::ReverseBytes { data } => Expression::ReverseBytes {
             data: Box::new(substitute_expression(
                 data, index_var, value_var, k, array_name,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -637,8 +637,10 @@ pub enum Expression {
         hash_type: Box<Expression>,
     },
     // ─── Arithmetic ────────────────────────────────────────────────────
-    /// Negate a BigNum value: negate(value)
+    /// Arithmetic negation: -value
     Negate { value: Box<Expression> },
+    /// Boolean negation: !value
+    Not { value: Box<Expression> },
     /// Modular exponentiation: modExp(base, exponent, modulus)
     ModExp {
         base: Box<Expression>,

--- a/src/parser/crypto.rs
+++ b/src/parser/crypto.rs
@@ -10,11 +10,7 @@ use pest::iterators::Pair;
 pub(crate) fn parse_sha256_initialize(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     let data_pair = inner.next().ok_or("Missing data in sha256Initialize")?;
-    let data = match data_pair.as_rule() {
-        Rule::identifier => Expression::Variable(data_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(data_pair.as_str().to_string()),
-        _ => Expression::Property(data_pair.as_str().to_string()),
-    };
+    let data = parse_general_expression(data_pair)?;
     Ok(Expression::Sha256Initialize {
         data: Box::new(data),
     })
@@ -27,11 +23,7 @@ pub(crate) fn parse_sha256_update(pair: Pair<Rule>) -> Result<Expression, String
     let context = Expression::Variable(ctx_pair.as_str().to_string());
 
     let chunk_pair = inner.next().ok_or("Missing chunk in sha256Update")?;
-    let chunk = match chunk_pair.as_rule() {
-        Rule::identifier => Expression::Variable(chunk_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(chunk_pair.as_str().to_string()),
-        _ => Expression::Property(chunk_pair.as_str().to_string()),
-    };
+    let chunk = parse_general_expression(chunk_pair)?;
     Ok(Expression::Sha256Update {
         context: Box::new(context),
         chunk: Box::new(chunk),
@@ -45,11 +37,7 @@ pub(crate) fn parse_sha256_finalize(pair: Pair<Rule>) -> Result<Expression, Stri
     let context = Expression::Variable(ctx_pair.as_str().to_string());
 
     let chunk_pair = inner.next().ok_or("Missing lastChunk in sha256Finalize")?;
-    let last_chunk = match chunk_pair.as_rule() {
-        Rule::identifier => Expression::Variable(chunk_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(chunk_pair.as_str().to_string()),
-        _ => Expression::Property(chunk_pair.as_str().to_string()),
-    };
+    let last_chunk = parse_general_expression(chunk_pair)?;
     Ok(Expression::Sha256Finalize {
         context: Box::new(context),
         last_chunk: Box::new(last_chunk),
@@ -62,14 +50,14 @@ pub(crate) fn parse_sighash(pair: Pair<Rule>) -> Result<Expression, String> {
         .next()
         .ok_or("Missing hash type in sighash")?;
     Ok(Expression::Sighash {
-        hash_type: Box::new(parse_atom_pair(hash_type)),
+        hash_type: Box::new(parse_general_expression(hash_type)?),
     })
 }
 
 pub(crate) fn parse_digest(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     let data = parse_additive_expr(inner.next().ok_or("Missing data in digest")?)?;
-    let hash_type = parse_atom_pair(inner.next().ok_or("Missing hash type in digest")?);
+    let hash_type = parse_general_expression(inner.next().ok_or("Missing hash type in digest")?)?;
     Ok(Expression::Digest {
         data: Box::new(data),
         hash_type: Box::new(hash_type),
@@ -82,15 +70,15 @@ pub(crate) fn parse_digest(pair: Pair<Rule>) -> Result<Expression, String> {
 pub(crate) fn parse_mod_exp(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     Ok(Expression::ModExp {
-        base: Box::new(parse_atom_pair(
+        base: Box::new(parse_general_expression(
             inner.next().ok_or("Missing base in modExp")?,
-        )),
-        exponent: Box::new(parse_atom_pair(
+        )?),
+        exponent: Box::new(parse_general_expression(
             inner.next().ok_or("Missing exponent in modExp")?,
-        )),
-        modulus: Box::new(parse_atom_pair(
+        )?),
+        modulus: Box::new(parse_general_expression(
             inner.next().ok_or("Missing modulus in modExp")?,
-        )),
+        )?),
     })
 }
 
@@ -99,54 +87,66 @@ pub(crate) fn parse_mod_exp(pair: Pair<Rule>) -> Result<Expression, String> {
 pub(crate) fn parse_ec_add(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     Ok(Expression::EcAdd {
-        x1: Box::new(parse_atom_pair(inner.next().ok_or("Missing x1 in ecAdd")?)),
-        y1: Box::new(parse_atom_pair(inner.next().ok_or("Missing y1 in ecAdd")?)),
-        x2: Box::new(parse_atom_pair(inner.next().ok_or("Missing x2 in ecAdd")?)),
-        y2: Box::new(parse_atom_pair(inner.next().ok_or("Missing y2 in ecAdd")?)),
-        curve_id: Box::new(parse_atom_pair(
+        x1: Box::new(parse_general_expression(
+            inner.next().ok_or("Missing x1 in ecAdd")?,
+        )?),
+        y1: Box::new(parse_general_expression(
+            inner.next().ok_or("Missing y1 in ecAdd")?,
+        )?),
+        x2: Box::new(parse_general_expression(
+            inner.next().ok_or("Missing x2 in ecAdd")?,
+        )?),
+        y2: Box::new(parse_general_expression(
+            inner.next().ok_or("Missing y2 in ecAdd")?,
+        )?),
+        curve_id: Box::new(parse_general_expression(
             inner.next().ok_or("Missing curve ID in ecAdd")?,
-        )),
+        )?),
     })
 }
 
 pub(crate) fn parse_ec_mul(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     Ok(Expression::EcMul {
-        x: Box::new(parse_atom_pair(inner.next().ok_or("Missing x in ecMul")?)),
-        y: Box::new(parse_atom_pair(inner.next().ok_or("Missing y in ecMul")?)),
-        scalar: Box::new(parse_atom_pair(
+        x: Box::new(parse_general_expression(
+            inner.next().ok_or("Missing x in ecMul")?,
+        )?),
+        y: Box::new(parse_general_expression(
+            inner.next().ok_or("Missing y in ecMul")?,
+        )?),
+        scalar: Box::new(parse_general_expression(
             inner.next().ok_or("Missing scalar in ecMul")?,
-        )),
-        curve_id: Box::new(parse_atom_pair(
+        )?),
+        curve_id: Box::new(parse_general_expression(
             inner.next().ok_or("Missing curve ID in ecMul")?,
-        )),
+        )?),
     })
 }
 
 pub(crate) fn parse_ec_pairing(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     Ok(Expression::EcPairing {
-        g1_x: Box::new(parse_atom_pair(
+        g1_x: Box::new(parse_general_expression(
             inner.next().ok_or("Missing G1 x in ecPairing")?,
-        )),
-        g1_y: Box::new(parse_atom_pair(
+        )?),
+        g1_y: Box::new(parse_general_expression(
             inner.next().ok_or("Missing G1 y in ecPairing")?,
-        )),
-        g2_x_c1: Box::new(parse_atom_pair(
+        )?),
+        g2_x_c1: Box::new(parse_general_expression(
             inner.next().ok_or("Missing G2 x c1 in ecPairing")?,
-        )),
-        g2_x_c0: Box::new(parse_atom_pair(
+        )?),
+        g2_x_c0: Box::new(parse_general_expression(
             inner.next().ok_or("Missing G2 x c0 in ecPairing")?,
-        )),
-        g2_y_c1: Box::new(parse_atom_pair(
+        )?),
+        g2_y_c1: Box::new(parse_general_expression(
             inner.next().ok_or("Missing G2 y c1 in ecPairing")?,
-        )),
-        g2_y_c0: Box::new(parse_atom_pair(
+        )?),
+        g2_y_c0: Box::new(parse_general_expression(
             inner.next().ok_or("Missing G2 y c0 in ecPairing")?,
-        )),
-        curve_id: Box::new(parse_atom_pair(
+        )?),
+        curve_id: Box::new(parse_general_expression(
             inner.next().ok_or("Missing curve ID in ecPairing")?,
-        )),
+        )?),
     })
 }
 
@@ -157,25 +157,13 @@ pub(crate) fn parse_ec_mul_scalar_verify(pair: Pair<Rule>) -> Result<Expression,
     let scalar_pair = inner
         .next()
         .ok_or("Missing scalar k in ecMulScalarVerify")?;
-    let scalar = match scalar_pair.as_rule() {
-        Rule::identifier => Expression::Variable(scalar_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(scalar_pair.as_str().to_string()),
-        _ => Expression::Property(scalar_pair.as_str().to_string()),
-    };
+    let scalar = parse_general_expression(scalar_pair)?;
 
     let point_p_pair = inner.next().ok_or("Missing point P in ecMulScalarVerify")?;
-    let point_p = match point_p_pair.as_rule() {
-        Rule::identifier => Expression::Variable(point_p_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(point_p_pair.as_str().to_string()),
-        _ => Expression::Property(point_p_pair.as_str().to_string()),
-    };
+    let point_p = parse_general_expression(point_p_pair)?;
 
     let point_q_pair = inner.next().ok_or("Missing point Q in ecMulScalarVerify")?;
-    let point_q = match point_q_pair.as_rule() {
-        Rule::identifier => Expression::Variable(point_q_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(point_q_pair.as_str().to_string()),
-        _ => Expression::Property(point_q_pair.as_str().to_string()),
-    };
+    let point_q = parse_general_expression(point_q_pair)?;
 
     Ok(Expression::EcMulScalarVerify {
         scalar: Box::new(scalar),
@@ -189,25 +177,13 @@ pub(crate) fn parse_tweak_verify(pair: Pair<Rule>) -> Result<Expression, String>
     let mut inner = pair.into_inner();
 
     let point_p_pair = inner.next().ok_or("Missing point P in tweakVerify")?;
-    let point_p = match point_p_pair.as_rule() {
-        Rule::identifier => Expression::Variable(point_p_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(point_p_pair.as_str().to_string()),
-        _ => Expression::Property(point_p_pair.as_str().to_string()),
-    };
+    let point_p = parse_general_expression(point_p_pair)?;
 
     let tweak_pair = inner.next().ok_or("Missing tweak k in tweakVerify")?;
-    let tweak = match tweak_pair.as_rule() {
-        Rule::identifier => Expression::Variable(tweak_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(tweak_pair.as_str().to_string()),
-        _ => Expression::Property(tweak_pair.as_str().to_string()),
-    };
+    let tweak = parse_general_expression(tweak_pair)?;
 
     let point_q_pair = inner.next().ok_or("Missing point Q in tweakVerify")?;
-    let point_q = match point_q_pair.as_rule() {
-        Rule::identifier => Expression::Variable(point_q_pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(point_q_pair.as_str().to_string()),
-        _ => Expression::Property(point_q_pair.as_str().to_string()),
-    };
+    let point_q = parse_general_expression(point_q_pair)?;
 
     Ok(Expression::TweakVerify {
         point_p: Box::new(point_p),
@@ -255,8 +231,8 @@ pub(crate) fn parse_check_sig_from_stack_verify_expr(
 pub(crate) fn parse_substr(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
     let data = parse_byte_value(inner.next().ok_or("Missing data in substr")?)?;
-    let offset = parse_atom_pair(inner.next().ok_or("Missing offset in substr")?);
-    let size = parse_atom_pair(inner.next().ok_or("Missing size in substr")?);
+    let offset = parse_general_expression(inner.next().ok_or("Missing offset in substr")?)?;
+    let size = parse_general_expression(inner.next().ok_or("Missing size in substr")?)?;
     Ok(Expression::Substr {
         data: Box::new(data),
         offset: Box::new(offset),
@@ -287,8 +263,8 @@ pub(crate) fn parse_bin2num(pair: Pair<Rule>) -> Result<Expression, String> {
 /// Parse num2bin(value, size) → Expression::Num2Bin
 pub(crate) fn parse_num2bin(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
-    let value = parse_atom_pair(inner.next().ok_or("Missing value in num2bin")?);
-    let size = parse_atom_pair(inner.next().ok_or("Missing size in num2bin")?);
+    let value = parse_general_expression(inner.next().ok_or("Missing value in num2bin")?)?;
+    let size = parse_general_expression(inner.next().ok_or("Missing size in num2bin")?)?;
     Ok(Expression::Num2Bin {
         value: Box::new(value),
         size: Box::new(size),

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -174,17 +174,22 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
             let inner = pair.into_inner().next().ok_or("Empty primary expression")?;
             parse_primary_expr(inner)
         }
-        // `-operand` negates; without the leading `-` this is a pass-through.
-        Rule::unary_expr => {
+        Rule::unary_expr | Rule::unary_atom => {
             let mut inner = pair.into_inner();
-            let first = inner.next().ok_or("Empty unary expression")?;
-            if first.as_rule() != Rule::sub_op {
-                return parse_primary_expr(first);
+            let operand = inner.next_back().ok_or("Empty unary expression")?;
+            let mut value = parse_primary_expr(operand)?;
+            for operator in inner.rev() {
+                value = match operator.as_rule() {
+                    Rule::sub_op => Expression::Negate {
+                        value: Box::new(value),
+                    },
+                    Rule::not_op => Expression::Not {
+                        value: Box::new(value),
+                    },
+                    _ => return Err("Unexpected unary operator".to_string()),
+                };
             }
-            let operand = inner.next().ok_or("Missing operand after unary `-`")?;
-            Ok(Expression::Negate {
-                value: Box::new(parse_primary_expr(operand)?),
-            })
+            Ok(value)
         }
         Rule::general_expression | Rule::comparison_expr => {
             // Parenthesized expression
@@ -354,17 +359,6 @@ pub(crate) fn parse_complex_expression(pair: Pair<Rule>) -> Result<Requirement, 
 }
 
 // ─── Byte-string Manipulation Parsing ──────────────────────────────────
-
-/// Helper: convert an inner pair to an Expression for the byte-string
-/// and packet primitives. Identifiers → Variable, numbers → Literal,
-/// everything else → Property.
-pub(crate) fn parse_atom_pair(pair: Pair<Rule>) -> Expression {
-    match pair.as_rule() {
-        Rule::identifier => Expression::Variable(pair.as_str().to_string()),
-        Rule::number_literal => Expression::Literal(pair.as_str().to_string()),
-        _ => Expression::Property(pair.as_str().to_string()),
-    }
-}
 
 pub(crate) fn parse_property_access(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner().collect::<Vec<_>>();

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -133,8 +133,11 @@ multiplicative_expr = {
     unary_expr ~ ((mul_op | div_op) ~ unary_expr)*
 }
 
-// Unary expressions: an optional leading `-` negates its operand.
-unary_expr = { sub_op? ~ primary_expr }
+// Prefix operators bind tighter than multiplication and apply right to left.
+unary_expr = { (sub_op | not_op)* ~ primary_expr }
+
+// Built-in atom arguments accept prefix operators on literals and bindings.
+unary_atom = { (sub_op | not_op)* ~ ("(" ~ unary_atom ~ ")" | bool_literal | identifier | number_literal) }
 
 // Primary expressions (atoms)
 primary_expr = {
@@ -194,9 +197,10 @@ array_index_access = {
 
 // Operators
 comparison_operator = { ">=" | "<=" | "==" | "!=" | ">" | "<" }
-bool_literal = { ("true" | "false") ~ !(ASCII_ALPHANUMERIC | "_") }
+bool_literal = @{ ("true" | "false") ~ !(ASCII_ALPHANUMERIC | "_") }
 add_op = { "+" }
 sub_op = { "-" }
+not_op = { "!" ~ !"=" }
 mul_op = { "*" }
 div_op = { "/" }
 
@@ -530,56 +534,56 @@ sha256_func = {
 
 // Streaming SHA256 initialize: sha256Initialize(data) → OP_SHA256INITIALIZE
 sha256_initialize = {
-    "sha256Initialize" ~ "(" ~ (identifier | number_literal) ~ ")"
+    "sha256Initialize" ~ "(" ~ unary_atom ~ ")"
 }
 
 // Streaming SHA256 update: sha256Update(ctx, chunk) → OP_SHA256UPDATE
 sha256_update = {
-    "sha256Update" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")"
+    "sha256Update" ~ "(" ~ identifier ~ "," ~ unary_atom ~ ")"
 }
 
 // Streaming SHA256 finalize: sha256Finalize(ctx, lastChunk) → OP_SHA256FINALIZE
 sha256_finalize = {
-    "sha256Finalize" ~ "(" ~ identifier ~ "," ~ (identifier | number_literal) ~ ")"
+    "sha256Finalize" ~ "(" ~ identifier ~ "," ~ unary_atom ~ ")"
 }
 
 sighash_func = {
-    "sighash" ~ "(" ~ (identifier | number_literal) ~ ")"
+    "sighash" ~ "(" ~ unary_atom ~ ")"
 }
 
 digest_func = {
-    "digest" ~ "(" ~ additive_expr ~ "," ~ (identifier | number_literal) ~ ")"
+    "digest" ~ "(" ~ additive_expr ~ "," ~ unary_atom ~ ")"
 }
 
 // ─── Arithmetic ────────────────────────────────────────────────────────
 
 // Modular exponentiation: modExp(base, exponent, modulus) → OP_MODEXP
 mod_exp_func = {
-    "modExp" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "modExp" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 // ─── Crypto Opcodes ────────────────────────────────────────────────────
 
 ec_add = {
-    "ecAdd" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "ecAdd" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 ec_mul = {
-    "ecMul" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "ecMul" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 ec_pairing = {
-    "ecPairing" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "ecPairing" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 // EC scalar multiplication verify: ecMulScalarVerify(k, P, Q) → OP_ECMULSCALARVERIFY
 ec_mul_scalar_verify = {
-    "ecMulScalarVerify" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "ecMulScalarVerify" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 // Tweak verification: tweakVerify(P, k, Q) → OP_TWEAKVERIFY
 tweak_verify = {
-    "tweakVerify" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "tweakVerify" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 // CheckSigFromStack with verify: checkSigFromStackVerify(sig, pubkey, msg) → OP_CHECKSIGFROMSTACK OP_VERIFY
@@ -610,7 +614,7 @@ byte_value = {
 
 // Substring extraction: substr(data, offset, size) → OP_SUBSTR
 substr_func = {
-    "substr" ~ "(" ~ byte_value ~ "," ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "substr" ~ "(" ~ byte_value ~ "," ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 // Byte concatenation: cat(a, b) → OP_CAT
@@ -625,7 +629,7 @@ bin2num_func = {
 
 // BigNum → fixed-width bytes: num2bin(num, size) → OP_NUM2BIN
 num2bin_func = {
-    "num2bin" ~ "(" ~ (identifier | number_literal) ~ "," ~ (identifier | number_literal) ~ ")"
+    "num2bin" ~ "(" ~ unary_atom ~ "," ~ unary_atom ~ ")"
 }
 
 // Reverse a byte array: reverseBytes(bytes) → OP_REVERSEBYTES
@@ -646,13 +650,13 @@ size_func = {
 
 // Current-tx packet: tx.packet(packetType) → <packetType> OP_INSPECTPACKET OP_1 OP_EQUALVERIFY
 packet_inspect = {
-    "tx" ~ "." ~ "packet" ~ "(" ~ (identifier | number_literal) ~ ")"
+    "tx" ~ "." ~ "packet" ~ "(" ~ unary_atom ~ ")"
 }
 
 // Previous Ark-tx packet via input i: tx.inputs[i].packet(packetType)
 // → <packetType> <i> OP_INSPECTINPUTPACKET OP_1 OP_EQUALVERIFY
 input_packet_inspect = {
-    "tx" ~ "." ~ "inputs" ~ array_access ~ "." ~ "packet" ~ "(" ~ (identifier | number_literal) ~ ")"
+    "tx" ~ "." ~ "inputs" ~ array_access ~ "." ~ "packet" ~ "(" ~ unary_atom ~ ")"
 }
 
 // ─── Terminals ─────────────────────────────────────────────────────────────────

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -136,8 +136,8 @@ multiplicative_expr = {
 // Prefix operators bind tighter than multiplication and apply right to left.
 unary_expr = { (sub_op | not_op)* ~ primary_expr }
 
-// Built-in atom arguments accept prefix operators on literals and bindings.
-unary_atom = { (sub_op | not_op)* ~ ("(" ~ unary_atom ~ ")" | bool_literal | identifier | number_literal) }
+// Built-in operands accept prefixes on literals, bindings, and grouped expressions.
+unary_atom = { (sub_op | not_op)* ~ ("(" ~ general_expression ~ ")" | bool_literal | identifier | number_literal) }
 
 // Primary expressions (atoms)
 primary_expr = {

--- a/src/parser/introspection.rs
+++ b/src/parser/introspection.rs
@@ -89,7 +89,8 @@ pub(crate) fn parse_output_introspection_to_expression(
 /// Parse tx.packet(packetType) → Expression::PacketInspect
 pub(crate) fn parse_packet_inspect(pair: Pair<Rule>) -> Result<Expression, String> {
     let mut inner = pair.into_inner();
-    let packet_type = parse_atom_pair(inner.next().ok_or("Missing packet type in tx.packet()")?);
+    let packet_type =
+        parse_general_expression(inner.next().ok_or("Missing packet type in tx.packet()")?)?;
     Ok(Expression::PacketInspect {
         packet_type: Box::new(packet_type),
     })
@@ -107,13 +108,13 @@ pub(crate) fn parse_input_packet_inspect(pair: Pair<Rule>) -> Result<Expression,
         .into_inner()
         .next()
         .ok_or("Empty array access in tx.inputs[i].packet()")?;
-    let index = parse_atom_pair(index_pair);
+    let index = parse_general_expression(index_pair)?;
 
-    let packet_type = parse_atom_pair(
+    let packet_type = parse_general_expression(
         inner
             .next()
             .ok_or("Missing packet type in tx.inputs[i].packet()")?,
-    );
+    )?;
 
     Ok(Expression::InputPacketInspect {
         index: Box::new(index),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -410,6 +410,30 @@ mod tests {
     use crate::models::{AssignmentTarget, Expression, Requirement, Statement};
 
     #[test]
+    fn parses_unary_prefix_order_and_boolean_boundaries() {
+        let contract = parse("contract Unary() { function spend() { let result = -!true != false; let truth = !trueValue; } }").unwrap();
+        let Statement::LetBinding {
+            value: Expression::BinaryOp { left, op, right },
+            ..
+        } = &contract.functions[0].statements[0]
+        else {
+            panic!("comparison must be the outer expression");
+        };
+        assert_eq!(op, "!=");
+        let Expression::Negate { value } = left.as_ref() else {
+            panic!("minus must be the outer prefix");
+        };
+        let Expression::Not { value } = value.as_ref() else {
+            panic!("not must be the inner prefix");
+        };
+        assert!(matches!(value.as_ref(), Expression::Literal(value) if value == "true"));
+        assert!(matches!(right.as_ref(), Expression::Literal(value) if value == "false"));
+        assert!(
+            matches!(&contract.functions[0].statements[1], Statement::LetBinding { value: Expression::Not { value }, .. } if matches!(value.as_ref(), Expression::Variable(name) if name == "trueValue"))
+        );
+    }
+
+    #[test]
     fn parses_structured_assignment_targets() {
         let contract = parse(
             r#"

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -369,6 +369,7 @@ fn resolve_expression(expression: &mut Expression, scope: &Scope) {
         Expression::Sha256 { data }
         | Expression::Sha256Initialize { data }
         | Expression::Negate { value: data }
+        | Expression::Not { value: data }
         | Expression::Bin2Num { data }
         | Expression::ReverseBytes { data }
         | Expression::SizeOf { data }
@@ -724,6 +725,9 @@ fn check_requirement(req: &Requirement, scope: &Scope, errors: &mut Vec<TypeErro
 
 fn check_expression(expr: &Expression, scope: &Scope, errors: &mut Vec<TypeError>, fn_name: &str) {
     match expr {
+        Expression::Negate { value } | Expression::Not { value } => {
+            check_expression(value, scope, errors, fn_name);
+        }
         Expression::ArrayIndex { array, index } => {
             check_array_index(array, index, scope, errors, fn_name);
         }
@@ -777,13 +781,14 @@ fn check_array_index(
     }
 }
 
-pub(crate) fn literal_index(expression: &Expression) -> Option<(bool, &str)> {
+pub(crate) fn literal_index(mut expression: &Expression) -> Option<(bool, &str)> {
+    let mut negative = false;
+    while let Expression::Negate { value } = expression {
+        negative = !negative;
+        expression = value;
+    }
     match expression {
-        Expression::Literal(value) => Some((false, value)),
-        Expression::Negate { value } => match value.as_ref() {
-            Expression::Literal(value) => Some((true, value)),
-            _ => None,
-        },
+        Expression::Literal(value) => Some((negative, value)),
         _ => None,
     }
 }
@@ -1020,6 +1025,7 @@ pub fn infer_type(expr: &Expression, scope: &Scope) -> ArkType {
 
         // Arithmetic
         Expression::Negate { .. } | Expression::ModExp { .. } => ArkType::Int,
+        Expression::Not { .. } => ArkType::Bool,
 
         // Crypto expressions
         Expression::CheckSigExpr { .. }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -649,7 +649,7 @@ fn child_exprs(expr: &Expression) -> Vec<&Expression> {
         } => vec![context, last_chunk],
         Expression::Sighash { hash_type } => vec![hash_type],
         Expression::Digest { data, hash_type } => vec![data, hash_type],
-        Expression::Negate { value } => vec![value],
+        Expression::Negate { value } | Expression::Not { value } => vec![value],
         Expression::ModExp {
             base,
             exponent,
@@ -1430,6 +1430,24 @@ fn validate_binding_expression(
     }
 
     match expression {
+        Expression::Negate { value } | Expression::Not { value } => {
+            let (operator, expected) = if matches!(expression, Expression::Negate { .. }) {
+                ("-", ArkType::Int)
+            } else {
+                ("!", ArkType::Bool)
+            };
+            let actual = resolved_expression_type(value, scopes);
+            if actual != expected && actual != ArkType::Unknown {
+                issues.push(ValidationIssue::error(format!(
+                    "function '{}': unary '{}' operand has type '{}', expected '{}'",
+                    function_name,
+                    operator,
+                    actual.as_str(),
+                    expected.as_str()
+                )));
+            }
+        }
+
         Expression::StructLiteral(_) => {
             issues.push(ValidationIssue::error(format!(
                 "function '{}': struct literals may only initialize typed struct declarations",

--- a/tests/features/opcode_functions.rs
+++ b/tests/features/opcode_functions.rs
@@ -488,3 +488,238 @@ fn test_streaming_hash_full_workflow() {
         asm_str
     );
 }
+
+#[test]
+fn unary_negation_precedence_and_spend_shape() {
+    for (expression, expected) in [
+        ("--1", "1 OP_NEGATE OP_NEGATE"),
+        ("-(-1)", "1 OP_NEGATE OP_NEGATE"),
+        ("1 - -2 * 3", "1 2 OP_NEGATE 3 OP_MUL OP_SUB"),
+        ("-(1 + 2) * 3", "1 2 OP_ADD OP_NEGATE 3 OP_MUL"),
+        ("!true", "OP_1 OP_NOT"),
+        ("!false", "OP_0 OP_NOT"),
+        ("!!true", "OP_1 OP_NOT OP_NOT"),
+        ("!!false", "OP_0 OP_NOT OP_NOT"),
+        ("!(1 < 2)", "1 2 OP_LESSTHAN OP_NOT"),
+        ("!true != false", "OP_1 OP_NOT OP_0 OP_EQUAL OP_NOT"),
+        ("num2bin(-1, 4)", "1 OP_NEGATE 4 OP_NUM2BIN"),
+        ("modExp(-2, 3, 5)", "2 OP_NEGATE 3 5 OP_MODEXP"),
+    ] {
+        let source = format!(
+            "contract Unary() {{ function spend() {{ let result = {expression}; require(result == result); }} }}"
+        );
+        let output = compile(&source).unwrap_or_else(|error| panic!("{expression}: {error}"));
+        assert!(
+            output.warnings.is_empty(),
+            "{expression}: {:?}",
+            output.warnings
+        );
+        let asm = crate::common::arkade_asm_tokens(&output, "spend");
+        assert!(
+            contains_tokens(&asm, &expected.split_whitespace().collect::<Vec<_>>()),
+            "{expression}: {asm:?}"
+        );
+        assert_eq!(output.functions.len(), 1);
+        assert_eq!(crate::common::group(&output, "spend").leaves.len(), 1);
+        assert!(crate::common::arkade_inputs(&output, "spend").is_empty());
+        assert_eq!(
+            crate::common::witness_names(&output, "spend", "spend"),
+            ["serverSig", "emulatorSig"]
+        );
+        assert_eq!(
+            crate::common::leaf_asm(&output, "spend", "spend"),
+            "<SERVER_KEY> OP_CHECKSIGVERIFY <EMULATOR_KEY:spend> OP_CHECKSIG"
+        );
+    }
+}
+
+#[test]
+fn unary_negation_in_loops_and_conditions() {
+    let output = compile(
+        r#"
+        contract Unary() {
+            function spend(bool[2] flags) {
+                for (i, flag) in flags {
+                    if (!flag) { require(!!flag == false); }
+                    let bytes = num2bin(-i, 4);
+                    require(size(bytes) == 4);
+                }
+            }
+        }
+    "#,
+    )
+    .expect("negated loop operands compile");
+    assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    let asm = crate::common::arkade_asm(&output, "spend");
+    for index in 0..2 {
+        assert!(
+            asm.contains(&format!("{index} OP_NEGATE 4 OP_NUM2BIN")),
+            "{asm}"
+        );
+    }
+    assert_eq!(
+        crate::common::opcode_count_in_arkade(&output, "spend", "OP_NOT"),
+        6
+    );
+    assert!(!asm.contains("<flag>") && !asm.contains("<i>"), "{asm}");
+}
+
+#[test]
+fn unary_negation_rejects_invalid_operand_types() {
+    for (params, expression, expected) in [
+        ("bool value", "-value", "expected 'int'"),
+        ("bytes value", "-value", "expected 'int'"),
+        ("int value", "!value", "expected 'bool'"),
+        ("bytes value", "!value", "expected 'bool'"),
+        ("bool value", "num2bin(-value, 4)", "expected 'int'"),
+        ("bool value", "modExp(-value, 2, 3)", "expected 'int'"),
+        ("bool value", "!-value", "expected 'int'"),
+        ("int value", "-!value", "expected 'bool'"),
+        ("bool[2] value", "-value[0]", "expected 'int'"),
+        ("int[2] value", "!value[0]", "expected 'bool'"),
+    ] {
+        let source = format!("contract Unary() {{ function spend({params}) {{ let result = {expression}; require(true); }} }}");
+        let error = compile(&source).expect_err(&source).to_string();
+        assert!(
+            error.contains("unary '") && error.contains(expected),
+            "{expression}: {error}"
+        );
+    }
+}
+
+#[test]
+fn unary_negation_preserves_literal_index_bounds() {
+    for (index, valid) in [
+        ("--1", true),
+        ("---0", true),
+        ("---1", false),
+        ("--2", false),
+    ] {
+        let source = format!("contract Unary() {{ function spend(int[2] values) {{ require(values[{index}] == 0); }} }}");
+        let result = compile(&source);
+        if valid {
+            result.expect(&source);
+        } else {
+            assert!(
+                result.unwrap_err().to_string().contains("out of range"),
+                "{index}"
+            );
+        }
+    }
+}
+
+#[test]
+fn unary_negation_remains_unsupported_in_l1_tapscripts() {
+    for condition in [
+        "!checkSig(sig, owner)",
+        "-checkSig(sig, owner)",
+        "!!checkSig(sig, owner)",
+    ] {
+        let source = format!("contract Unary(pubkey owner) {{ function spend(signature sig) tapscript {{ require({condition}); }} }}");
+        let error = compile(&source).expect_err(&source).to_string();
+        assert!(
+            error.contains("unsupported compound expression in tapscript"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn unary_negation_in_builtin_atom_arguments() {
+    for (statement, expected) in [
+        (
+            "let result = num2bin(-(-1), 4);",
+            "1 OP_NEGATE OP_NEGATE 4 OP_NUM2BIN",
+        ),
+        (
+            "let result = num2bin(-value, 4);",
+            "OP_0 OP_PICK OP_NEGATE 4 OP_NUM2BIN",
+        ),
+        (
+            "let result = modExp(--value, 2, 3);",
+            "OP_0 OP_PICK OP_NEGATE OP_NEGATE 2 3 OP_MODEXP",
+        ),
+        (
+            "let result = ecAdd(-1, 2, 3, 4, 0);",
+            "1 OP_NEGATE 2 3 4 0 OP_ECADD",
+        ),
+        (
+            "let result = ecMul(1, 2, -3, 0);",
+            "1 2 3 OP_NEGATE 0 OP_ECMUL",
+        ),
+        (
+            "let result = ecPairing(1, -2, 3, 4, 5, 6, 0);",
+            "1 2 OP_NEGATE 3 4 5 6 OP_1 0 OP_ECPAIRING",
+        ),
+        (
+            "require(ecMulScalarVerify(-1, 2, 3));",
+            "1 OP_NEGATE 2 3 OP_ECMULSCALARVERIFY",
+        ),
+        (
+            "require(tweakVerify(1, -2, 3));",
+            "1 2 OP_NEGATE 3 OP_TWEAKVERIFY",
+        ),
+        (
+            "let result = sha256Initialize(-1);",
+            "1 OP_NEGATE OP_SHA256INITIALIZE",
+        ),
+        (
+            "let result = sha256Update(data, -1);",
+            "1 OP_NEGATE OP_SHA256UPDATE",
+        ),
+        (
+            "let result = sha256Finalize(data, -1);",
+            "1 OP_NEGATE OP_SHA256FINALIZE",
+        ),
+        ("let result = sighash(-1);", "1 OP_NEGATE OP_SIGHASH"),
+        ("let result = digest(data, -1);", "1 OP_NEGATE OP_DIGEST"),
+        (
+            "let result = substr(data, --0, 1);",
+            "0 OP_NEGATE OP_NEGATE 1 OP_SUBSTR",
+        ),
+        (
+            "let result = tx.packet(--1);",
+            "1 OP_NEGATE OP_NEGATE OP_INSPECTPACKET",
+        ),
+        (
+            "let result = tx.inputs[0].packet(--1);",
+            "1 OP_NEGATE OP_NEGATE 0 OP_INSPECTINPUTPACKET",
+        ),
+    ] {
+        let source = format!("contract Unary() {{ function spend(int value, bytes data) {{ {statement} require(true); }} }}");
+        let output = compile(&source).unwrap_or_else(|error| panic!("{statement}: {error}"));
+        let asm = crate::common::arkade_asm_tokens(&output, "spend");
+        assert!(
+            contains_tokens(&asm, &expected.split_whitespace().collect::<Vec<_>>()),
+            "{statement}: {asm:?}"
+        );
+    }
+}
+
+#[test]
+fn logical_negation_preserves_nested_expressions() {
+    let output = compile(
+        r#"
+        struct State { bool enabled; }
+        contract Unary(pubkey owner) {
+            function spend(State state, signature sig, bytes left, bytes right) {
+                require(!state.enabled);
+                require(!(left + right == left));
+                require(!checkSig(sig, owner));
+            }
+        }
+    "#,
+    )
+    .expect("nested logical operands compile");
+    assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert!(asm.iter().any(|token| token == "OP_CAT"), "{asm:?}");
+    assert!(
+        contains_tokens(&asm, &["OP_EQUAL", "OP_NOT", "OP_VERIFY"]),
+        "{asm:?}"
+    );
+    assert!(
+        contains_tokens(&asm, &["OP_CHECKSIG", "OP_NOT", "OP_VERIFY"]),
+        "{asm:?}"
+    );
+}

--- a/tests/features/opcode_functions.rs
+++ b/tests/features/opcode_functions.rs
@@ -541,7 +541,7 @@ fn unary_negation_in_loops_and_conditions() {
             function spend(bool[2] flags) {
                 for (i, flag) in flags {
                     if (!flag) { require(!!flag == false); }
-                    let bytes = num2bin(-i, 4);
+                    let bytes = num2bin(-(i + 1), 4);
                     require(size(bytes) == 4);
                 }
             }
@@ -553,7 +553,7 @@ fn unary_negation_in_loops_and_conditions() {
     let asm = crate::common::arkade_asm(&output, "spend");
     for index in 0..2 {
         assert!(
-            asm.contains(&format!("{index} OP_NEGATE 4 OP_NUM2BIN")),
+            asm.contains(&format!("{index} 1 OP_ADD OP_NEGATE 4 OP_NUM2BIN")),
             "{asm}"
         );
     }
@@ -572,6 +572,7 @@ fn unary_negation_rejects_invalid_operand_types() {
         ("int value", "!value", "expected 'bool'"),
         ("bytes value", "!value", "expected 'bool'"),
         ("bool value", "num2bin(-value, 4)", "expected 'int'"),
+        ("int value", "num2bin(-(value == 1), 4)", "expected 'int'"),
         ("bool value", "modExp(-value, 2, 3)", "expected 'int'"),
         ("bool value", "!-value", "expected 'int'"),
         ("int value", "-!value", "expected 'bool'"),
@@ -674,6 +675,18 @@ fn unary_negation_in_builtin_atom_arguments() {
         ("let result = sighash(-1);", "1 OP_NEGATE OP_SIGHASH"),
         ("let result = digest(data, -1);", "1 OP_NEGATE OP_DIGEST"),
         (
+            "let result = substr(data, -(value + 1), (2 * 3));",
+            "1 OP_ADD OP_NEGATE 2 3 OP_MUL OP_SUBSTR",
+        ),
+        (
+            "let result = num2bin(-(value + 1), (2 + 2));",
+            "1 OP_ADD OP_NEGATE 2 2 OP_ADD OP_NUM2BIN",
+        ),
+        (
+            "require(ecMulScalarVerify(value, (data + data), data));",
+            "OP_CAT",
+        ),
+        (
             "let result = substr(data, --0, 1);",
             "0 OP_NEGATE OP_NEGATE 1 OP_SUBSTR",
         ),
@@ -722,4 +735,12 @@ fn logical_negation_preserves_nested_expressions() {
         contains_tokens(&asm, &["OP_CHECKSIG", "OP_NOT", "OP_VERIFY"]),
         "{asm:?}"
     );
+}
+
+#[test]
+fn grouped_builtin_operands_reject_implicit_byte_conversion() {
+    let error = compile("contract Grouped() { function spend(bytes data) { require(ecMulScalarVerify(1, (data + 1), data)); } }")
+        .expect_err("grouped operands must validate concatenation types")
+        .to_string();
+    assert!(error.contains("cannot concatenate bytes"), "{error}");
 }


### PR DESCRIPTION
Unary minus accepted non-integer operands, logical `!` and repeated prefixes did not parse, and built-ins rejected negative arguments such as `num2bin(-1, 4)`.

Support arithmetic and boolean negation with right-to-left prefix application, and parse negated literals/bindings consistently in built-in atom arguments, including grouped compound expressions such as `substr(data, -(offset + 1), size)`. Traverse nested built-in operands during concatenation rewriting so byte sums emit `OP_CAT` and mixed byte/integer sums are rejected. Reject invalid unary operand types before emission. Preserve constant array-index bounds checking through repeated minus signs and fix boolean literals consuming trailing whitespace.

Regression coverage checks parser precedence and token boundaries, opcode emission, all affected built-in argument parsers, loop substitution, nested expressions, invalid operand types, array bounds, and covenant/leaf/witness shape. L1 tapscripts retain their restricted closure syntax.

The public Rust expression enum gains `Expression::Not`; consumers with exhaustive AST matches need an arm for it. The compiled JSON artifact shape is unchanged.

Validation:
- `cargo test --workspace` — passed (435 tests; 36 ignored).
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --check` — passed.
- `./playground/build.sh` — passed.

Re-reviewed parsing, expression traversal, type validation, code emission, and binding-generator compatibility after the changes; no remaining findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logical negation with the `!` operator, including chained and nested expressions.
  * Extended unary negation across compiler operations, loops, conditions, built-in functions, and packet inspection.
  * Built-in operation arguments now accept complete expressions, including unary operators.

* **Bug Fixes**
  * Improved type validation for arithmetic and logical negation.
  * Preserved correct precedence, literal indexing, and loop-variable handling.

* **Compatibility**
  * Unary expressions remain unsupported in L1 tapscripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->