### PR TITLE
Compare whole arrays and structs with == and !=

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Comments use `//`. Identifiers start with a letter and contain letters, digits, 
 | `struct` | User-declared, nested structs and scalar arrays allowed |
 | `AssetId`, `Outpoint`, `ECPoint` | Native result structs: `{txid, gidx}`, `{txid, vout}`, `{x, y}` |
 
-Arrays and structs are allowed in constructor and covenant parameters and as locals. Tapscript inputs must be scalars. Arrays of structs, whole-struct assignment, and whole-struct comparison are not supported.
+Arrays and structs are allowed in constructor and covenant parameters and as locals. Tapscript inputs must be scalars. Arrays of structs and whole-struct assignment are not supported. Whole arrays and structs compare with `==` and `!=` inside `require`, leaf by leaf, and both sides must have the same declared type.
 
 ### Functions
 

--- a/src/compiler/comparison.rs
+++ b/src/compiler/comparison.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::models::*;
+use crate::opcodes::OP_ROLL;
+use crate::typechecker::{bind_local_type, infer_type, ArkType};
 
 /// Emit assembly for a comparison requirement.
 ///
@@ -33,5 +35,63 @@ pub(crate) fn emit_comparison_op(op: &str, asm: &mut Vec<String>) {
         "<=" => asm.push(OP_LESSTHANOREQUAL.to_string()),
         "<" => asm.push(OP_LESSTHAN.to_string()),
         _ => asm.push(format!("OP_{}", op)),
+    }
+}
+
+impl Generator {
+    pub(super) fn composite_type(&self, expression: &Expression) -> Option<String> {
+        match infer_type(expression, &self.scope) {
+            composite @ (ArkType::Array(..) | ArkType::Struct(_)) => Some(composite.as_str()),
+            _ => None,
+        }
+    }
+
+    pub(super) fn bind_type(&mut self, name: &str, ty: &str) {
+        let structs = std::mem::take(&mut self.structs);
+        bind_local_type(&mut self.scope, name, Some(ty), ArkType::Unknown, &structs);
+        self.structs = structs;
+    }
+
+    pub(super) fn emit_composite_requirement(
+        &mut self,
+        left: &Expression,
+        op: &str,
+        right: &Expression,
+        ty: &str,
+    ) -> Result<(), String> {
+        if !matches!(op, "==" | "!=") {
+            return Err(format!("'{op}' is not defined for '{ty}' values"));
+        }
+        let width = self.value_leaves("", ty)?.len();
+        self.emit_typed_value(left, ty)?;
+        self.emit_typed_value(right, ty)?;
+        for remaining in (1..=width).rev() {
+            if op == "==" {
+                if remaining > 1 {
+                    self.roll(remaining)?;
+                }
+                self.apply(OP_EQUALVERIFY, 2, 0)?;
+            } else if remaining == width {
+                self.roll(width)?;
+                self.apply(OP_EQUAL, 2, 1)?;
+            } else {
+                self.roll(remaining + 1)?;
+                self.roll(2)?;
+                self.apply(OP_EQUAL, 2, 1)?;
+                self.apply(OP_BOOLAND, 2, 1)?;
+            }
+        }
+        if op == "!=" {
+            self.apply(OP_NOT, 1, 1)?;
+            self.apply(OP_VERIFY, 1, 0)?;
+        }
+        Ok(())
+    }
+
+    fn roll(&mut self, depth: usize) -> Result<(), String> {
+        self.push_integer_temporary(depth);
+        self.pop_temporaries(1, OP_ROLL)?;
+        self.asm.push(OP_ROLL.to_string());
+        Ok(())
     }
 }

--- a/src/compiler/comparison.rs
+++ b/src/compiler/comparison.rs
@@ -47,9 +47,13 @@ impl Generator {
     }
 
     pub(super) fn bind_type(&mut self, name: &str, ty: &str) {
-        let structs = std::mem::take(&mut self.structs);
-        bind_local_type(&mut self.scope, name, Some(ty), ArkType::Unknown, &structs);
-        self.structs = structs;
+        bind_local_type(
+            &mut self.scope,
+            name,
+            Some(ty),
+            ArkType::Unknown,
+            &self.structs,
+        );
     }
 
     pub(super) fn emit_composite_requirement(

--- a/src/compiler/functions.rs
+++ b/src/compiler/functions.rs
@@ -141,6 +141,7 @@ impl Generator {
             return Err(format!("wrong argument count for '{name}'"));
         }
         let caller = self.stack.clone();
+        let caller_scope = self.scope.clone();
         let baseline = caller.len();
         let mut arguments = Vec::new();
         for (index, (argument, parameter)) in args.iter().zip(&function.parameters).enumerate() {
@@ -200,6 +201,7 @@ impl Generator {
         }
         self.discard_call_frame(baseline, results.len())?;
         self.stack[..baseline].clone_from_slice(&caller);
+        self.scope = caller_scope;
         self.return_type = previous_return;
         Ok(())
     }

--- a/src/compiler/functions.rs
+++ b/src/compiler/functions.rs
@@ -30,7 +30,7 @@ pub(super) fn contains_return(statements: &[Statement]) -> bool {
 }
 
 impl Generator {
-    fn value_leaves(&self, name: &str, ty: &str) -> Result<Vec<TypeLeaf>, String> {
+    pub(super) fn value_leaves(&self, name: &str, ty: &str) -> Result<Vec<TypeLeaf>, String> {
         flatten_parameter(
             &Parameter {
                 name: name.to_string(),
@@ -177,6 +177,9 @@ impl Generator {
                     kind: BindingKind::Local,
                 };
             }
+        }
+        for parameter in &function.parameters {
+            self.bind_type(&parameter.name, &parameter.param_type);
         }
         let previous_return = self.return_type.replace(function.return_type.clone());
         self.push_temporary(OP_0);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -72,6 +72,7 @@ struct Generator {
     scopes: Vec<usize>,
     constructor_array_expansions: Vec<(String, String)>,
     structs: Vec<crate::models::StructDefinition>,
+    scope: typechecker::Scope,
     functions: Vec<Function>,
     // None outside a helper; Some(None) inside a void helper.
     return_type: Option<Option<String>>,
@@ -123,12 +124,18 @@ impl Generator {
                 kind: BindingKind::Constructor,
             });
         }
+        let mut scope = typechecker::build_scope_with_structs(function_parameters, structs);
+        scope.extend(typechecker::build_scope_with_structs(
+            constructor_parameters,
+            structs,
+        ));
         Ok(Self {
             asm,
             stack,
             scopes: Vec::new(),
             constructor_array_expansions,
             structs: structs.to_vec(),
+            scope,
             functions: Vec::new(),
             return_type: None,
         })
@@ -901,6 +908,7 @@ fn generate_asm_from_statements_recursive(
                 if let Some(ty) = result_type {
                     generator.emit_typed_value(value, ty)?;
                     generator.bind_value(name, ty)?;
+                    generator.bind_type(name, ty);
                 } else {
                     generator.emit_expression(value)?;
                     generator.bind_local(name)?;
@@ -1046,6 +1054,12 @@ fn generate_requirement_asm(req: &Requirement, generator: &mut Generator) -> Res
             Ok(())
         }
         Requirement::Comparison { left, op, right } => {
+            if let Some(ty) = generator
+                .composite_type(left)
+                .or_else(|| generator.composite_type(right))
+            {
+                return generator.emit_composite_requirement(left, op, right, &ty);
+            }
             generator.emit_expression(left)?;
             generator.emit_expression(right)?;
             let mut raw = Vec::new();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -69,7 +69,7 @@ fn internal_array_binding_name(array: &str, index: &str) -> String {
 struct Generator {
     asm: Vec<String>,
     stack: Vec<StackItem>,
-    scopes: Vec<usize>,
+    scopes: Vec<(usize, typechecker::Scope)>,
     constructor_array_expansions: Vec<(String, String)>,
     structs: Vec<crate::models::StructDefinition>,
     scope: typechecker::Scope,
@@ -124,9 +124,9 @@ impl Generator {
                 kind: BindingKind::Constructor,
             });
         }
-        let mut scope = typechecker::build_scope_with_structs(function_parameters, structs);
+        let mut scope = typechecker::build_scope_with_structs(constructor_parameters, structs);
         scope.extend(typechecker::build_scope_with_structs(
-            constructor_parameters,
+            function_parameters,
             structs,
         ));
         Ok(Self {
@@ -578,14 +578,15 @@ impl Generator {
     }
 
     fn enter_scope(&mut self) {
-        self.scopes.push(self.stack.len());
+        self.scopes.push((self.stack.len(), self.scope.clone()));
     }
 
     fn exit_scope(&mut self) -> Result<(), String> {
-        let baseline = self
+        let (baseline, scope) = self
             .scopes
             .pop()
             .ok_or_else(|| "internal compiler error: scope stack underflow".to_string())?;
+        self.scope = scope;
         while self.stack.len() > baseline {
             match self.stack.last() {
                 Some(StackItem::Binding {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -913,6 +913,8 @@ fn generate_asm_from_statements_recursive(
                 } else {
                     generator.emit_expression(value)?;
                     generator.bind_local(name)?;
+                    let ty = typechecker::infer_type(value, &generator.scope);
+                    generator.scope.insert(name.clone(), ty);
                 }
             }
             Statement::VarAssign { target, value } => {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -712,10 +712,15 @@ fn check_comparison(
     if matches!(left_type, ArkType::Array(..) | ArkType::Struct(..))
         || matches!(right_type, ArkType::Array(..) | ArkType::Struct(..))
     {
-        errors.push(TypeError::new(format!(
-            "fn {}: composite comparison '{}' is not supported",
-            fn_name, op
-        )));
+        if !matches!(op, "==" | "!=") || left_type != right_type {
+            errors.push(TypeError::new(format!(
+                "fn {}: comparison '{}' is not defined between '{}' and '{}'",
+                fn_name,
+                op,
+                left_type.as_str(),
+                right_type.as_str()
+            )));
+        }
         return;
     }
 

--- a/src/validator/functions.rs
+++ b/src/validator/functions.rs
@@ -76,6 +76,26 @@ fn validate_body(
             );
         }
         match statement {
+            Statement::Require(Requirement::Comparison { left, right, .. }) => {
+                for (value, other) in [(left, right), (right, left)] {
+                    if matches!(
+                        value,
+                        Expression::ArrayLiteral(_) | Expression::StructLiteral(_)
+                    ) {
+                        let expected = infer_type(other, scope);
+                        if matches!(expected, ArkType::Array(..) | ArkType::Struct(_)) {
+                            validate_value(
+                                &expected.as_str(),
+                                value,
+                                scope,
+                                contract,
+                                &format!("comparison in '{}'", function.name),
+                                issues,
+                            );
+                        }
+                    }
+                }
+            }
             Statement::Return(value) => {
                 if !function.is_private {
                     issues.push(ValidationIssue::error(format!(

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1362,9 +1362,33 @@ fn validate_binding_requirement(
             validate_named_binding(preimage, None, "preimage", function_name, scopes, issues);
             validate_named_binding(hash, None, "hash", function_name, scopes, issues);
         }
-        Requirement::Comparison { left, right, .. } => {
-            validate_binding_expression(left, function_name, scopes, issues, true);
-            validate_binding_expression(right, function_name, scopes, issues, true);
+        Requirement::Comparison { left, op, right } => {
+            let left_type = resolved_expression_type(left, scopes);
+            let right_type = resolved_expression_type(right, scopes);
+            let composite = matches!(left_type, ArkType::Array(..) | ArkType::Struct(..))
+                || matches!(right_type, ArkType::Array(..) | ArkType::Struct(..));
+            if composite {
+                if !matches!(op.as_str(), "==" | "!=") {
+                    issues.push(ValidationIssue::error(format!(
+                        "function '{}': '{}' is not defined for composite values",
+                        function_name, op
+                    )));
+                } else if left_type != ArkType::Unknown
+                    && right_type != ArkType::Unknown
+                    && !binding_types_compatible(&left_type, &right_type)
+                    && !binding_types_compatible(&right_type, &left_type)
+                {
+                    issues.push(ValidationIssue::error(format!(
+                        "function '{}': comparison '{}' is not defined between '{}' and '{}'",
+                        function_name,
+                        op,
+                        left_type.as_str(),
+                        right_type.as_str()
+                    )));
+                }
+            }
+            validate_binding_expression(left, function_name, scopes, issues, !composite);
+            validate_binding_expression(right, function_name, scopes, issues, !composite);
         }
     }
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1375,8 +1375,7 @@ fn validate_binding_requirement(
                     )));
                 } else if left_type != ArkType::Unknown
                     && right_type != ArkType::Unknown
-                    && !binding_types_compatible(&left_type, &right_type)
-                    && !binding_types_compatible(&right_type, &left_type)
+                    && left_type != right_type
                 {
                     issues.push(ValidationIssue::error(format!(
                         "function '{}': comparison '{}' is not defined between '{}' and '{}'",

--- a/tests/e2e/contracts/private_functions.ark
+++ b/tests/e2e/contracts/private_functions.ark
@@ -50,6 +50,7 @@ contract PrivateFunctions(Config config) {
         require(false);
     }
     private function verify(int value, int expected) { require(value == expected); }
+    private function same(Result left, Result right) { require(left == right); }
     private function difference(int left, int right) int { return left - right; }
 
     private function point(int x, int y) ECPoint { return ecMul(x, y, 1, 0); }
@@ -84,6 +85,10 @@ contract PrivateFunctions(Config config) {
         require(changed[1] == value + 1);
         require(original.values[0] == value + 1);
         require(original.values[1] == value + 2);
+        require(previous == direct);
+        require(original == result(value));
+        require(initial != changed);
+        same(original, result(value));
         require(difference(bump(value), bump(value + 1)) == -1);
         checked(pass);
         skip(pass);

--- a/tests/e2e/contracts/structs.ark
+++ b/tests/e2e/contracts/structs.ark
@@ -47,12 +47,15 @@ contract Structs(Account account) {
     }
     require(local.weights.length == 3, "array field length");
     require(total == expected, "local struct result");
+    require(local != supplied, "mutated struct differs");
+    require(supplied.weights == [41, 43, 47], "whole array equality");
 
     let indexedOutpoint = tx.inputs[0].outpoint;
     Outpoint currentOutpoint = tx.input.current.outpoint;
     require(indexedOutpoint.txid == currentOutpoint.txid, "outpoint txid");
     require(indexedOutpoint.vout == currentOutpoint.vout, "outpoint vout");
     require(currentOutpoint.vout == 0, "funding vout");
+    require(indexedOutpoint == currentOutpoint, "whole outpoint equality");
 
     let outputAssetId = tx.outputs[0].assets[0].assetId;
     require(outputAssetId.gidx == 0, "asset group index");
@@ -61,6 +64,7 @@ contract Structs(Account account) {
     AssetId groupAssetId = assetGroup.assetId;
     require(groupAssetId.txid == outputAssetId.txid, "group asset txid");
     require(groupAssetId.gidx == outputAssetId.gidx, "group asset index");
+    require(groupAssetId == outputAssetId, "whole asset id equality");
 
     let generatorX = generator.x;
     let generatorY = generator.y;
@@ -70,6 +74,7 @@ contract Structs(Account account) {
     require(added.y == generator.y, "ecAdd y");
     require(multiplied.x == generator.x, "ecMul x");
     require(multiplied.y == generator.y, "ecMul y");
+    require(added == multiplied, "whole ec point equality");
 
     require(checkSig(ownerSig, account.owner));
   }

--- a/tests/features/general_comparisons.rs
+++ b/tests/features/general_comparisons.rs
@@ -1,7 +1,8 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_0, OP_1, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_EQUAL, OP_GREATERTHAN, OP_GREATERTHANOREQUAL,
-    OP_LESSTHAN, OP_LESSTHANOREQUAL, OP_NOT, OP_PICK, OP_PUSHCURRENTINPUTINDEX, OP_VERIFY,
+    OP_0, OP_1, OP_BOOLAND, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_EQUAL, OP_EQUALVERIFY,
+    OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_LESSTHAN, OP_LESSTHANOREQUAL, OP_NOT, OP_PICK,
+    OP_PUSHCURRENTINPUTINDEX, OP_ROLL, OP_VERIFY,
 };
 
 fn compile_asm(source: &str) -> Vec<String> {
@@ -339,18 +340,55 @@ fn mismatched_comparisons_warn() {
 }
 
 #[test]
-fn direct_array_equality_is_rejected() {
-    let error = compile(
-        "contract Invalid() {
+fn array_equality_compares_every_element() {
+    let asm = compile_asm(
+        "contract Compare() {
             function compare(int[3] left, int[3] right) {
                 require(left == right);
             }
         }",
+    );
+    assert_eq!(
+        asm.iter().filter(|token| *token == OP_EQUALVERIFY).count(),
+        3,
+        "every element pair must be verified: {asm:?}"
+    );
+    assert!(
+        asm.iter().any(|token| token == OP_ROLL),
+        "element pairs are rolled together: {asm:?}"
+    );
+
+    let error = compile(
+        "contract Invalid() {
+            function compare(int[3] left, int[2] right) {
+                require(left == right);
+            }
+        }",
     )
-    .expect_err("array bindings cannot be read as one stack item")
+    .expect_err("arrays of different length have no common layout")
     .to_string();
     assert!(
-        error.contains("array expressions are composite values"),
-        "direct array equality must be rejected: {error}"
+        error.contains("comparison '==' is not defined between 'int[3]' and 'int[2]'"),
+        "{error}"
+    );
+}
+
+#[test]
+fn array_inequality_negates_the_folded_comparison() {
+    let asm = compile_asm(
+        "contract Compare() {
+            function compare(int[2] left, int[2] right) {
+                require(left != right);
+            }
+        }",
+    );
+    assert_eq!(
+        asm.iter().filter(|token| *token == OP_EQUAL).count(),
+        2,
+        "both element pairs are compared: {asm:?}"
+    );
+    assert!(
+        contains_tokens(&asm, &[OP_BOOLAND, OP_NOT, OP_VERIFY]),
+        "the folded result must be negated: {asm:?}"
     );
 }

--- a/tests/features/general_comparisons.rs
+++ b/tests/features/general_comparisons.rs
@@ -392,3 +392,60 @@ fn array_inequality_negates_the_folded_comparison() {
         "the folded result must be negated: {asm:?}"
     );
 }
+
+#[test]
+fn composite_comparison_literals_are_validated() {
+    for (ty, literal, diagnostic) in [
+        ("int[2]", "[1, true]", "expected 'int', got 'bool'"),
+        ("Point", "{x: 1, y: 2, y: 3}", "duplicate field 'y'"),
+        ("Point", "{x: 1, y: 2, z: 3}", "unknown field 'z'"),
+        ("Point", "{x: 1}", "missing field 'y'"),
+        ("Point", "{x: true, y: 2}", "expected 'int', got 'bool'"),
+        (
+            "Nested",
+            "{point: {x: 1, y: 2}, values: [1, true]}",
+            "expected 'int', got 'bool'",
+        ),
+    ] {
+        for op in ["==", "!="] {
+            for (left, right) in [("value", literal), (literal, "value")] {
+                let source = format!(
+                    "struct Point {{ int x; int y; }}
+                     struct Nested {{ Point point; int[2] values; }}
+                     contract C() {{
+                         function spend({ty} value) {{ require({left} {op} {right}); }}
+                     }}"
+                );
+                let error = compile(&source).expect_err(&source).to_string();
+                assert!(error.contains(diagnostic), "{source}: {error}");
+            }
+        }
+    }
+    let error = compile("contract C() { function spend() { require([1, true] == [1, 2]); } }")
+        .expect_err("both operands are literals")
+        .to_string();
+    assert!(error.contains("expected 'int', got 'bool'"), "{error}");
+}
+
+#[test]
+fn composite_comparisons_resolve_inferred_locals() {
+    let source = "struct Point { int x; int y; }
+        contract C() {
+            private function helper() { let q = 5; require(q == 5); }
+            function compare(Point q, int[2] a) {
+                helper();
+                let n = 1;
+                require([n, 2] == a);
+                require(a == [n, 2]);
+                require([n, 3] != a);
+                require(a != [n, 3]);
+                require(q == {x: 1, y: 2});
+            }
+        }";
+    let asm = compile_asm(source);
+    assert_eq!(
+        asm.iter().filter(|token| *token == OP_EQUALVERIFY).count(),
+        6
+    );
+    assert_eq!(asm.iter().filter(|token| *token == OP_BOOLAND).count(), 2);
+}

--- a/tests/features/io_introspection.rs
+++ b/tests/features/io_introspection.rs
@@ -1,6 +1,6 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_INSPECTINPUTOUTPOINT, OP_INSPECTINPUTSCRIPTPUBKEY, OP_INSPECTINPUTSEQUENCE,
+    OP_EQUALVERIFY, OP_INSPECTINPUTOUTPOINT, OP_INSPECTINPUTSCRIPTPUBKEY, OP_INSPECTINPUTSEQUENCE,
     OP_INSPECTINPUTVALUE, OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE, OP_SWAP,
 };
 
@@ -108,8 +108,8 @@ fn test_input_outpoint_returns_struct() {
 }
 
 #[test]
-fn test_input_outpoint_cannot_be_compared_as_a_scalar() {
-    let error = compile(
+fn test_input_outpoint_is_compared_field_by_field() {
+    let output = compile(
         r#"
         contract OutpointChecker() {
             function checkOutpoint() {
@@ -119,12 +119,20 @@ fn test_input_outpoint_cannot_be_compared_as_a_scalar() {
         }
     "#,
     )
-    .expect_err("outpoint equality is a composite comparison")
-    .to_string();
+    .expect("outpoint equality compares txid and vout");
 
-    assert!(
-        error.contains("struct expressions are composite values"),
-        "{error}"
+    let asm = crate::common::arkade_asm_tokens(&output, "checkOutpoint");
+    assert_eq!(
+        asm.iter()
+            .filter(|token| *token == OP_INSPECTINPUTOUTPOINT)
+            .count(),
+        2,
+        "both outpoints are inspected: {asm:?}"
+    );
+    assert_eq!(
+        asm.iter().filter(|token| *token == OP_EQUALVERIFY).count(),
+        2,
+        "txid and vout are both verified: {asm:?}"
     );
 }
 

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,8 +1,8 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_EQUAL, OP_GREATERTHANOREQUAL,
-    OP_INSPECTASSETGROUPASSETID, OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN, OP_PICK, OP_PUT, OP_SWAP,
-    OP_VERIFY,
+    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_EQUAL, OP_EQUALVERIFY,
+    OP_GREATERTHANOREQUAL, OP_INSPECTASSETGROUPASSETID, OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN,
+    OP_PICK, OP_PUT, OP_SWAP, OP_VERIFY,
 };
 
 #[test]
@@ -186,7 +186,7 @@ contract C(Point point) {
         r#"
 struct Point { int x; int y; }
 contract C(Point point) {
-    function spend() { require(point == point); }
+    function spend() { require(point); }
 }
 "#,
     )
@@ -195,6 +195,42 @@ contract C(Point point) {
     assert!(
         composite.contains("struct expressions are composite values"),
         "{composite}"
+    );
+}
+
+#[test]
+fn struct_equality_compares_every_field() {
+    let output = compile(
+        r#"
+struct Point { int x; int y; }
+struct Pair { Point a; Point b; }
+contract C(Pair left) {
+    function spend(Pair right) { require(left == right); }
+}
+"#,
+    )
+    .expect("struct equality compares leaf by leaf");
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert_eq!(
+        asm.iter().filter(|token| *token == OP_EQUALVERIFY).count(),
+        4,
+        "every leaf of the nested struct is verified: {asm:?}"
+    );
+
+    let mismatch = compile(
+        r#"
+struct Point { int x; int y; }
+struct Pair { Point a; Point b; }
+contract C(Point point) {
+    function spend(Pair pair) { require(point == pair); }
+}
+"#,
+    )
+    .expect_err("structs with different layouts")
+    .to_string();
+    assert!(
+        mismatch.contains("comparison '==' is not defined between 'Point' and 'Pair'"),
+        "{mismatch}"
     );
 }
 

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,6 +1,6 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_EQUAL, OP_EQUALVERIFY,
+    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_ENDIF, OP_EQUAL, OP_EQUALVERIFY,
     OP_GREATERTHANOREQUAL, OP_INSPECTASSETGROUPASSETID, OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN,
     OP_PICK, OP_PUT, OP_SWAP, OP_VERIFY,
 };
@@ -232,6 +232,56 @@ contract C(Point point) {
         mismatch.contains("comparison '==' is not defined between 'Point' and 'Pair'"),
         "{mismatch}"
     );
+
+    let widened = compile(
+        r#"
+contract C(bytes[1] a) {
+    function spend(bytes20[1] b) { require(a == b); }
+}
+"#,
+    )
+    .expect_err("element types must match exactly")
+    .to_string();
+    assert!(
+        widened.contains("comparison '==' is not defined between 'bytes[1]' and 'bytes20[1]'"),
+        "{widened}"
+    );
+}
+
+#[test]
+fn composite_types_do_not_outlive_their_bindings() {
+    let after_call = compile(
+        r#"
+struct Res { int selected; int other; }
+contract C() {
+    private function same(Res left, Res right) { require(left == right); }
+    function spend(Res a, Res b, int left) {
+        same(a, b);
+        require(left == 1);
+    }
+}
+"#,
+    )
+    .expect("helper parameter types stay inside the helper");
+    assert!(crate::common::arkade_asm(&after_call, "spend").contains(OP_EQUALVERIFY));
+
+    let after_block = compile(
+        r#"
+struct Point { int x; int y; }
+contract C() {
+    function spend(int flag) {
+        if (flag == 1) {
+            Point q = { x: 1, y: 2 };
+            require(q.x == 1);
+        }
+        let q = 5;
+        require(q == 5);
+    }
+}
+"#,
+    )
+    .expect("block-local struct types end with the block");
+    assert!(crate::common::arkade_asm(&after_block, "spend").contains(OP_ENDIF));
 }
 
 #[test]

--- a/tests/features/structs.rs
+++ b/tests/features/structs.rs
@@ -1,8 +1,8 @@
 use arkade_compiler::compile;
 use arkade_compiler::opcodes::{
-    OP_ADD, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_ENDIF, OP_EQUAL, OP_EQUALVERIFY,
-    OP_GREATERTHANOREQUAL, OP_INSPECTASSETGROUPASSETID, OP_INSPECTINPUTOUTPOINT, OP_LESSTHAN,
-    OP_PICK, OP_PUT, OP_SWAP, OP_VERIFY,
+    OP_ADD, OP_BOOLAND, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DUP, OP_ENDIF, OP_EQUAL,
+    OP_EQUALVERIFY, OP_GREATERTHANOREQUAL, OP_INSPECTASSETGROUPASSETID, OP_INSPECTINPUTOUTPOINT,
+    OP_LESSTHAN, OP_NOT, OP_PICK, OP_PUT, OP_SWAP, OP_VERIFY,
 };
 
 #[test]
@@ -245,6 +245,30 @@ contract C(bytes[1] a) {
     assert!(
         widened.contains("comparison '==' is not defined between 'bytes[1]' and 'bytes20[1]'"),
         "{widened}"
+    );
+}
+
+#[test]
+fn struct_inequality_checks_the_final_leaf() {
+    let output = compile(
+        "struct Point { int x; int y; }
+         struct Pair { Point a; Point b; }
+         contract C() {
+             function spend() {
+                 Pair left = {a: {x: 1, y: 2}, b: {x: 3, y: 4}};
+                 Pair right = {a: {x: 1, y: 2}, b: {x: 3, y: 5}};
+                 require(left != right);
+             }
+         }",
+    )
+    .expect("only the final leaf differs");
+    let asm = crate::common::arkade_asm_tokens(&output, "spend");
+    assert_eq!(asm.iter().filter(|token| *token == OP_EQUAL).count(), 4);
+    assert_eq!(asm.iter().filter(|token| *token == OP_BOOLAND).count(), 3);
+    assert!(
+        asm.windows(4)
+            .any(|tokens| tokens == [OP_EQUAL, OP_BOOLAND, OP_NOT, OP_VERIFY]),
+        "{asm:?}"
     );
 }
 


### PR DESCRIPTION
`require(arr0 == arr1)` and `require(point0 == point1)` now compile instead of being rejected as composite values. Nested structs, struct fields of struct or array type, array literals, private-call results, and the native result structs (`Outpoint`, `AssetId`, `ECPoint`) all work on either side.

## How it compiles

Both operands are laid out on the stack through the existing `emit_typed_value` (first leaf on top), then each pair is rolled together:

- `==` → `<n> OP_ROLL OP_EQUALVERIFY` per pair; the last pair needs no roll since `OP_EQUALVERIFY` is symmetric
- `!=` → pair results are folded with `OP_BOOLAND`, then `OP_NOT OP_VERIFY`

```
require(keys == other);
<keys.1> <keys.0> OP_1 OP_PICK OP_1 OP_PICK OP_5 OP_PICK OP_5 OP_PICK OP_2 OP_ROLL OP_EQUALVERIFY OP_EQUALVERIFY
```

## Changes

- `src/compiler/comparison.rs` — `emit_composite_requirement`, plus `composite_type` and a `roll` helper on `Generator`
- `src/compiler/mod.rs` — `Generator` carries a typechecker `Scope` built from the existing `build_scope_with_structs`, so it knows an operand's declared type and leaf count; `Requirement::Comparison` routes composites to the new emitter
- `src/compiler/functions.rs` — private-function parameters register their types for the callee body
- `src/typechecker/mod.rs`, `src/validator/mod.rs` — composite operands are allowed in a comparison; `>`/`<` and friends stay rejected, and mismatched layouts are a hard error (`comparison '==' is not defined between 'int[3]' and 'int[2]'`). Composites in any other value position stay rejected as before
- `README.md` — the "whole-struct comparison is not supported" line documents the feature instead

## Tests

Three tests that asserted the old rejection became positive tests (array `==`/`!=`, nested-struct `==` plus layout mismatch, whole-outpoint `==`).

The Go e2e suite executes composite comparisons on the real VM: struct `==`, struct `!=`, array-vs-literal `==`, native `Outpoint`/`AssetId`/`ECPoint` `==`, and `original == result(value)` against a private-call result. Each new check was confirmed to bite — flipping an expected element fails with `OP_EQUALVERIFY failed`, and `supplied != supplied` fails with `OP_VERIFY failed`.

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, and `./scripts/e2e.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uB2qKYUVTjJRPDCToNxmJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for comparing complete arrays and structs with `==` and `!=`.
  * Comparisons evaluate each element or field, including nested composites and built-in composite values.
  * Composite comparisons require matching declared types; other comparison operators remain unsupported.
  * Added support for multi-file imports, recursive dependency loading, and imported helpers.

* **Documentation**
  * Documented compiler and WebAssembly APIs, source bundles, constructor validation, and file-aware warnings.
  * Clarified function, constant, indexing, array, and struct comparison behavior.

* **Tests**
  * Added coverage for imports, bundles, and composite comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->