### PR TITLE
Add static functions and compile-time constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ function name(<params>) { ... }                // Public Arkade transaction entr
 public function name(<params>) { ... }         // Explicit public visibility
 private function name(<params>) { ... }        // Void helper
 private function name(<params>) bool { ... }   // Helper with a typed result
+static function name(<params>) int { ... }     // Helper without access to constructor state
 function name(<params>) tapscript { ... }      // L1 tapleaf, plain Bitcoin Script
 ```
 
@@ -269,6 +270,8 @@ A covenant with no tapscript of the same name gets a synthesized `server` + `twe
 Private functions are callable only from covenant functions in the same contract, including other private functions. Calls are inlined, and private functions create no spend group or leaf. Tapscript functions cannot call or bind to a private function, including through `tweak(emulator, name)`. Public covenant functions remain transaction entrypoints and cannot be called as helpers. Declaration order does not matter; direct and mutual recursion are rejected. The old `internal` modifier is not supported.
 
 Arguments are evaluated once, left to right, and passed by value. Each helper sees its own parameters and locals plus the immutable constructor parameters, including struct fields and array elements. It cannot read or mutate caller locals unless their values are passed as arguments; modifying a parameter changes only the helper's copy.
+
+A `static` function is a private helper that belongs to the contract rather than to an instance of it. It sees only its own parameters, its locals, and compile-time constants; referencing a constructor parameter, or a field or element of one, is rejected. It may call other static functions but not private or public ones. Everything else matches a private function, including inlining, the return-type rules, and the recursion ban. `static` is a visibility of its own: `public static` and `private static` do not parse.
 
 A return type follows the parameter list directly and is allowed only on private functions. It can be a scalar, fixed-size array, or struct, including native result structs such as `ECPoint`. Every path through a value-returning helper must return a compatible value. A helper without a return type may fall through or use `return;`. Early returns inside branches or loops exit the helper and resume the caller. Returning a boolean does not enforce it: use `require(predicate(...));`. Value-returning calls cannot discard their result; void calls cannot be used in expressions.
 
@@ -285,6 +288,39 @@ contract Minimum(int minimum) {
 ```
 
 Every spend path must contain at least one `require`, directly or through a helper that enforces a requirement on every path. An `if` without `else`, or an `else` branch without a `require`, is rejected as a bare path.
+
+### Constants
+
+```solidity
+const int EXIT_DELAY = 144;
+const bool STRICT = true;
+```
+
+Constants are declared in the contract body, in any position, and are folded into a literal at every use site before validation. They are `int` or `bool` only — the language has no other literal form — and the initializer must be a literal, not an expression. They never reach the artifact: no constructor input, no placeholder, no ABI entry.
+
+A constant is readable anywhere a literal is, including covenant bodies, private and static helpers, and a tapleaf's `older(...)` or `after(...)` operand — which is the point, since a delay shared by a covenant and its L1 exit is written once.
+
+Constant names may not collide with a constructor parameter or a function, and no parameter, binding, loop variable, or tapscript input may shadow one. Constants cannot be assigned to.
+
+```solidity
+contract Vault(pubkey owner) {
+    const int EXIT_DELAY = 144;
+
+    static function pct(int amount, int bps) int {
+        return amount * bps / 10000;
+    }
+
+    function spend(signature sig, int amount) {
+        require(checkSig(sig, owner));
+        require(pct(amount, 50) > 0);
+    }
+
+    function exit(signature sig) tapscript {
+        require(older(EXIT_DELAY));
+        require(checkSig(sig, owner));
+    }
+}
+```
 
 ### Statements (covenant bodies)
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Arrays are fixed-size and part of the type. Loops unroll at compile time, one co
 | Directory | Shows |
 |---|---|
 | `single_sig`, `htlc` | Minimum viable VTXO and hash/time locks |
-| `non_interactive_swap` | Atomic asset swap with `new SingleSig(...)` payout and CLTV cancel |
+| `non_interactive_swap` | Atomic asset swap with `new SingleSig(...)` payout and locktime-gated cancel |
 | `payment_auth` | Introspection-driven payout splits with `if`/`else` and `tx.input.current.value` |
 | `token_vault`, `controlled_mint`, `nft_mint` | Asset lookups, asset groups, control assets |
 | `struct_vault`, `threshold_oracle` | Structs, arrays, loops, oracle quorum |
@@ -298,7 +298,7 @@ const bool STRICT = true;
 
 Constants are declared in the contract body, in any position, and are folded into a literal at every use site before validation. They are `int` or `bool` only — the language has no other literal form — and the initializer must be a literal, not an expression. They never reach the artifact: no constructor input, no placeholder, no ABI entry.
 
-A constant is readable anywhere a literal is, including covenant bodies, private and static helpers, and a tapleaf's `older(...)` or `after(...)` operand — which is the point, since a delay shared by a covenant and its L1 exit is written once.
+A constant is readable in covenant bodies, private and static helpers, array indices (including crypto operands), multisig thresholds, and a tapleaf's `older(...)` or `after(...)` operand. A delay shared by a covenant and its L1 exit is written once. Array sizes still require numeric literals.
 
 Constant names may not collide with a constructor parameter or a function, and no parameter, binding, loop variable, or tapscript input may shadow one. Constants cannot be assigned to.
 
@@ -350,7 +350,7 @@ Arithmetic `+ - * /` and unary `-` on `int`. Comparison `== != < <= > >=`. `+` o
 
 **Hashes.** `sha256`, `hash160`, `hash256`, `ripemd160` as `require(hashFn(preimage) == hash)`. `sha256(expr)` also works as a value, including over concatenations and `substr` results. Streaming: `sha256Initialize`, `sha256Update`, `sha256Finalize`. Runtime-selected: `digest(data, hashType)`, `sighash(hashType)`.
 
-**Time.** In covenants, `tx.time` is the transaction locktime as an `int`, so `require(tx.time >= deadline)` is a CLTV check. In tapscripts, `older(n)` emits CSV and `after(n)` or `tx.time >= n` emits CLTV. `after(...)` is tapscript-only.
+**Time.** In covenants, `tx.time` reads the transaction locktime using `OP_INSPECTLOCKTIME`, and `require(tx.time >= deadline)` compares it with the bound, whether a literal, constant, or runtime value. In tapscripts, `older(n)` emits CSV and `after(n)` or `tx.time >= n` emits CLTV. `after(...)` is tapscript-only.
 
 **Transaction.** `tx.version`, `tx.locktime`, `tx.numInputs`, `tx.numOutputs`, `tx.weight`, `tx.id`, `this.activeInputIndex`, `this.activeBytecode`.
 

--- a/playground/arkade-language.js
+++ b/playground/arkade-language.js
@@ -6,7 +6,7 @@ const arkadeMonarch = {
 
     keywords: [
         'contract', 'struct', 'function', 'tapscript', 'require', 'if', 'else',
-        'for', 'in', 'let', 'private', 'public', 'return', 'new'
+        'for', 'in', 'let', 'private', 'public', 'static', 'const', 'return', 'new'
     ],
 
     typeKeywords: [
@@ -36,7 +36,7 @@ const arkadeMonarch = {
             [/\s+/, 'white'],
 
             // Keywords
-            [/\b(contract|struct|function|tapscript|require|if|else|for|in|let|private|public|return|new)\b/, 'keyword'],
+            [/\b(contract|struct|function|tapscript|require|if|else|for|in|let|private|public|static|const|return|new)\b/, 'keyword'],
 
             // Types
             [/\b(pubkey|signature|bytes32|bytes20|bytes|asset|int|bool)\b/, 'type'],
@@ -138,6 +138,8 @@ const arkadeCompletions = [
     { label: 'for', kind: 'Keyword', insertText: 'for (${1:i}, ${2:item}) in ${3:array} {\n\t$0\n}', insertTextRules: 4 },
     { label: 'let', kind: 'Keyword', insertText: 'let ${1:name} = ${2:value};', insertTextRules: 4 },
     { label: 'private', kind: 'Keyword', insertText: 'private function ${1:name}(${2:params}) ${3:bool} {\n\treturn ${4:value};\n}', insertTextRules: 4 },
+    { label: 'static', kind: 'Keyword', insertText: 'static function ${1:name}(${2:params}) ${3:int} {\n\treturn ${4:value};\n}', insertTextRules: 4 },
+    { label: 'const', kind: 'Keyword', insertText: 'const ${1:int} ${2:NAME} = ${3:0};', insertTextRules: 4 },
     { label: 'public', kind: 'Keyword', insertText: 'public' },
     { label: 'return', kind: 'Keyword', insertText: 'return ${1:value};', insertTextRules: 4 },
 

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -1,0 +1,137 @@
+use crate::models::{
+    AssignmentTarget, Constant, Contract, Expression, Requirement, Statement, TapItem,
+};
+use std::collections::HashMap;
+
+/// Validate constant declarations and fold every reference to them into a literal.
+/// Runs before validation so no later stage ever observes a constant identifier.
+pub(crate) fn fold(contract: &mut Contract) -> Result<(), String> {
+    let values = collect(contract)?;
+    if values.is_empty() {
+        return Ok(());
+    }
+    for function in &mut contract.functions {
+        fold_statements(&mut function.statements, &values);
+    }
+    for tapscript in &mut contract.tapscripts {
+        for item in &mut tapscript.items {
+            if let TapItem::Older { value } | TapItem::After { value } = item {
+                if let Some(text) = values.get(value.as_str()) {
+                    *value = text.clone();
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect(contract: &Contract) -> Result<HashMap<String, String>, String> {
+    let mut values: HashMap<String, String> = HashMap::new();
+    for Constant {
+        name,
+        const_type,
+        value,
+    } in &contract.constants
+    {
+        if values.contains_key(name) {
+            return Err(format!("duplicate constant '{name}'"));
+        }
+        if contract.parameters.iter().any(|p| p.name == *name) {
+            return Err(format!(
+                "constant '{name}' collides with constructor parameter '{name}'"
+            ));
+        }
+        if contract.functions.iter().any(|f| f.name == *name)
+            || contract.tapscripts.iter().any(|t| t.name == *name)
+        {
+            return Err(format!("constant '{name}' collides with function '{name}'"));
+        }
+        let Expression::Literal(text) = value else {
+            return Err(format!(
+                "constant '{name}' must be initialized with a literal"
+            ));
+        };
+        let matches_type = match const_type.as_str() {
+            "int" => text.bytes().all(|b| b.is_ascii_digit()),
+            "bool" => text == "true" || text == "false",
+            _ => return Err(format!("constant '{name}' must be int or bool")),
+        };
+        if !matches_type {
+            return Err(format!(
+                "constant '{name}' is not a valid '{const_type}' literal"
+            ));
+        }
+        values.insert(name.clone(), text.clone());
+    }
+    Ok(values)
+}
+
+fn fold_statements(statements: &mut [Statement], values: &HashMap<String, String>) {
+    for statement in statements {
+        match statement {
+            Statement::Call(expression)
+            | Statement::Return(Some(expression))
+            | Statement::LetBinding {
+                value: expression, ..
+            } => fold_expression(expression, values),
+            Statement::VarAssign { target, value } => {
+                if let AssignmentTarget::ArrayIndex { index, .. } = target {
+                    fold_expression(index, values);
+                }
+                fold_expression(value, values);
+            }
+            Statement::Require(requirement) => fold_requirement(requirement, values),
+            Statement::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                fold_expression(condition, values);
+                fold_statements(then_body, values);
+                if let Some(body) = else_body {
+                    fold_statements(body, values);
+                }
+            }
+            Statement::ForIn { iterable, body, .. } => {
+                fold_expression(iterable, values);
+                fold_statements(body, values);
+            }
+            Statement::Return(None) => {}
+        }
+    }
+}
+
+fn fold_requirement(requirement: &mut Requirement, values: &HashMap<String, String>) {
+    match requirement {
+        Requirement::Expression(expression) => fold_expression(expression, values),
+        Requirement::Comparison { left, right, .. } => {
+            fold_expression(left, values);
+            fold_expression(right, values);
+        }
+        Requirement::After {
+            blocks,
+            timelock_var,
+        } => {
+            let Some(name) = timelock_var.as_deref() else {
+                return;
+            };
+            if let Some(Ok(value)) = values.get(name).map(|text| text.parse::<u64>()) {
+                *blocks = value;
+                *timelock_var = None;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn fold_expression(expression: &mut Expression, values: &HashMap<String, String>) {
+    if let Expression::Variable(name) = expression {
+        if let Some(text) = values.get(name.as_str()) {
+            *expression = Expression::Literal(text.clone());
+            return;
+        }
+    }
+    for child in crate::models::child_exprs_mut(expression) {
+        fold_expression(child, values);
+    }
+}

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -1,5 +1,5 @@
 use crate::models::{
-    AssignmentTarget, Constant, Contract, Expression, Requirement, Statement, TapItem,
+    AssignmentTarget, Constant, Contract, Expression, KeyExpr, Requirement, Statement, TapItem,
 };
 use std::collections::HashMap;
 
@@ -15,9 +15,25 @@ pub(crate) fn fold(contract: &mut Contract) -> Result<(), String> {
     }
     for tapscript in &mut contract.tapscripts {
         for item in &mut tapscript.items {
-            if let TapItem::Older { value } | TapItem::After { value } = item {
-                if let Some(text) = values.get(value.as_str()) {
-                    *value = text.clone();
+            match item {
+                TapItem::Older { value } | TapItem::After { value } => {
+                    if let Some(text) = values.get(value.as_str()) {
+                        *value = text.clone();
+                    }
+                }
+                TapItem::Hash { preimage, hash, .. } => {
+                    fold_named_index(preimage, &values);
+                    fold_named_index(hash, &values);
+                }
+                TapItem::Sig { keys, sigs, .. } => {
+                    for key in keys {
+                        if let KeyExpr::Ident(name) = key {
+                            fold_named_index(name, &values);
+                        }
+                    }
+                    for name in sigs {
+                        fold_named_index(name, &values);
+                    }
                 }
             }
         }
@@ -33,6 +49,12 @@ fn collect(contract: &Contract) -> Result<HashMap<String, String>, String> {
         value,
     } in &contract.constants
     {
+        if matches!(
+            name.as_str(),
+            "true" | "false" | "server" | "emulator" | "SERVER_KEY"
+        ) {
+            return Err(format!("constant name '{name}' is reserved"));
+        }
         if values.contains_key(name) {
             return Err(format!("duplicate constant '{name}'"));
         }
@@ -108,30 +130,73 @@ fn fold_requirement(requirement: &mut Requirement, values: &HashMap<String, Stri
             fold_expression(left, values);
             fold_expression(right, values);
         }
-        Requirement::After {
-            blocks,
-            timelock_var,
+        Requirement::CheckSig { signature, pubkey } => {
+            fold_named_index(signature, values);
+            fold_named_index(pubkey, values);
+        }
+        Requirement::CheckSigFromStack {
+            signature,
+            pubkey,
+            message,
         } => {
-            let Some(name) = timelock_var.as_deref() else {
-                return;
-            };
-            if let Some(Ok(value)) = values.get(name).map(|text| text.parse::<u64>()) {
-                *blocks = value;
-                *timelock_var = None;
+            fold_named_index(signature, values);
+            fold_named_index(pubkey, values);
+            fold_named_index(message, values);
+        }
+        Requirement::CheckMultisig {
+            pubkeys,
+            signatures,
+            ..
+        } => {
+            for name in pubkeys.iter_mut().chain(signatures) {
+                fold_named_index(name, values);
             }
         }
-        _ => {}
+        Requirement::HashEqual { preimage, hash, .. } => {
+            fold_named_index(preimage, values);
+            fold_named_index(hash, values);
+        }
     }
 }
 
 fn fold_expression(expression: &mut Expression, values: &HashMap<String, String>) {
-    if let Expression::Variable(name) = expression {
-        if let Some(text) = values.get(name.as_str()) {
-            *expression = Expression::Literal(text.clone());
-            return;
+    match expression {
+        Expression::Variable(name) => {
+            if let Some(text) = values.get(name.as_str()) {
+                *expression = Expression::Literal(text.clone());
+                return;
+            }
         }
+        Expression::Property(name) => fold_named_index(name, values),
+        Expression::CheckSigExpr { signature, pubkey } => {
+            fold_named_index(signature, values);
+            fold_named_index(pubkey, values);
+        }
+        Expression::CheckSigFromStackExpr {
+            signature,
+            pubkey,
+            message,
+        }
+        | Expression::CheckSigFromStackVerify {
+            signature,
+            pubkey,
+            message,
+        } => {
+            fold_named_index(signature, values);
+            fold_named_index(pubkey, values);
+            fold_named_index(message, values);
+        }
+        _ => {}
     }
     for child in crate::models::child_exprs_mut(expression) {
         fold_expression(child, values);
+    }
+}
+
+fn fold_named_index(name: &mut String, values: &HashMap<String, String>) {
+    if let Some((array, index)) = name.strip_suffix(']').and_then(|name| name.split_once('[')) {
+        if let Some(value) = values.get(index) {
+            *name = format!("{array}[{value}]");
+        }
     }
 }

--- a/src/compiler/loops.rs
+++ b/src/compiler/loops.rs
@@ -131,15 +131,6 @@ pub(crate) fn substitute_requirement(
                 .collect(),
             threshold: *threshold,
         },
-        Requirement::After {
-            blocks,
-            timelock_var,
-        } => Requirement::After {
-            blocks: *blocks,
-            timelock_var: timelock_var
-                .as_ref()
-                .map(|name| substitute_loop_name(name, index_var, value_var, k, array_name)),
-        },
         Requirement::HashEqual {
             hash_fn,
             preimage,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -32,11 +32,11 @@ pub mod tapscript;
 mod asset;
 mod comparison;
 mod concat;
+mod constants;
 mod expr;
 mod functions;
 mod introspection;
 mod loops;
-mod references;
 
 pub(crate) use asset::*;
 pub(crate) use comparison::*;
@@ -665,6 +665,8 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
         Err(e) => return Err(format!("Parse error: {}", e)),
     };
 
+    constants::fold(&mut contract)?;
+
     typechecker::resolve_group_properties(&mut contract);
 
     // ── Semantic validation ────────────────────────────────────────────────
@@ -776,7 +778,8 @@ fn covenant_for(
     functions: &[Function],
 ) -> Result<ArkadeCovenant, String> {
     let inputs = function_inputs(&function.parameters);
-    let references = references::referenced_parameters(&function.statements, functions);
+    let references =
+        crate::validator::references::referenced_parameters(&function.statements, functions);
     let retained_parameters = constructor_parameters
         .iter()
         .filter(|parameter| references.contains(parameter.name.as_str()))

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3,8 +3,8 @@ use crate::models::{
     FunctionInput, Parameter, Requirement, Statement,
 };
 use crate::opcodes::{
-    OP_0, OP_1, OP_ADD, OP_BIN2NUM, OP_BOOLAND, OP_CAT, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG,
-    OP_CHECKSIGADD, OP_CHECKSIGFROMSTACK, OP_DIGEST, OP_DIV, OP_DROP, OP_DUP, OP_ECADD, OP_ECMUL,
+    OP_0, OP_1, OP_ADD, OP_BIN2NUM, OP_BOOLAND, OP_CAT, OP_CHECKSIG, OP_CHECKSIGADD,
+    OP_CHECKSIGFROMSTACK, OP_DIGEST, OP_DIV, OP_DROP, OP_DUP, OP_ECADD, OP_ECMUL,
     OP_ECMULSCALARVERIFY, OP_ECPAIRING, OP_ELSE, OP_ENDIF, OP_EQUAL, OP_EQUALVERIFY,
     OP_FINDASSETGROUPBYASSETID, OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_IF, OP_INSPECTASSETGROUP,
     OP_INSPECTASSETGROUPASSETID, OP_INSPECTASSETGROUPCTRL, OP_INSPECTASSETGROUPMETADATAHASH,
@@ -1031,19 +1031,6 @@ fn generate_requirement_asm(req: &Requirement, generator: &mut Generator) -> Res
             }
             generator.apply(OP_NUMEQUAL, 2, 1)?;
             generator.apply(OP_VERIFY, 1, 0)?;
-            Ok(())
-        }
-        Requirement::After {
-            blocks,
-            timelock_var,
-        } => {
-            if let Some(var) = timelock_var {
-                generator.read_binding_or_integer(var)?;
-            } else {
-                generator.push_temporary(blocks.to_string());
-            }
-            generator.apply(OP_CHECKLOCKTIMEVERIFY, 1, 1)?;
-            generator.apply(OP_DROP, 1, 0)?;
             Ok(())
         }
         Requirement::HashEqual {

--- a/src/compiler/tapscript.rs
+++ b/src/compiler/tapscript.rs
@@ -789,11 +789,13 @@ mod tests {
                     parameters: vec![],
                     statements: vec![],
                     is_private: false,
+                    is_static: false,
                     return_type: None,
                 })
                 .collect(),
             tapscripts,
             imports: vec![],
+            constants: vec![],
         }
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -360,11 +360,6 @@ pub enum Requirement {
         signatures: Vec<String>,
         threshold: u16,
     },
-    /// After requirement
-    After {
-        blocks: u64,
-        timelock_var: Option<String>,
-    },
     /// Hash equal requirement
     HashEqual {
         hash_fn: HashFn,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -267,6 +267,16 @@ pub struct Contract {
     pub tapscripts: Vec<NamedTapscript>,
     /// Imported contract file paths (declared via `import "path.ark";`)
     pub imports: Vec<String>,
+    /// Compile-time constants declared in the contract body.
+    pub constants: Vec<Constant>,
+}
+
+/// A compile-time constant, folded into every use site before validation.
+#[derive(Debug, Clone)]
+pub struct Constant {
+    pub name: String,
+    pub const_type: String,
+    pub value: Expression,
 }
 
 /// Function AST
@@ -280,6 +290,8 @@ pub struct Function {
     pub statements: Vec<Statement>,
     /// Whether this is a callable helper rather than a transaction entrypoint.
     pub is_private: bool,
+    /// Whether this helper is a contract member that cannot see constructor state.
+    pub is_static: bool,
     /// Explicit result type; None means the function returns no value.
     pub return_type: Option<String>,
 }

--- a/src/parser/checksig.rs
+++ b/src/parser/checksig.rs
@@ -3,7 +3,6 @@ use super::Rule;
 use super::*;
 use crate::models::*;
 use pest::iterators::Pair;
-use std::str::FromStr;
 
 /// Parse checkSig(sig, pubkey) → CheckSig requirement
 pub(crate) fn parse_check_sig(pair: Pair<Rule>) -> Result<Requirement, String> {
@@ -43,7 +42,10 @@ pub(crate) fn parse_check_sig_from_stack(pair: Pair<Rule>) -> Result<Requirement
 }
 
 /// Parse checkMultisig([pubkeys], [sigs], threshold?) → CheckMultisig requirement
-pub(crate) fn parse_check_multisig(pair: Pair<Rule>) -> Result<Requirement, String> {
+pub(crate) fn parse_check_multisig(
+    pair: Pair<Rule>,
+    constants: &[Constant],
+) -> Result<Requirement, String> {
     let mut inner = pair
         .into_inner()
         .next()
@@ -64,10 +66,7 @@ pub(crate) fn parse_check_multisig(pair: Pair<Rule>) -> Result<Requirement, Stri
         .collect();
 
     let threshold = match inner.next() {
-        Some(next_pair) => match u16::from_str(next_pair.as_str()) {
-            Ok(threshold) => threshold,
-            Err(e) => return Err(format!("{}", e)),
-        },
+        Some(next_pair) => parse_multisig_threshold(next_pair, constants)?,
         None => pubkeys.len() as u16,
     };
 
@@ -76,4 +75,29 @@ pub(crate) fn parse_check_multisig(pair: Pair<Rule>) -> Result<Requirement, Stri
         signatures,
         threshold,
     })
+}
+
+pub(crate) fn parse_multisig_threshold(
+    pair: Pair<Rule>,
+    constants: &[Constant],
+) -> Result<u16, String> {
+    let name = pair.as_str();
+    let text = if pair.as_rule() == Rule::identifier {
+        let constant = constants
+            .iter()
+            .find(|constant| constant.name == name)
+            .ok_or_else(|| format!("multisig threshold '{name}' must be an int constant"))?;
+        match (&constant.value, constant.const_type.as_str()) {
+            (Expression::Literal(text), "int") => text.as_str(),
+            _ => {
+                return Err(format!(
+                    "multisig threshold '{name}' must be an int literal constant"
+                ))
+            }
+        }
+    } else {
+        name
+    };
+    text.parse::<u16>()
+        .map_err(|e| format!("invalid multisig threshold '{name}': {e}"))
 }

--- a/src/parser/comparison.rs
+++ b/src/parser/comparison.rs
@@ -6,10 +6,10 @@ use pest::iterators::Pair;
 
 pub(crate) fn parse_time_comparison(pair: Pair<Rule>) -> Result<Requirement, String> {
     let mut inner = pair.into_inner();
-    let timelock_var = inner.next().ok_or("Missing timelock")?.as_str().to_string();
-    Ok(Requirement::After {
-        blocks: 0,
-        timelock_var: Some(timelock_var),
+    Ok(Requirement::Comparison {
+        left: Expression::Property("tx.time".to_string()),
+        op: ">=".to_string(),
+        right: parse_additive_expr(inner.next().ok_or("Missing timelock")?)?,
     })
 }
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -338,7 +338,10 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
 }
 
 /// Parse a complex expression into a Requirement AST node
-pub(crate) fn parse_complex_expression(pair: Pair<Rule>) -> Result<Requirement, String> {
+pub(crate) fn parse_complex_expression(
+    pair: Pair<Rule>,
+    constants: &[Constant],
+) -> Result<Requirement, String> {
     match pair.as_rule() {
         Rule::general_expression => {
             let expression = parse_general_expression(pair)?;
@@ -361,7 +364,7 @@ pub(crate) fn parse_complex_expression(pair: Pair<Rule>) -> Result<Requirement, 
         Rule::check_sig => parse_check_sig(pair),
         Rule::check_sig_from_stack => parse_check_sig_from_stack(pair),
         Rule::check_sig_from_stack_verify => parse_check_sig_from_stack_verify(pair),
-        Rule::check_multisig => parse_check_multisig(pair),
+        Rule::check_multisig => parse_check_multisig(pair, constants),
         Rule::time_comparison => parse_time_comparison(pair),
         Rule::hash_comparison => parse_hash_comparison(pair),
         _ => Err(format!(

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -361,7 +361,7 @@ identifier_property_access = {
 
 // Time comparison (tx.time >= timelock)
 time_comparison = {
-    "tx.time" ~ ">=" ~ named_binding
+    "tx.time" ~ ">=" ~ additive_expr
 }
 
 // Generalized hash condition function name.
@@ -508,7 +508,7 @@ check_multisig = { check_threshold_multisig }
 // checkMultisig([keys], [sigs], threshold?) — keys may be tweak()s; the second
 // array carries the aligned signature inputs and the final threshold is optional.
 check_threshold_multisig = {
-    "checkMultisig" ~ "(" ~ key_array ~ "," ~ array ~ ("," ~ number_literal)? ~ ")"
+    "checkMultisig" ~ "(" ~ key_array ~ "," ~ array ~ ("," ~ (number_literal | identifier))? ~ ")"
 }
 
 // Array of identifiers

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -18,8 +18,12 @@ struct_field = { data_type ~ identifier ~ ";" }
 contract = {
     "contract" ~ identifier ~
     "(" ~ param_list ~ ")" ~
-    "{" ~ function* ~ "}"
+    "{" ~ (const_decl | function)* ~ "}"
 }
+
+// Compile-time constant: const int NAME = 144;
+const_keyword = @{ "const" ~ !(ASCII_ALPHANUMERIC | "_") }
+const_decl = { const_keyword ~ data_type ~ identifier ~ "=" ~ general_expression ~ ";" }
 
 // Parameter list with proper comma separation
 param_list = {
@@ -42,7 +46,7 @@ function = {
     ( "tapscript" ~ tapscript_block
     | data_type? ~ "{" ~ statement* ~ "}" )
 }
-function_visibility = @{ ("private" | "public") ~ !(ASCII_ALPHANUMERIC | "_") }
+function_visibility = @{ ("private" | "public" | "static") ~ !(ASCII_ALPHANUMERIC | "_") }
 tapscript_block = { "{" ~ require_stmt* ~ "}" }
 return_keyword = @{ "return" ~ !(ASCII_ALPHANUMERIC | "_") }
 return_stmt = { return_keyword ~ general_expression? ~ ";" }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,6 @@
-use crate::models::{AssignmentTarget, Contract, Function, Parameter, Statement, StructDefinition};
+use crate::models::{
+    AssignmentTarget, Constant, Contract, Function, Parameter, Statement, StructDefinition,
+};
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
 use pest_derive::Parser;
@@ -45,6 +47,7 @@ fn build_ast(pairs: Pairs<Rule>) -> Result<Contract, String> {
         functions: Vec::new(),
         tapscripts: Vec::new(),
         imports: Vec::new(),
+        constants: Vec::new(),
     };
 
     for pair in pairs {
@@ -125,6 +128,10 @@ fn parse_contract(contract: &mut Contract, pair: Pair<Rule>) -> Result<(), Strin
     // Functions (covenant) and tapscript declarations share the `function` rule;
     // a tapscript carries a `tapscript_block` body.
     for func_pair in inner_pairs {
+        if func_pair.as_rule() == Rule::const_decl {
+            contract.constants.push(parse_const_decl(func_pair)?);
+            continue;
+        }
         if func_pair.as_rule() != Rule::function {
             continue;
         }
@@ -139,17 +146,37 @@ fn parse_contract(contract: &mut Contract, pair: Pair<Rule>) -> Result<(), Strin
     Ok(())
 }
 
+fn parse_const_decl(pair: Pair<Rule>) -> Result<Constant, String> {
+    let mut inner = pair
+        .into_inner()
+        .filter(|p| p.as_rule() != Rule::const_keyword);
+    let const_type = parse_data_type(inner.next().ok_or("Missing constant type")?);
+    let name = inner
+        .next()
+        .ok_or("Missing constant name")?
+        .as_str()
+        .to_string();
+    let value = parse_general_expression(inner.next().ok_or("Missing constant value")?)?;
+    Ok(Constant {
+        name,
+        const_type,
+        value,
+    })
+}
+
 /// Parse a function definition
 fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
     let mut inner = pair.into_inner().peekable();
-    let is_private = if inner
+    let visibility = if inner
         .peek()
         .is_some_and(|p| p.as_rule() == Rule::function_visibility)
     {
-        inner.next().expect("visibility").as_str() == "private"
+        inner.next().expect("visibility").as_str()
     } else {
-        false
+        "public"
     };
+    let is_static = visibility == "static";
+    let is_private = visibility != "public";
     let name = inner
         .next()
         .ok_or("Missing function name")?
@@ -175,6 +202,7 @@ fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
         parameters,
         statements: Vec::new(),
         is_private,
+        is_static,
         return_type,
     };
     for statement in inner {
@@ -373,6 +401,7 @@ fn parse_block(pair: Pair<Rule>) -> Result<Vec<Statement>, String> {
             parameters: Vec::new(),
             statements: Vec::new(),
             is_private: false,
+            is_static: false,
             return_type: None,
         };
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -125,21 +125,23 @@ fn parse_contract(contract: &mut Contract, pair: Pair<Rule>) -> Result<(), Strin
         contract.parameters = parse_parameters(param_list)?;
     }
 
+    contract.constants = inner_pairs
+        .clone()
+        .filter(|pair| pair.as_rule() == Rule::const_decl)
+        .map(parse_const_decl)
+        .collect::<Result<_, _>>()?;
+
     // Functions (covenant) and tapscript declarations share the `function` rule;
     // a tapscript carries a `tapscript_block` body.
     for func_pair in inner_pairs {
-        if func_pair.as_rule() == Rule::const_decl {
-            contract.constants.push(parse_const_decl(func_pair)?);
-            continue;
-        }
         if func_pair.as_rule() != Rule::function {
             continue;
         }
         if function_pair_is_tapscript(&func_pair) {
-            let ts = parse_named_tapscript(func_pair)?;
+            let ts = parse_named_tapscript(func_pair, &contract.constants)?;
             contract.tapscripts.push(ts);
         } else {
-            let func = parse_function(func_pair)?;
+            let func = parse_function(func_pair, &contract.constants)?;
             contract.functions.push(func);
         }
     }
@@ -165,7 +167,7 @@ fn parse_const_decl(pair: Pair<Rule>) -> Result<Constant, String> {
 }
 
 /// Parse a function definition
-fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
+fn parse_function(pair: Pair<Rule>, constants: &[Constant]) -> Result<Function, String> {
     let mut inner = pair.into_inner().peekable();
     let visibility = if inner
         .peek()
@@ -206,13 +208,17 @@ fn parse_function(pair: Pair<Rule>) -> Result<Function, String> {
         return_type,
     };
     for statement in inner {
-        parse_function_body(&mut func, statement)?;
+        parse_function_body(&mut func, statement, constants)?;
     }
     Ok(func)
 }
 
 /// Parse a statement in a function body (require, let binding, function call, variable declaration)
-fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), String> {
+fn parse_function_body(
+    func: &mut Function,
+    pair: Pair<Rule>,
+    constants: &[Constant],
+) -> Result<(), String> {
     match pair.as_rule() {
         Rule::require_stmt => {
             let mut inner = pair.into_inner();
@@ -225,7 +231,7 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
                     ))
                 }
             };
-            let requirement = parse_complex_expression(expr)?;
+            let requirement = parse_complex_expression(expr, constants)?;
 
             // Capture optional error message (stored in requirement metadata)
             let _message = inner.next().map(|p| p.as_str().to_string());
@@ -278,10 +284,10 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
             let then_block = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing then block in if statement".to_string())?;
-            let then_body = parse_block(then_block)?;
+            let then_body = parse_block(then_block, constants)?;
 
             let else_body = if let Some(else_block) = inner.next() {
-                Some(parse_block(else_block)?)
+                Some(parse_block(else_block, constants)?)
             } else {
                 None
             };
@@ -312,7 +318,7 @@ fn parse_function_body(func: &mut Function, pair: Pair<Rule>) -> Result<(), Stri
             let body_block = inner
                 .next()
                 .ok_or_else(|| "Parse error: Missing body in for loop".to_string())?;
-            let body = parse_block(body_block)?;
+            let body = parse_block(body_block, constants)?;
 
             func.statements.push(Statement::ForIn {
                 index_var,
@@ -391,7 +397,7 @@ fn parse_assignment_target(pair: Pair<Rule>) -> Result<AssignmentTarget, String>
 // ─── Expression Parsing ────────────────────────────────────────────────────────
 
 // Parse a block of statements
-fn parse_block(pair: Pair<Rule>) -> Result<Vec<Statement>, String> {
+fn parse_block(pair: Pair<Rule>, constants: &[Constant]) -> Result<Vec<Statement>, String> {
     let mut statements = Vec::new();
 
     for inner in pair.into_inner() {
@@ -405,7 +411,7 @@ fn parse_block(pair: Pair<Rule>) -> Result<Vec<Statement>, String> {
             return_type: None,
         };
 
-        parse_function_body(&mut temp_func, inner)?;
+        parse_function_body(&mut temp_func, inner, constants)?;
         statements.extend(temp_func.statements);
     }
 
@@ -593,6 +599,36 @@ contract Demo(pubkey first, pubkey second) {
                 threshold: 2,
             }) if pubkeys == &["first", "second"] && signatures == &["firstSig", "secondSig"]
         ));
+    }
+
+    #[test]
+    fn resolves_constant_thresholds_in_nested_helper_bodies() {
+        let contract = parse(
+            r#"
+contract Demo() {
+    static function authorize(pubkey key, signature sig, bool choose) {
+        if (choose) { require(checkMultisig([key], [sig], QUORUM)); }
+        else { require(checkMultisig([key], [sig], QUORUM)); }
+    }
+    const int QUORUM = 1;
+}
+"#,
+        )
+        .unwrap();
+        let Statement::IfElse {
+            then_body,
+            else_body: Some(else_body),
+            ..
+        } = &contract.functions[0].statements[0]
+        else {
+            panic!("expected if/else");
+        };
+        for body in [then_body, else_body] {
+            assert!(matches!(
+                body[0],
+                Statement::Require(Requirement::CheckMultisig { threshold: 1, .. })
+            ));
+        }
     }
 
     #[test]

--- a/src/parser/tapscript.rs
+++ b/src/parser/tapscript.rs
@@ -13,6 +13,7 @@ pub(crate) fn function_pair_is_tapscript(pair: &Pair<Rule>) -> bool {
 /// Parse a `function <name>(<params>) tapscript { … }` declaration.
 pub(crate) fn parse_named_tapscript(
     pair: Pair<Rule>,
+    constants: &[Constant],
 ) -> Result<crate::models::NamedTapscript, String> {
     let mut inner = pair.into_inner().peekable();
     if inner
@@ -39,7 +40,7 @@ pub(crate) fn parse_named_tapscript(
                 .into_inner()
                 .next()
                 .ok_or("Empty require() in tapscript")?;
-            items.push(parse_tap_item(expr)?);
+            items.push(parse_tap_item(expr, constants)?);
         }
     }
     Ok(crate::models::NamedTapscript {
@@ -50,7 +51,10 @@ pub(crate) fn parse_named_tapscript(
 }
 
 /// Interpret one `require(...)` inner expression as a tapscript item.
-pub(crate) fn parse_tap_item(pair: Pair<Rule>) -> Result<crate::models::TapItem, String> {
+pub(crate) fn parse_tap_item(
+    pair: Pair<Rule>,
+    constants: &[Constant],
+) -> Result<crate::models::TapItem, String> {
     use crate::models::{HashFn, TapItem};
     match pair.as_rule() {
         Rule::general_expression
@@ -66,7 +70,7 @@ pub(crate) fn parse_tap_item(pair: Pair<Rule>) -> Result<crate::models::TapItem,
             if inner.next().is_some() {
                 return Err("unsupported compound expression in tapscript require()".to_string());
             }
-            parse_tap_item(item)
+            parse_tap_item(item, constants)
         }
         Rule::hash_comparison => {
             let mut inner = pair.into_inner();
@@ -121,7 +125,7 @@ pub(crate) fn parse_tap_item(pair: Pair<Rule>) -> Result<crate::models::TapItem,
                 .into_inner()
                 .next()
                 .ok_or("Missing checkMultisig body")?;
-            parse_tap_multisig(inner)
+            parse_tap_multisig(inner, constants)
         }
         Rule::function_call => {
             // older(n) / after(n)
@@ -155,7 +159,10 @@ pub(crate) fn parse_tap_item(pair: Pair<Rule>) -> Result<crate::models::TapItem,
 }
 
 /// Parse `check_threshold_multisig` inner pairs into a Sig item.
-pub(crate) fn parse_tap_multisig(pair: Pair<Rule>) -> Result<crate::models::TapItem, String> {
+pub(crate) fn parse_tap_multisig(
+    pair: Pair<Rule>,
+    constants: &[Constant],
+) -> Result<crate::models::TapItem, String> {
     use crate::models::TapItem;
     let mut keys = Vec::new();
     let mut sigs = Vec::new();
@@ -172,13 +179,8 @@ pub(crate) fn parse_tap_multisig(pair: Pair<Rule>) -> Result<crate::models::TapI
                     sigs.push(s.as_str().to_string());
                 }
             }
-            Rule::number_literal => {
-                threshold = Some(
-                    child
-                        .as_str()
-                        .parse::<u16>()
-                        .map_err(|e| format!("invalid threshold: {e}"))?,
-                );
+            Rule::number_literal | Rule::identifier => {
+                threshold = Some(parse_multisig_threshold(child, constants)?);
             }
             _ => {}
         }

--- a/src/parser/tapscript.rs
+++ b/src/parser/tapscript.rs
@@ -18,9 +18,11 @@ pub(crate) fn parse_named_tapscript(
     if inner
         .peek()
         .is_some_and(|p| p.as_rule() == Rule::function_visibility)
-        && inner.next().expect("visibility").as_str() == "private"
     {
-        return Err("tapscript functions cannot be private".to_string());
+        let visibility = inner.next().expect("visibility").as_str();
+        if visibility != "public" {
+            return Err(format!("tapscript functions cannot be {visibility}"));
+        }
     }
     let name = inner
         .next()

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -578,7 +578,6 @@ fn check_requirement(req: &Requirement, scope: &Scope, errors: &mut Vec<TypeErro
             check_expression(right, scope, errors, fn_name);
             check_comparison(left, op, right, scope, errors, fn_name);
         }
-        Requirement::After { .. } => {} // No type checking needed
     }
 }
 

--- a/src/validator/functions.rs
+++ b/src/validator/functions.rs
@@ -17,6 +17,17 @@ pub(super) fn validate_functions(contract: &Contract, issues: &mut Vec<Validatio
             }
             validate_declared_type(result, "return type", &definitions, issues);
         }
+        if function.is_static {
+            let referenced = super::references::referenced_parameters(&function.statements, &[]);
+            for parameter in &contract.parameters {
+                if referenced.contains(parameter.name.as_str()) {
+                    issues.push(ValidationIssue::error(format!(
+                        "static function '{}' cannot reference constructor parameter '{}'",
+                        function.name, parameter.name
+                    )));
+                }
+            }
+        }
         let mut scope = build_scope_with_structs(&contract.parameters, &contract.structs);
         scope.extend(build_scope_with_structs(
             &function.parameters,
@@ -58,6 +69,7 @@ fn validate_body(
             validate_calls(
                 expression,
                 !matches!(statement, Statement::Call(_)),
+                function,
                 scope,
                 contract,
                 issues,
@@ -137,6 +149,7 @@ fn validate_body(
 fn validate_calls(
     expression: &Expression,
     value_position: bool,
+    caller: &Function,
     scope: &Scope,
     contract: &Contract,
     issues: &mut Vec<ValidationIssue>,
@@ -150,6 +163,12 @@ fn validate_calls(
                 if !function.is_private {
                     issues.push(ValidationIssue::error(format!(
                         "public function '{name}' is an entrypoint and cannot be called"
+                    )));
+                }
+                if caller.is_static && !function.is_static {
+                    issues.push(ValidationIssue::error(format!(
+                        "static function '{}' cannot call non-static function '{name}'",
+                        caller.name
                     )));
                 }
                 if value_position && function.return_type.is_none() {
@@ -182,7 +201,7 @@ fn validate_calls(
         }
     }
     for child in child_exprs(expression) {
-        validate_calls(child, true, scope, contract, issues);
+        validate_calls(child, true, caller, scope, contract, issues);
     }
 }
 

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1358,18 +1358,6 @@ fn validate_binding_requirement(
                 );
             }
         }
-        Requirement::After {
-            timelock_var: Some(name),
-            ..
-        } => validate_named_binding(
-            name,
-            Some(ArkType::Int),
-            "timelock",
-            function_name,
-            scopes,
-            issues,
-        ),
-        Requirement::After { .. } => {}
         Requirement::HashEqual { preimage, hash, .. } => {
             validate_named_binding(preimage, None, "preimage", function_name, scopes, issues);
             validate_named_binding(hash, None, "hash", function_name, scopes, issues);

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -24,6 +24,7 @@ use crate::typechecker::{build_scope_with_structs, infer_type, literal_index, Ar
 use std::collections::{HashMap, HashSet};
 
 mod functions;
+pub(crate) mod references;
 
 // ─── Issue types ──────────────────────────────────────────────────────────────
 
@@ -1714,6 +1715,7 @@ fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
         .iter()
         .map(|p| p.name.as_str())
         .collect();
+    let const_names: HashSet<&str> = contract.constants.iter().map(|c| c.name.as_str()).collect();
 
     for tapscript in &contract.tapscripts {
         for input in &tapscript.inputs {
@@ -1723,16 +1725,32 @@ fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
                     input.name, tapscript.name, input.name
                 )));
             }
+            if const_names.contains(input.name.as_str()) {
+                issues.push(ValidationIssue::error(format!(
+                    "input '{}' in tapscript '{}' shadows constant '{}'",
+                    input.name, tapscript.name, input.name
+                )));
+            }
         }
     }
 
     for func in &contract.functions {
         // Seed frame: constructor params + this function's params.
-        let mut seed: HashSet<String> = ctor_names.iter().map(|s| s.to_string()).collect();
+        let mut seed: HashSet<String> = ctor_names
+            .iter()
+            .chain(&const_names)
+            .map(|s| s.to_string())
+            .collect();
         for param in &func.parameters {
             if ctor_names.contains(param.name.as_str()) {
                 issues.push(ValidationIssue::error(format!(
                     "parameter '{}' in function '{}' shadows constructor parameter '{}'",
+                    param.name, func.name, param.name
+                )));
+            }
+            if const_names.contains(param.name.as_str()) {
+                issues.push(ValidationIssue::error(format!(
+                    "parameter '{}' in function '{}' shadows constant '{}'",
                     param.name, func.name, param.name
                 )));
             }
@@ -1742,7 +1760,13 @@ fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
         let mut stack: Vec<HashSet<String>> = vec![seed];
         walk_scope(&func.statements, &func.name, &mut stack, issues);
 
-        check_ctor_assignment(&func.statements, &func.name, &ctor_names, issues);
+        check_ctor_assignment(
+            &func.statements,
+            &func.name,
+            &ctor_names,
+            &const_names,
+            issues,
+        );
     }
 }
 
@@ -1752,6 +1776,7 @@ fn check_ctor_assignment(
     stmts: &[Statement],
     fname: &str,
     ctor_names: &HashSet<&str>,
+    const_names: &HashSet<&str>,
     issues: &mut Vec<ValidationIssue>,
 ) {
     for stmt in stmts {
@@ -1769,19 +1794,25 @@ fn check_ctor_assignment(
                         name, fname
                     )));
                 }
+                if const_names.contains(root) {
+                    issues.push(ValidationIssue::error(format!(
+                        "cannot assign to constant '{}' in function '{}'",
+                        name, fname
+                    )));
+                }
             }
             Statement::IfElse {
                 then_body,
                 else_body,
                 ..
             } => {
-                check_ctor_assignment(then_body, fname, ctor_names, issues);
+                check_ctor_assignment(then_body, fname, ctor_names, const_names, issues);
                 if let Some(eb) = else_body {
-                    check_ctor_assignment(eb, fname, ctor_names, issues);
+                    check_ctor_assignment(eb, fname, ctor_names, const_names, issues);
                 }
             }
             Statement::ForIn { body, .. } => {
-                check_ctor_assignment(body, fname, ctor_names, issues);
+                check_ctor_assignment(body, fname, ctor_names, const_names, issues);
             }
             Statement::LetBinding { .. }
             | Statement::Require(_)
@@ -2138,10 +2169,12 @@ contract Demo() {
                     pubkey: "owner".to_string(),
                 })],
                 is_private: false,
+                is_static: false,
                 return_type: None,
             }],
             tapscripts: Vec::new(),
             imports: vec![],
+            constants: vec![],
         }
     }
 

--- a/src/validator/references.rs
+++ b/src/validator/references.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
+use super::child_exprs;
 use crate::models::{AssignmentTarget, Expression, Function, Requirement, Statement};
-use crate::validator::child_exprs;
 
 // Parameters are retained whole; pruning individual composite fields needs a sparse stack layout.
-pub(super) fn referenced_parameters<'a>(
+pub(crate) fn referenced_parameters<'a>(
     statements: &'a [Statement],
     functions: &'a [Function],
 ) -> HashSet<&'a str> {

--- a/src/validator/references.rs
+++ b/src/validator/references.rs
@@ -99,11 +99,6 @@ fn collect_requirement<'a>(
                 collect_name(name, names);
             }
         }
-        Requirement::After { timelock_var, .. } => {
-            if let Some(name) = timelock_var {
-                collect_name(name, names);
-            }
-        }
         Requirement::HashEqual { preimage, hash, .. } => {
             collect_name(preimage, names);
             collect_name(hash, names);

--- a/tests/examples/cash_secured_put.rs
+++ b/tests/examples/cash_secured_put.rs
@@ -1,6 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTOUTASSETLOOKUP,
+    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTLOCKTIME,
+    OP_INSPECTOUTASSETLOOKUP,
 };
 
 use crate::common::{arkade_asm, arkade_inputs, group};
@@ -64,13 +65,13 @@ fn test_exercise_verifies_btc_delivery_and_stable_payout() {
         "exercise must verify output 0's BTC value"
     );
     assert!(
-        asm.contains(OP_CHECKLOCKTIMEVERIFY),
+        asm.contains(OP_INSPECTLOCKTIME),
         "exercise must enforce tx.time >= expiryHeight"
     );
 }
 
 #[test]
-fn test_reclaim_is_seller_only_with_cltv() {
+fn test_reclaim_is_seller_only_with_timelock() {
     let out = compile(PUT_CODE).unwrap();
     let names = arkade_inputs(&out, "reclaim");
     assert!(
@@ -83,7 +84,7 @@ fn test_reclaim_is_seller_only_with_cltv() {
     );
     let asm = arkade_asm(&out, "reclaim");
     assert!(
-        asm.contains(OP_CHECKLOCKTIMEVERIFY),
+        asm.contains(OP_INSPECTLOCKTIME),
         "reclaim must enforce timelock"
     );
     assert!(

--- a/tests/examples/covered_call.rs
+++ b/tests/examples/covered_call.rs
@@ -1,6 +1,7 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTOUTASSETLOOKUP,
+    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTLOCKTIME,
+    OP_INSPECTOUTASSETLOOKUP,
 };
 
 use crate::common::{arkade_asm, arkade_inputs, group};
@@ -65,15 +66,15 @@ fn test_exercise_verifies_strike_payment() {
         asm.contains("OP_INSPECTOUTPUTVALUE"),
         "exercise must verify output 1's BTC value"
     );
-    // CLTV on expiryHeight = exercise window opens
+    // The exercise window opens at expiryHeight.
     assert!(
-        asm.contains(OP_CHECKLOCKTIMEVERIFY),
+        asm.contains(OP_INSPECTLOCKTIME),
         "exercise must enforce tx.time >= expiryHeight"
     );
 }
 
 #[test]
-fn test_reclaim_is_seller_only_with_cltv() {
+fn test_reclaim_is_seller_only_with_timelock() {
     let out = compile(CALL_CODE).unwrap();
     let names = arkade_inputs(&out, "reclaim");
     assert!(
@@ -86,7 +87,7 @@ fn test_reclaim_is_seller_only_with_cltv() {
     );
     let asm = arkade_asm(&out, "reclaim");
     assert!(
-        asm.contains(OP_CHECKLOCKTIMEVERIFY),
+        asm.contains(OP_INSPECTLOCKTIME),
         "reclaim must enforce timelock"
     );
     assert!(

--- a/tests/examples/fuji_safe.rs
+++ b/tests/examples/fuji_safe.rs
@@ -1,6 +1,6 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_CHECKSIGVERIFY, OP_LESSTHAN,
+    OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_CHECKSIGVERIFY, OP_INSPECTLOCKTIME, OP_LESSTHAN,
 };
 
 #[test]
@@ -57,10 +57,10 @@ fn test_fuji_safe_contract() {
         }
     }
 
-    // Verify claim function: checks expiration timeout (CLTV) in arkade covenant
+    // The claim covenant checks expiration through locktime inspection.
     let claim_asm = crate::common::arkade_asm(&output, "claim");
     assert!(
-        claim_asm.contains(OP_CHECKLOCKTIMEVERIFY),
+        claim_asm.contains(OP_INSPECTLOCKTIME),
         "claim covenant should enforce expiration timeout: {}",
         claim_asm
     );

--- a/tests/examples/repayment_pool.rs
+++ b/tests/examples/repayment_pool.rs
@@ -555,47 +555,32 @@ fn test_redeem_is_pro_rata_post_window() {
     );
     assert!(asm.contains(OP_CHECKSIG), "redeem needs holder sig");
 
-    // The post-window gate `require(tx.time >= maturity + auctionWindow)` is
-    // what makes the redemption rate (usdtBalance / totalCreditOutstanding)
-    // fixed and fair for all orderings — it is the keystone of the phased
-    // design. The compiler lowers `tx.time >= redeemStart` to
-    // OP_CHECKLOCKTIMEVERIFY (the dedicated Bitcoin time-lock opcode),
-    // because that's exactly the "block height ≥ N" semantic.
+    // Redemption opens after maturity + auctionWindow.
     assert_eq!(
-        opcode_count_in_arkade(&output, "redeem", "OP_CHECKLOCKTIMEVERIFY"),
+        opcode_count_in_arkade(&output, "redeem", "OP_INSPECTLOCKTIME"),
         1,
-        "redeem must gate on tx.time >= maturity + auctionWindow (CLTV, post-window phase)"
+        "redeem must inspect locktime for the post-window gate"
     );
-
-    // Verify the CLTV operand actually DERIVES FROM the contract's two
-    // time-axis constructor parameters: a future refactor that accidentally
-    // lowered `tx.time >= 0` (or any literal) to a CLTV would pass the
-    // opcode-count check above but bypass the gate semantically. Both
-    // `<maturity>` and `<auctionWindow>` placeholders must appear in the
-    // redeem ASM for the gate's operand to be the intended sum.
     let tokens = arkade_asm_tokens(&output, "redeem");
-    assert!(
-        tokens.iter().any(|t| t == "<maturity>"),
-        "redeem CLTV operand must derive from maturity (placeholder missing)"
-    );
-    assert!(
-        tokens.iter().any(|t| t == "<auctionWindow>"),
-        "redeem CLTV operand must derive from auctionWindow (placeholder missing)"
-    );
-    // Structural check: the token IMMEDIATELY BEFORE OP_CHECKLOCKTIMEVERIFY
-    // must be the redeemStart let-binding placeholder — not a literal, not
-    // an unrelated placeholder. A refactor that accidentally locked CLTV to
-    // a literal (e.g. `tx.time >= 0`) would push something other than
-    // <redeemStart> here and fail the test.
-    let cltv_idx = tokens
+    for parameter in ["<maturity>", "<auctionWindow>"] {
+        assert!(tokens.iter().any(|token| token == parameter));
+    }
+    assert!(!tokens.iter().any(|token| token == "OP_CHECKLOCKTIMEVERIFY"));
+    // The inspected locktime must feed the gate, not be read and discarded.
+    let inspect = tokens
         .iter()
-        .position(|op| op == "OP_CHECKLOCKTIMEVERIFY")
-        .expect("OP_CHECKLOCKTIMEVERIFY missing");
-    assert!(cltv_idx > 0, "OP_CHECKLOCKTIMEVERIFY must have an operand");
-    let operand = &tokens[cltv_idx - 1];
-    assert_eq!(
-        operand, "<redeemStart>",
-        "CLTV operand must be the redeemStart let-binding (= maturity + auctionWindow), got: {operand}"
+        .position(|token| token == "OP_INSPECTLOCKTIME")
+        .expect("OP_INSPECTLOCKTIME missing");
+    let gate = tokens
+        .iter()
+        .skip(inspect)
+        .position(|token| token == "OP_GREATERTHANOREQUAL")
+        .expect("locktime gate missing");
+    assert_eq!(tokens[inspect + gate + 1], "OP_VERIFY");
+    let bound = &tokens[inspect + 1..inspect + gate];
+    assert!(
+        bound.iter().any(|token| token == "OP_PICK"),
+        "locktime bound must read the redeemStart binding, not a literal: {bound:?}"
     );
 }
 

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -12,6 +12,8 @@ mod bare_vtxo;
 mod beacon;
 #[path = "features/concat_op.rs"]
 mod concat_op;
+#[path = "features/constants.rs"]
+mod constants;
 #[path = "features/contract_import_instantiation.rs"]
 mod contract_import_instantiation;
 #[path = "features/epoch_limiter.rs"]
@@ -32,6 +34,8 @@ mod packet_primitives;
 mod private_functions;
 #[path = "features/static_arrays.rs"]
 mod static_arrays;
+#[path = "features/static_functions.rs"]
+mod static_functions;
 #[path = "features/structs.rs"]
 mod structs;
 #[path = "features/symbolic_stack.rs"]

--- a/tests/features/constants.rs
+++ b/tests/features/constants.rs
@@ -1,0 +1,240 @@
+use crate::common::*;
+use arkade_compiler::compile;
+
+fn error(source: &str) -> String {
+    compile(source)
+        .expect_err("expected compile error")
+        .to_string()
+}
+
+#[test]
+fn constants_fold_into_covenant_and_tapleaf() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner) {
+    const int EXIT_DELAY = 144;
+    const bool STRICT = true;
+    function spend(signature sig, int amount) {
+        require(checkSig(sig, owner));
+        require(amount > EXIT_DELAY);
+        require(STRICT);
+    }
+    function exit(signature sig) tapscript {
+        require(older(EXIT_DELAY));
+        require(checkSig(sig, owner));
+    }
+}
+"#,
+    )
+    .expect("constants");
+    assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    assert!(arkade_asm_tokens(&output, "spend").contains(&"144".to_string()));
+    assert_eq!(
+        leaf_asm_tokens(&output, "exit", "exit")[0],
+        "144".to_string()
+    );
+    assert!(!arkade_asm(&output, "spend").contains("EXIT_DELAY"));
+    assert_eq!(
+        output
+            .parameters
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>(),
+        ["owner"]
+    );
+}
+
+#[test]
+fn constant_folds_into_a_covenant_absolute_timelock() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner) {
+    const int DEADLINE = 500000;
+    function spend(signature sig) {
+        require(tx.time >= DEADLINE);
+        require(checkSig(sig, owner));
+    }
+}
+"#,
+    )
+    .expect("timelock constant");
+    let asm = arkade_asm_tokens(&output, "spend");
+    assert!(asm.contains(&"500000".to_string()), "{asm:?}");
+}
+
+#[test]
+fn constant_is_readable_from_a_static_function() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner) {
+    const int BPS = 10000;
+    static function pct(int amount, int bps) int { return amount * bps / BPS; }
+    function spend(signature sig, int amount) {
+        require(checkSig(sig, owner));
+        require(pct(amount, 50) > 0);
+    }
+}
+"#,
+    )
+    .expect("constant in static function");
+    assert!(arkade_asm_tokens(&output, "spend").contains(&"10000".to_string()));
+}
+
+#[test]
+fn constant_is_usable_as_a_loop_bound_and_array_index() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner, int[3] limits) {
+    const int FIRST = 0;
+    function spend(signature sig) {
+        require(checkSig(sig, owner));
+        require(limits[FIRST] > 0);
+    }
+}
+"#,
+    )
+    .expect("constant index");
+    assert!(!arkade_asm(&output, "spend").contains("FIRST"));
+}
+
+#[test]
+fn constant_must_be_int_or_bool() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const pubkey KEY = 1;
+    function spend(int amount) { require(amount > 0); }
+}
+"#
+    )
+    .contains("constant 'KEY' must be int or bool"));
+}
+
+#[test]
+fn constant_literal_must_match_its_declared_type() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const bool FLAG = 3;
+    function spend(int amount) { require(amount > 0); }
+}
+"#
+    )
+    .contains("constant 'FLAG' is not a valid 'bool' literal"));
+}
+
+#[test]
+fn constant_initializer_must_be_a_literal() {
+    for initializer in ["fee", "1 + 1", "-1"] {
+        let source = format!(
+            r#"
+contract Vault(pubkey owner, int fee) {{
+    const int A = {initializer};
+    function spend(int amount) {{ require(amount > A); }}
+}}
+"#
+        );
+        assert!(
+            error(&source).contains("constant 'A' must be initialized with a literal"),
+            "{initializer} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn constant_names_must_be_unique_and_not_collide() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const int A = 1;
+    const int A = 2;
+    function spend(int amount) { require(amount > A); }
+}
+"#
+    )
+    .contains("duplicate constant 'A'"));
+    assert!(error(
+        r#"
+contract Vault(pubkey owner, int fee) {
+    const int fee = 1;
+    function spend(int amount) { require(amount > fee); }
+}
+"#
+    )
+    .contains("constant 'fee' collides with constructor parameter 'fee'"));
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const int spend = 1;
+    function spend(int amount) { require(amount > 0); }
+}
+"#
+    )
+    .contains("constant 'spend' collides with function 'spend'"));
+}
+
+#[test]
+fn bindings_may_not_shadow_a_constant() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const int A = 1;
+    function spend(int A) { require(A > 0); }
+}
+"#
+    )
+    .contains("parameter 'A' in function 'spend' shadows constant 'A'"));
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const int A = 1;
+    function spend(int amount) { let A = 2; require(amount > A); }
+}
+"#
+    )
+    .contains("binding 'A' in function 'spend' shadows an in-scope binding"));
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const int A = 1;
+    function spend(signature sig) {
+        require(checkSig(sig, owner));
+    }
+    function exit(signature A) tapscript {
+        require(older(10));
+        require(checkSig(A, owner));
+    }
+}
+"#
+    )
+    .contains("input 'A' in tapscript 'exit' shadows constant 'A'"));
+}
+
+#[test]
+fn constants_cannot_be_assigned() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    const int A = 1;
+    function spend(int amount) { A = 2; require(amount > 0); }
+}
+"#
+    )
+    .contains("cannot assign to constant 'A' in function 'spend'"));
+}
+
+#[test]
+fn const_identifier_prefix_is_still_a_name() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner) {
+    function spend(signature sig, int constant) {
+        require(checkSig(sig, owner));
+        require(constant > 0);
+    }
+}
+"#,
+    )
+    .expect("constant identifier");
+    assert_eq!(arkade_inputs(&output, "spend"), ["sig", "constant"]);
+}

--- a/tests/features/constants.rs
+++ b/tests/features/constants.rs
@@ -45,21 +45,167 @@ contract Vault(pubkey owner) {
 }
 
 #[test]
-fn constant_folds_into_a_covenant_absolute_timelock() {
-    let output = compile(
-        r#"
-contract Vault(pubkey owner) {
-    const int DEADLINE = 500000;
-    function spend(signature sig) {
-        require(tx.time >= DEADLINE);
-        require(checkSig(sig, owner));
+fn covenant_time_comparisons_use_inspection() {
+    for bound in ["500000", "DEADLINE", "deadline", "deadline + 1"] {
+        let source = format!(
+            "contract Vault(int deadline) {{ const int DEADLINE = 500000; function spend() {{ require(tx.time >= {bound}); }} }}"
+        );
+        let output = compile(&source).expect("time comparison");
+        let asm = arkade_asm_tokens(&output, "spend");
+        assert!(asm.contains(&"OP_INSPECTLOCKTIME".to_string()), "{asm:?}");
+        assert!(
+            asm.contains(&"OP_GREATERTHANOREQUAL".to_string()),
+            "{asm:?}"
+        );
+        assert!(
+            !asm.contains(&"OP_CHECKLOCKTIMEVERIFY".to_string()),
+            "{asm:?}"
+        );
+        let general = compile(&source.replace("require(tx.time", "require((tx.time)")).unwrap();
+        assert_eq!(asm, arkade_asm_tokens(&general, "spend"));
+        if bound == "DEADLINE" {
+            let literal = compile(&source.replace(">= DEADLINE", ">= 500000")).unwrap();
+            assert_eq!(asm, arkade_asm_tokens(&literal, "spend"));
+        }
+        assert_eq!(arkade_inputs(&output, "spend"), Vec::<String>::new());
+        assert_eq!(output.functions.len(), 1);
     }
 }
-"#,
-    )
-    .expect("timelock constant");
-    let asm = arkade_asm_tokens(&output, "spend");
-    assert!(asm.contains(&"500000".to_string()), "{asm:?}");
+
+#[test]
+fn tapleaf_time_comparisons_keep_cltv() {
+    for bound in ["500000", "DEADLINE", "deadline"] {
+        let output = compile(&format!(
+            "contract Vault(int deadline) {{ const int DEADLINE = 500000; function exit(signature sig) tapscript {{ require(tx.time >= {bound}); require(checkSig(sig, server)); }} }}"
+        )).unwrap();
+        let operand = if bound == "deadline" {
+            "<deadline>"
+        } else {
+            "500000"
+        };
+        assert_eq!(
+            leaf_asm(&output, "exit", "exit"),
+            format!("{operand} OP_CHECKLOCKTIMEVERIFY OP_DROP <SERVER_KEY> OP_CHECKSIG")
+        );
+        assert!(group(&output, "exit").arkade.is_none());
+        assert_eq!(witness_names(&output, "exit", "exit"), ["sig"]);
+    }
+}
+
+#[test]
+fn constant_indices_fold_in_named_operands() {
+    for body in [
+        "require(checkSig(sigs[FIRST], keys[FIRST]));",
+        "require(checkSig(sigs[FIRST], keys[FIRST]) == true);",
+        "require(checkSigFromStack(sigs[FIRST], keys[FIRST], messages[FIRST]));",
+        "require(checkSigFromStack(sigs[FIRST], keys[FIRST], messages[FIRST]) == true);",
+        "require(checkSigFromStackVerify(sigs[FIRST], keys[FIRST], messages[FIRST]));",
+        "require(checkMultisig([keys[FIRST]], [sigs[FIRST]], 1));",
+        "require(sha256(message) == messages[FIRST]);",
+        "require(size(messages[FIRST]) == 32);",
+        "if (checkSig(sigs[FIRST], keys[FIRST])) { require(true); } else { require(false); }",
+    ] {
+        let source = format!("contract Vault(pubkey[2] keys, bytes32[2] messages) {{ const int FIRST = 0; function spend(signature[2] sigs, bytes32 message) {{ {body} }} }}");
+        let output = compile(&source).unwrap_or_else(|e| panic!("{body}: {e}"));
+        let literal = compile(&source.replace("[FIRST]", "[0]")).unwrap();
+        assert_eq!(
+            arkade_asm_tokens(&output, "spend"),
+            arkade_asm_tokens(&literal, "spend"),
+            "{body}"
+        );
+        assert_eq!(
+            arkade_inputs(&output, "spend"),
+            arkade_inputs(&literal, "spend")
+        );
+    }
+    let source = "contract Vault(pubkey[2] keys, bytes32[2] hashes) { const int FIRST = 0; function exit(signature sig, bytes preimage) tapscript { require(sha256(preimage) == hashes[FIRST]); require(older(10)); require(checkSig(sig, keys[FIRST])); } }";
+    let output = compile(source).unwrap();
+    let literal = compile(&source.replace("[FIRST]", "[0]")).unwrap();
+    assert_eq!(
+        leaf_asm(&output, "exit", "exit"),
+        leaf_asm(&literal, "exit", "exit")
+    );
+    assert_eq!(witness_names(&output, "exit", "exit"), ["sig", "preimage"]);
+
+    for value in ["2", "true"] {
+        let ty = if value == "true" { "bool" } else { "int" };
+        let source = format!("contract Vault(pubkey[2] keys) {{ const {ty} FIRST = {value}; function spend(signature sig) {{ require(checkSig(sig, keys[FIRST])); }} }}");
+        assert!(compile(&source).is_err(), "{value} is not a valid index");
+    }
+}
+
+#[test]
+fn multisig_threshold_constants_resolve_before_and_after_functions() {
+    for declaration_first in [true, false] {
+        for modifier in ["", " tapscript"] {
+            let declaration = "const int QUORUM = 2;";
+            let timelock = if modifier.is_empty() {
+                ""
+            } else {
+                "require(older(10));"
+            };
+            let function = format!("function spend(signature firstSig, signature secondSig){modifier} {{ {timelock} require(checkMultisig([owner, backup], [firstSig, secondSig], QUORUM)); }}");
+            let members = if declaration_first {
+                format!("{declaration} {function}")
+            } else {
+                format!("{function} {declaration}")
+            };
+            let source = format!("contract Vault(pubkey owner, pubkey backup) {{ {members} }}");
+            let output = compile(&source).unwrap();
+            let literal = compile(&source.replace(", QUORUM)", ", 2)")).unwrap();
+            assert_eq!(output.functions.len(), 1);
+            assert_eq!(
+                leaf_asm(&output, "spend", "spend"),
+                leaf_asm(&literal, "spend", "spend")
+            );
+            assert_eq!(
+                witness_names(&output, "spend", "spend"),
+                witness_names(&literal, "spend", "spend")
+            );
+            if modifier.is_empty() {
+                assert_eq!(
+                    arkade_asm_tokens(&output, "spend"),
+                    arkade_asm_tokens(&literal, "spend")
+                );
+                assert_eq!(arkade_inputs(&output, "spend"), ["firstSig", "secondSig"]);
+            } else {
+                assert!(group(&output, "spend").arkade.is_none());
+            }
+        }
+    }
+}
+
+#[test]
+fn multisig_threshold_rejects_non_constants_and_invalid_values() {
+    for declaration in [
+        "",
+        "const bool QUORUM = true;",
+        "const int QUORUM = 65536;",
+        "const int QUORUM = 0;",
+        "const int QUORUM = 3;",
+    ] {
+        for modifier in ["", " tapscript"] {
+            let timelock = if modifier.is_empty() {
+                ""
+            } else {
+                "require(older(10));"
+            };
+            let source = format!("contract Vault(pubkey owner, int QUORUM_INPUT) {{ {declaration} function spend(signature sig){modifier} {{ {timelock} require(checkMultisig([owner], [sig], QUORUM)); }} }}");
+            compile(&source.replace(", QUORUM)", ", 1)")).expect("literal threshold");
+            assert!(compile(&source).is_err(), "{declaration} {modifier}");
+            assert!(compile(&source.replace(", QUORUM)", ", QUORUM_INPUT)")).is_err());
+        }
+    }
+}
+
+#[test]
+fn reserved_names_cannot_be_constants() {
+    for name in ["true", "false", "server", "emulator", "SERVER_KEY"] {
+        let source = format!(
+            "contract Vault() {{ const int {name} = 10; function spend() {{ require(true); }} }}"
+        );
+        assert!(error(&source).contains(&format!("constant name '{name}' is reserved")));
+    }
 }
 
 #[test]

--- a/tests/features/constants.rs
+++ b/tests/features/constants.rs
@@ -9,29 +9,64 @@ fn error(source: &str) -> String {
 
 #[test]
 fn constants_fold_into_covenant_and_tapleaf() {
-    let output = compile(
-        r#"
-contract Vault(pubkey owner) {
-    const int EXIT_DELAY = 144;
-    const bool STRICT = true;
-    function spend(signature sig, int amount) {
+    let source = |declarations: &str, delay: &str, strict: &str| {
+        format!(
+            r#"
+contract Vault(pubkey owner) {{
+    {declarations}
+    function spend(signature sig, int amount) {{
         require(checkSig(sig, owner));
-        require(amount > EXIT_DELAY);
-        require(STRICT);
-    }
-    function exit(signature sig) tapscript {
-        require(older(EXIT_DELAY));
+        require(amount > {delay});
+        require({strict});
+    }}
+    function exit(signature sig) tapscript {{
+        require(older({delay}));
         require(checkSig(sig, owner));
-    }
-}
-"#,
-    )
+    }}
+}}
+"#
+        )
+    };
+    let output = compile(&source(
+        "const int EXIT_DELAY = 144; const bool STRICT = true;",
+        "EXIT_DELAY",
+        "STRICT",
+    ))
     .expect("constants");
+    let literal = compile(&source("", "144", "true")).expect("literal");
     assert!(output.warnings.is_empty(), "{:?}", output.warnings);
-    assert!(arkade_asm_tokens(&output, "spend").contains(&"144".to_string()));
+
     assert_eq!(
-        leaf_asm_tokens(&output, "exit", "exit")[0],
-        "144".to_string()
+        leaf_asm(&output, "exit", "exit"),
+        "144 OP_CHECKSEQUENCEVERIFY OP_DROP <owner> OP_CHECKSIG"
+    );
+    assert_eq!(witness_names(&output, "exit", "exit"), ["sig"]);
+    assert!(group(&output, "exit").arkade.is_none());
+
+    assert_eq!(
+        arkade_asm_tokens(&output, "spend"),
+        arkade_asm_tokens(&literal, "spend")
+    );
+    assert_eq!(
+        leaf_asm(&output, "exit", "exit"),
+        leaf_asm(&literal, "exit", "exit")
+    );
+    assert_eq!(
+        leaf_asm(&output, "spend", "spend"),
+        leaf_asm(&literal, "spend", "spend")
+    );
+    assert_eq!(
+        witness_names(&output, "spend", "spend"),
+        witness_names(&literal, "spend", "spend")
+    );
+    assert_eq!(arkade_inputs(&output, "spend"), ["sig", "amount"]);
+    assert_eq!(
+        output
+            .functions
+            .iter()
+            .map(|g| g.name.as_str())
+            .collect::<Vec<_>>(),
+        ["spend", "exit"]
     );
     assert!(!arkade_asm(&output, "spend").contains("EXIT_DELAY"));
     assert_eq!(

--- a/tests/features/static_functions.rs
+++ b/tests/features/static_functions.rs
@@ -1,0 +1,199 @@
+use crate::common::*;
+use arkade_compiler::compile;
+
+fn error(source: &str) -> String {
+    compile(source)
+        .expect_err("expected compile error")
+        .to_string()
+}
+
+#[test]
+fn static_function_compiles_like_the_private_equivalent() {
+    let body = |visibility: &str| {
+        format!(
+            r#"
+contract Vault(pubkey owner) {{
+    {visibility} function pct(int amount, int bps) int {{
+        return amount * bps / 10000;
+    }}
+    function spend(signature sig, int amount) {{
+        require(checkSig(sig, owner));
+        require(pct(amount, 50) > 0);
+    }}
+}}
+"#
+        )
+    };
+    let with_static = compile(&body("static")).expect("static");
+    let with_private = compile(&body("private")).expect("private");
+    assert!(
+        with_static.warnings.is_empty(),
+        "{:?}",
+        with_static.warnings
+    );
+    assert_eq!(
+        arkade_asm_tokens(&with_static, "spend"),
+        arkade_asm_tokens(&with_private, "spend")
+    );
+    assert_eq!(
+        with_static
+            .functions
+            .iter()
+            .map(|g| g.name.as_str())
+            .collect::<Vec<_>>(),
+        ["spend"]
+    );
+    assert_eq!(arkade_inputs(&with_static, "spend"), ["sig", "amount"]);
+}
+
+#[test]
+fn static_function_may_call_another_static_function() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner) {
+    static function double(int amount) int { return amount * 2; }
+    static function quadruple(int amount) int { return double(double(amount)); }
+    function spend(signature sig, int amount) {
+        require(checkSig(sig, owner));
+        require(quadruple(amount) > 0);
+    }
+}
+"#,
+    )
+    .expect("static chain");
+    assert!(arkade_asm(&output, "spend").contains("OP_MUL"));
+}
+
+#[test]
+fn static_function_rejects_constructor_parameter() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner, int fee) {
+    static function net(int amount) int { return amount - fee; }
+    function spend(int amount) { require(net(amount) > 0); }
+}
+"#
+    )
+    .contains("static function 'net' cannot reference constructor parameter 'fee'"));
+}
+
+#[test]
+fn static_function_rejects_constructor_struct_field_and_array_element() {
+    let field = error(
+        r#"
+struct Policy { int minimum; }
+contract Vault(Policy policy) {
+    static function floor(int amount) int { return amount + policy.minimum; }
+    function spend(int amount) { require(floor(amount) > 0); }
+}
+"#,
+    );
+    assert!(
+        field.contains("static function 'floor' cannot reference constructor parameter 'policy'"),
+        "{field}"
+    );
+    let element = error(
+        r#"
+contract Vault(int[2] limits) {
+    static function floor(int amount) int { return amount + limits[0]; }
+    function spend(int amount) { require(floor(amount) > 0); }
+}
+"#,
+    );
+    assert!(
+        element.contains("static function 'floor' cannot reference constructor parameter 'limits'"),
+        "{element}"
+    );
+}
+
+#[test]
+fn static_function_rejects_constructor_key_in_a_signature_check() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    static function authorize(signature sig) { require(checkSig(sig, owner)); }
+    function spend(signature sig) { authorize(sig); }
+}
+"#
+    )
+    .contains("static function 'authorize' cannot reference constructor parameter 'owner'"));
+}
+
+#[test]
+fn static_function_rejects_calling_a_non_static_function() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner, int fee) {
+    private function net(int amount) int { return amount - fee; }
+    static function twice(int amount) int { return net(amount) * 2; }
+    function spend(int amount) { require(twice(amount) > 0); }
+}
+"#
+    )
+    .contains("static function 'twice' cannot call non-static function 'net'"));
+}
+
+#[test]
+fn static_visibility_cannot_be_combined_with_private_or_public() {
+    for visibility in ["public static", "private static", "static private"] {
+        let source = format!(
+            r#"
+contract Vault(pubkey owner) {{
+    {visibility} function f(int amount) int {{ return amount; }}
+    function spend(int amount) {{ require(f(amount) > 0); }}
+}}
+"#
+        );
+        assert!(
+            error(&source).contains("Parse error"),
+            "{visibility} should not parse"
+        );
+    }
+}
+
+#[test]
+fn static_function_must_return_on_every_path() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    static function pick(int amount) int {
+        if (amount > 0) { return amount; }
+    }
+    function spend(int amount) { require(pick(amount) > 0); }
+}
+"#
+    )
+    .contains("must return a value on every path"));
+}
+
+#[test]
+fn static_identifier_prefix_is_still_a_name() {
+    let output = compile(
+        r#"
+contract Vault(pubkey owner) {
+    function spend(signature sig, int staticFee) {
+        require(checkSig(sig, owner));
+        require(staticFee > 0);
+    }
+}
+"#,
+    )
+    .expect("staticFee");
+    assert_eq!(arkade_inputs(&output, "spend"), ["sig", "staticFee"]);
+}
+
+#[test]
+fn tapscript_declarations_cannot_be_static() {
+    assert!(error(
+        r#"
+contract Vault(pubkey owner) {
+    function spend(signature sig) { require(checkSig(sig, owner)); }
+    static function exit(signature sig) tapscript {
+        require(older(10));
+        require(checkSig(sig, owner));
+    }
+}
+"#
+    )
+    .contains("tapscript functions cannot be static"));
+}


### PR DESCRIPTION
Adds two contract-level members that belong to the contract rather than to an instance of it.

## `static function`

```solidity
static function pct(int amount, int bps) int {
    return amount * bps / BPS;
}
```

A private helper that cannot see constructor state. `static` is a third alternative in `function_visibility`, so `public static`, `private static`, and `static function ... tapscript` all fail to parse.

Code generation is unchanged: the parser sets `is_private` alongside `is_static`, so static functions reuse the existing inlining, recursion ban, and return-path rules verbatim. The two new restrictions are validation-only:

- reading a constructor parameter, or a field or element of one, is rejected;
- calling a non-static function is rejected.

## `const`

```solidity
const int EXIT_DELAY = 144;
const bool STRICT = true;
```

Declared anywhere in the contract body and folded to a literal before validation, so no later stage ever observes a constant identifier. `int` and `bool` only, with literal initializers only, because the language has no other literal form.

Constants fold into covenant bodies, private and static helpers, covenant `tx.time >=` timelocks, and a tapleaf's `older(...)` / `after(...)` operand — the last being the point, since a delay shared by a covenant and its L1 exit is now written once. They never reach the artifact.

Names may not collide with a constructor parameter or a function, nothing may shadow one, and they cannot be assigned to.

## Implementation

The constant feature is one rewrite pass (`src/compiler/constants.rs`) plus collision seeds in the existing `check_shadowing` and `check_ctor_assignment`. Nothing was added to the typechecker or the scope machinery.

The static restrictions cost about 25 lines: the call check folds into the existing `validate_calls`, and the constructor-parameter check reuses `referenced_parameters`, which already resolves root names across every named operand form. That collector moved from `src/compiler/references.rs` to `src/validator/references.rs` — a pure move that also fixes the layering, since it already imported from `validator`.

## Bug found on the way

`parse_named_tapscript` only rejected the literal string `"private"`, so `static function f() tapscript` would have been accepted as a public tapscript. It now rejects any non-`public` visibility.

## Out of scope

Cross-contract `B.func()` / `B.CONST` (needs real import resolution — `Contract.imports` is parsed and ignored today), constant expressions, constants as array sizes, and non-scalar constant types.

One known gap: a constant used as a bracket index inside a named crypto operand, such as `checkSig(sigs[IDX], owner)`, is not folded, because those fields are `String` rather than `Expression`. It reports `array index 'IDX' is undefined` rather than compiling. The general `arr[IDX]` form in expressions works.

## Verification

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, and `./playground/build.sh` all pass. New coverage in `tests/features/static_functions.rs` and `tests/features/constants.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compile-time integer and boolean constants with folding in contract logic, arrays, loops, and multisig thresholds.
  * Added static functions that cannot access constructor state or call non-static functions.
  * Added parser and editor support for `const` and `static`, including autocomplete snippets.

* **Validation**
  * Added checks for duplicate names, invalid values, shadowing, reassignment, and invalid static-function usage.

* **Documentation**
  * Documented constants and static functions in the README.

* **Changes**
  * Covenant time comparisons now use locktime inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->