### PR TITLE
Add contract imports and self-contained source artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Comments use `//`. Identifiers start with a letter and contain letters, digits, 
 
 ### Imports
 
-Imports resolve relative to the importing file, with explicit `.ark` filenames. Files may declare structs and at most one contract. An imported contract can contain only constants and static helpers; compiling an entry contract still requires a spend function or tapscript.
+Imports resolve relative to the importing file, with explicit `.ark` filenames. Files may declare structs and at most one contract. Imported contracts may contain spend functions and tapscripts, or just constants and static helpers. Only the entry contract emits spend groups and must have a spend function or tapscript. Importers can access constants, call static helpers, and instantiate the imported contract with `new Contract(...)`; they cannot call its spend functions or private helpers.
 
 ```solidity
 // types.ark
@@ -275,7 +275,7 @@ Each file sees its own declarations and declarations directly imported from othe
 
 `new Contract(args...)` requires the current contract or a directly imported contract and checks the constructor's argument count and types. It still emits a runtime VTXO placeholder; imported contracts do not add spend groups to the entry artifact. FujiSafe accepts its treasury and borrower burn-output witness programs as constructor inputs; clients construct these from the keys and asset commitment and preserve them on renewal.
 
-The playground compiles against the files in its Explorer. Source paths appear above the editor; default shared SingleSig lives at `single_sig/single_sig.ark`. Imported files are editable, and shared links contain the files used by the selected contract.
+The playground compiles against the files in its Explorer. Source paths appear above the editor; default shared SingleSig lives at `single_sig/single_sig.ark`. Imported files are editable, and shared links contain the files used by the selected contract. Sharing is limited to 1 MiB of encoded URL content and 4 MiB of decompressed UTF-8 source data.
 
 ### Types
 
@@ -454,7 +454,7 @@ Keys resolve to constructor `pubkey` parameters, declared `pubkey` inputs, or th
 
 Witness `encoding` values: `compressed-33`, `schnorr-64`, `raw`, `raw-20`, `raw-32`, `scriptnum`. `updatedAt` changes on every compile; ignore it when diffing artifacts.
 
-The `source` field is a bundle object, replacing the previous single string. It includes only files loaded for this compilation. Paths are normalized and relative, preserving import relationships; native compilation strips the common directory prefix from the loaded files. File contents are preserved verbatim. Recompile with the same compiler version using `compile_sources(source.entry, &source.files)`; `updatedAt` is the only dynamic field. Standalone compilation produces a one-file bundle with entry `main.ark`.
+The `source` field is a bundle object, replacing the previous single string. This is an intentional breaking format change: regenerate string-source artifacts with this compiler before loading them in updated consumers such as `arkade-bindgen`, and upgrade compiler and consumers together. It includes only files loaded for this compilation. Paths are normalized and relative, preserving import relationships; native compilation strips the common directory prefix from the loaded files. File contents are preserved verbatim. Recompile with the same compiler version using `compile_sources(source.entry, &source.files)`; `updatedAt` is the only dynamic field. Standalone compilation produces a one-file bundle with entry `main.ark`.
 
 ### Covenant stack ABI
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The playground runs the real compiler as WebAssembly. Nothing is installed and n
 | Bindings | Generated TypeScript or Go client code for the artifact, switchable per target |
 | Errors | Parse, type, and validation errors; the offending line is selected in the editor |
 
-The Explorer ships the single-file examples (SingleSig, HTLC, FujiSafe, StructVault, NonInteractiveSwap) and the multi-file projects (Stability, LayerZero / USDT0, Options, Bonds). You can add files and folders, rename, drag between folders, and everything persists in `localStorage`. The link button copies a URL with your current source compressed into the hash, so a contract can be shared without a backend.
+The Explorer ships the single-file examples (SingleSig, HTLC, FujiSafe, StructVault, NonInteractiveSwap) and the multi-file projects (Stability, LayerZero / USDT0, Options, Bonds). You can add files and folders, rename, drag between folders, and everything persists in `localStorage`. The link button compiles the selected contract and copies a URL containing its source bundle, including imports, so a contract can be shared without a backend.
 
 Every pull request gets its own build at `https://arkade-os.github.io/compiler/pr-previews/pr-<number>/`, posted as a comment on the PR.
 
@@ -90,7 +90,7 @@ contract Splitter(pubkey alicePk, pubkey bobPk, int exit) {
 }
 ```
 
-`new SingleSig(alicePk, exit)` compiles to the opaque placeholder `<VTXO:SingleSig(<alicePk>,<exit>)>`. The Arkade runtime resolves it to the child contract's Taproot scriptPubKey at instantiation, so the check itself is a plain `OP_INSPECTOUTPUTSCRIPTPUBKEY ... OP_EQUAL`. Arguments must be constructor parameters or literals; function inputs only exist at spend time and cannot be baked into a placeholder. A contract can instantiate itself with `import "self.ark";` to enforce state continuation (see `examples/fuji_safe`).
+`new SingleSig(alicePk, exit)` compiles to the opaque placeholder `<VTXO:SingleSig(<alicePk>,<exit>)>`. The Arkade runtime resolves it to the child contract's Taproot scriptPubKey at instantiation, so the check itself is a plain `OP_INSPECTOUTPUTSCRIPTPUBKEY ... OP_EQUAL`. Arguments must be constructor parameters or literals; function inputs only exist at spend time and cannot be baked into a placeholder. A contract can instantiate itself without an import to enforce state continuation (see `examples/fuji_safe`).
 
 ### Assets
 
@@ -200,7 +200,7 @@ cargo run -p arkade-bindgen -- --list-targets
 
 `--embed` inlines the artifact JSON into the generated file; `--package` sets the module or namespace name.
 
-Use the compiler as a library with `arkade_compiler::compile(source) -> Result<ContractJson, _>`. The `wasm` feature exposes `compile`, `validate`, and `version` through `wasm-bindgen`; that is what the playground calls.
+Use `arkade_compiler::compile(source)` for standalone source, `compile_file(path)` to load an entry file and its relative imports, or `compile_sources(entry, &files)` for an in-memory project (`BTreeMap<String, String>` mapping paths to source text). All return `Result<ContractJson, _>`. Standalone source uses `main.ark` as its filename and cannot load imports. The `wasm` feature exposes `compile`, `compile_sources`, `validate`, and `version`; the WASM `compile_sources(entry, files)` accepts the file map as a JSON string and returns the artifact as a JSON string.
 
 ### Run the playground locally
 
@@ -218,6 +218,7 @@ cargo install wasm-pack
 cargo test --workspace                                   # unit, feature, and example tests
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --check
+node playground/imports.test.mjs                         # after the playground build
 ./scripts/e2e.sh -v                                      # builds arkadec, runs artifacts through the Arkade VM and btcd (Go)
 cp ./scripts/pre-commit .git/hooks                       # fmt + test before every commit
 ```
@@ -229,14 +230,52 @@ The E2E suite pins its dependencies in `tests/e2e/go.mod`; no Docker or emulator
 ### File layout
 
 ```solidity
-import "other.ark";          // zero or more; declares contracts usable in `new`
+import "./other.ark";        // zero or more; imports structs and the contract name
 struct Name { ... }          // zero or more, before the contract
-contract Name(<params>) {    // exactly one
+contract Name(<params>) {    // optional in an imported file; one in the entry file
   function ...
 }
 ```
 
 Comments use `//`. Identifiers start with a letter and contain letters, digits, and underscores. Number literals are decimal integers; string literals appear only in `import` and as `require` messages.
+
+### Imports
+
+Imports resolve relative to the importing file, with explicit `.ark` filenames. Files may declare structs and at most one contract. An imported contract can contain only constants and static helpers; compiling an entry contract still requires a spend function or tapscript.
+
+```solidity
+// types.ark
+struct Policy { int maximum; }
+```
+
+```solidity
+// fees.ark
+contract Fees() {
+    const int MINIMUM = 10;
+    static function calculate(int amount) int { return amount / 100; }
+}
+```
+
+```solidity
+// vault.ark
+import "./types.ark";
+import "./fees.ark";
+
+contract Vault(Policy policy) {
+    function spend(int amount) {
+        require(amount >= Fees.MINIMUM);
+        require(Fees.calculate(amount) <= policy.maximum);
+    }
+}
+```
+
+Structs use their declared names; contract constants and static functions use `Contract.member`. Private functions and spend functions cannot be called externally. Imported static helpers inline into the calling covenant and cannot access the caller's state. Imported constants work wherever local constants work, including tapscript timelocks and multisig thresholds; static helper calls remain covenant-only.
+
+Each file sees its own declarations and declarations directly imported from other files. Dependencies of imported code retain their defining scope and are loaded recursively, but are not re-exported. Struct and contract names must be unique across the loaded files; repeated imports of the same normalized path are deduplicated. Bindings cannot shadow a visible contract namespace. Missing files, unknown members, and circular imports are errors. Import chains are limited to 128 files. There are no aliases, selective imports, package search paths, remote imports, or library objects.
+
+`new Contract(args...)` requires the current contract or a directly imported contract and checks the constructor's argument count and types. It still emits a runtime VTXO placeholder; imported contracts do not add spend groups to the entry artifact. FujiSafe accepts its treasury and borrower burn-output witness programs as constructor inputs; clients construct these from the keys and asset commitment and preserve them on renewal.
+
+The playground compiles against the files in its Explorer. Source paths appear above the editor; default shared SingleSig lives at `single_sig/single_sig.ark`. Imported files are editable, and shared links contain the files used by the selected contract.
 
 ### Types
 
@@ -397,7 +436,7 @@ Keys resolve to constructor `pubkey` parameters, declared `pubkey` inputs, or th
     },
     { "name": "unilateral", "leaves": [ ... ] }
   ],
-  "source": "...",
+  "source": { "entry": "htlc.ark", "files": { "htlc.ark": "..." } },
   "compiler": { "name": "arkade-compiler", "version": "0.1.0" },
   "updatedAt": "2026-01-01T00:00:00Z"
 }
@@ -411,8 +450,11 @@ Keys resolve to constructor `pubkey` parameters, declared `pubkey` inputs, or th
 | `arkade` | `{ inputs, asm }`; absent for groups made only of standalone leaves |
 | `leaves[]` | `{ name, witness, asm }`; `witness` lists spend-time values in source order, `injected: true` marks infrastructure signatures |
 | `warnings` | Type-check warnings, omitted when empty |
+| `source` | `{ entry, files }`: original entry source and every recursively imported file, including comments |
 
 Witness `encoding` values: `compressed-33`, `schnorr-64`, `raw`, `raw-20`, `raw-32`, `scriptnum`. `updatedAt` changes on every compile; ignore it when diffing artifacts.
+
+The `source` field is a bundle object, replacing the previous single string. It includes only files loaded for this compilation. Paths are normalized and relative, preserving import relationships; native compilation strips the common directory prefix from the loaded files. File contents are preserved verbatim. Recompile with the same compiler version using `compile_sources(source.entry, &source.files)`; `updatedAt` is the only dynamic field. Standalone compilation produces a one-file bundle with entry `main.ark`.
 
 ### Covenant stack ABI
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,11 @@ The playground runs the real compiler as WebAssembly. Nothing is installed and n
 | Bindings | Generated TypeScript or Go client code for the artifact, switchable per target |
 | Errors | Parse, type, and validation errors; the offending line is selected in the editor |
 
-The Explorer ships the single-file examples (SingleSig, HTLC, FujiSafe, StructVault, NonInteractiveSwap) and the multi-file projects (Stability, LayerZero / USDT0, Options, Bonds). You can add files and folders, rename, drag between folders, and everything persists in `localStorage`. The link button compiles the selected contract and copies a URL containing its source bundle, including imports, so a contract can be shared without a backend.
+The Explorer ships the single-file examples (SingleSig, HTLC, FujiSafe, StructVault, NonInteractiveSwap) and the multi-file projects (Stability, LayerZero / USDT0, Options, Bonds). You can add files and folders, rename, drag between folders, and everything persists in `localStorage`. The compiler resolves imports from the Explorer's files. The link button copies a URL containing the selected contract and its dependencies. Shared bundles support up to 1 MiB of encoded URL content and 4 MiB of decompressed source data.
 
 Every pull request gets its own build at `https://arkade-os.github.io/compiler/pr-previews/pr-<number>/`, posted as a comment on the PR.
 
 ## A tour by example
-
-Every snippet below compiles on `master`. Paste any of them into the playground.
 
 ### One key, one exit
 
@@ -90,7 +88,7 @@ contract Splitter(pubkey alicePk, pubkey bobPk, int exit) {
 }
 ```
 
-`new SingleSig(alicePk, exit)` compiles to the opaque placeholder `<VTXO:SingleSig(<alicePk>,<exit>)>`. The Arkade runtime resolves it to the child contract's Taproot scriptPubKey at instantiation, so the check itself is a plain `OP_INSPECTOUTPUTSCRIPTPUBKEY ... OP_EQUAL`. Arguments must be constructor parameters or literals; function inputs only exist at spend time and cannot be baked into a placeholder. A contract can instantiate itself without an import to enforce state continuation (see `examples/fuji_safe`).
+`new SingleSig(alicePk, exit)` compiles to the opaque placeholder `<VTXO:SingleSig(<alicePk>,<exit>)>`. The Arkade runtime resolves it to the child contract's Taproot scriptPubKey at instantiation, so the check itself is a plain `OP_INSPECTOUTPUTSCRIPTPUBKEY ... OP_EQUAL`. Arguments are constructor parameters or literals, resolved when the contract is instantiated. A contract can instantiate itself without an import to enforce state continuation (see `examples/fuji_safe`).
 
 ### Assets
 
@@ -200,7 +198,7 @@ cargo run -p arkade-bindgen -- --list-targets
 
 `--embed` inlines the artifact JSON into the generated file; `--package` sets the module or namespace name.
 
-Use `arkade_compiler::compile(source)` for standalone source, `compile_file(path)` to load an entry file and its relative imports, or `compile_sources(entry, &files)` for an in-memory project (`BTreeMap<String, String>` mapping paths to source text). All return `Result<ContractJson, _>`. Standalone source uses `main.ark` as its filename and cannot load imports. The `wasm` feature exposes `compile`, `compile_sources`, `validate`, and `version`; the WASM `compile_sources(entry, files)` accepts the file map as a JSON string and returns the artifact as a JSON string.
+Use `arkade_compiler::compile(source)` for standalone source, `compile_file(path)` to load an entry file and its relative imports, or `compile_sources(entry, &files)` for an in-memory project (`BTreeMap<String, String>` mapping paths to source text). All return `Result<ContractJson, _>`. Standalone source uses `main.ark` as its filename. The `wasm` feature exposes `compile`, `compile_sources`, `validate`, and `version`; the WASM `compile_sources(entry, files)` accepts the file map as a JSON string and returns the artifact as a JSON string.
 
 ### Run the playground locally
 
@@ -241,7 +239,7 @@ Comments use `//`. Identifiers start with a letter and contain letters, digits, 
 
 ### Imports
 
-Imports resolve relative to the importing file, with explicit `.ark` filenames. Files may declare structs and at most one contract. Imported contracts may contain spend functions and tapscripts, or just constants and static helpers. Only the entry contract emits spend groups and must have a spend function or tapscript. Importers can access constants, call static helpers, and instantiate the imported contract with `new Contract(...)`; they cannot call its spend functions or private helpers.
+Imports use explicit `.ark` paths relative to the importing file. Each file may declare structs and one contract. An import exposes those structs, the contract's constants and static functions, and its constructor through `new Contract(...)`. The entry contract defines the artifact's spend groups; imported contracts supply reusable definitions.
 
 ```solidity
 // types.ark
@@ -269,15 +267,11 @@ contract Vault(Policy policy) {
 }
 ```
 
-Structs use their declared names; contract constants and static functions use `Contract.member`. Private functions and spend functions cannot be called externally. Imported static helpers inline into the calling covenant and cannot access the caller's state. Imported constants work wherever local constants work, including tapscript timelocks and multisig thresholds; static helper calls remain covenant-only.
+Structs use their declared names; constants and static functions use `Contract.member`. Each file sees its own declarations and its direct imports. Dependencies load recursively, and imported code keeps its defining scope. Static helpers inline into covenants; constants fold into literals, including in tapscript timelocks and multisig thresholds.
 
-Each file sees its own declarations and declarations directly imported from other files. Dependencies of imported code retain their defining scope and are loaded recursively, but are not re-exported. Struct and contract names must be unique across the loaded files; repeated imports of the same normalized path are deduplicated. Bindings cannot shadow a visible contract namespace. Missing files, unknown members, and circular imports are errors. Import chains are limited to 128 files. There are no aliases, selective imports, package search paths, remote imports, or library objects.
+Struct and contract names must be unique across loaded files. The compiler loads each normalized path once and reports missing files, unknown members, namespace collisions, and circular imports as errors. Import chains have a maximum depth of 128 files, including the entry file.
 
-`new Contract(args...)` requires the current contract or a directly imported contract and checks the constructor's argument count and types. It still emits a runtime VTXO placeholder; imported contracts do not add spend groups to the entry artifact.
-
-**FujiSafe constructor migration:** the constructor now takes 12 arguments. Append `bytes32 treasuryBurnScript` and `bytes32 borrowerBurnScript`, in that order, after `exit`. Clients construct these burn-output witness programs from the corresponding keys and asset commitment and preserve both on renewal. Regenerate FujiSafe artifacts and bindings, and update construction and scriptPubKey verification code together. The old ten-argument layout is rejected by the compiler and cannot be used to derive outputs for the updated contract.
-
-The playground compiles against the files in its Explorer. Source paths appear above the editor; default shared SingleSig lives at `single_sig/single_sig.ark`. Imported files are editable, and shared links contain the files used by the selected contract. Sharing is limited to 1 MiB of encoded URL content and 4 MiB of decompressed UTF-8 source data.
+`new Contract(args...)` refers to the current contract or a directly imported contract. The compiler checks constructor argument counts and types and emits a VTXO placeholder for the runtime to resolve.
 
 ### Types
 
@@ -293,7 +287,7 @@ The playground compiles against the files in its Explorer. Source paths appear a
 | `struct` | User-declared, nested structs and scalar arrays allowed |
 | `AssetId`, `Outpoint`, `ECPoint` | Native result structs: `{txid, gidx}`, `{txid, vout}`, `{x, y}` |
 
-Arrays and structs are allowed in constructor and covenant parameters and as locals. Tapscript inputs must be scalars. Arrays of structs, whole-struct assignment, and whole-struct comparison are not supported.
+Arrays and structs can be constructor parameters, covenant parameters, or locals. Arrays contain scalar elements; structs contain scalars, arrays, and nested structs. Read, assign, and compare struct fields individually. Tapscript inputs are scalars.
 
 ### Functions
 
@@ -308,13 +302,13 @@ function name(<params>) tapscript { ... }      // L1 tapleaf, plain Bitcoin Scri
 
 A covenant with no tapscript of the same name gets a synthesized `server` + `tweak(emulator, name)` leaf. A covenant and a tapscript that share a name form one spend group. A tapscript with no matching covenant is a standalone leaf, which is how unilateral exits are written.
 
-Private functions are callable only from covenant functions in the same contract, including other private functions. Calls are inlined, and private functions create no spend group or leaf. Tapscript functions cannot call or bind to a private function, including through `tweak(emulator, name)`. Public covenant functions remain transaction entrypoints and cannot be called as helpers. Declaration order does not matter; direct and mutual recursion are rejected. The old `internal` modifier is not supported.
+Private functions are helpers called from covenants and other private helpers in the same contract. Calls inline into the caller's script. Public functions define transaction entrypoints, and tapscript functions define L1 leaves. Functions can be declared in any order; call graphs must be acyclic.
 
-Arguments are evaluated once, left to right, and passed by value. Each helper sees its own parameters and locals plus the immutable constructor parameters, including struct fields and array elements. It cannot read or mutate caller locals unless their values are passed as arguments; modifying a parameter changes only the helper's copy.
+Arguments are evaluated once, left to right, and passed by value. Private helpers see their own parameters and locals plus immutable constructor state. Modifying a parameter changes the helper's local copy.
 
-A `static` function is a private helper that belongs to the contract rather than to an instance of it. It sees only its own parameters, its locals, and compile-time constants; referencing a constructor parameter, or a field or element of one, is rejected. It may call other static functions but not private or public ones. Everything else matches a private function, including inlining, the return-type rules, and the recursion ban. `static` is a visibility of its own: `public static` and `private static` do not parse.
+Static helpers see only their own parameters, locals, and compile-time constants. They can call other static helpers and are accessible through imports. Both private and static helpers use the same inlining and return rules.
 
-A return type follows the parameter list directly and is allowed only on private functions. It can be a scalar, fixed-size array, or struct, including native result structs such as `ECPoint`. Every path through a value-returning helper must return a compatible value. A helper without a return type may fall through or use `return;`. Early returns inside branches or loops exit the helper and resume the caller. Returning a boolean does not enforce it: use `require(predicate(...));`. Value-returning calls cannot discard their result; void calls cannot be used in expressions.
+A helper's return type follows its parameter list and can be a scalar, fixed-size array, or struct. Every path through a value-returning helper must return a compatible value, and each call's result must be used. Void helpers use `return;` or fall through. Early returns exit the helper and resume the caller. To enforce a boolean result, use `require(predicate(...));`.
 
 ```solidity
 contract Minimum(int minimum) {
@@ -337,11 +331,11 @@ const int EXIT_DELAY = 144;
 const bool STRICT = true;
 ```
 
-Constants are declared in the contract body, in any position, and are folded into a literal at every use site before validation. They are `int` or `bool` only — the language has no other literal form — and the initializer must be a literal, not an expression. They never reach the artifact: no constructor input, no placeholder, no ABI entry.
+Constants are `int` or `bool` literals declared anywhere in the contract body. The compiler substitutes their values before validation; they occupy no constructor or witness inputs.
 
-A constant is readable in covenant bodies, private and static helpers, array indices (including crypto operands), multisig thresholds, and a tapleaf's `older(...)` or `after(...)` operand. A delay shared by a covenant and its L1 exit is written once. Array sizes still require numeric literals.
+A constant is readable in covenant bodies, private and static helpers, array indices (including crypto operands), multisig thresholds, and a tapleaf's `older(...)` or `after(...)` operand. A delay shared by a covenant and its L1 exit is written once. Array sizes use positive integer literals.
 
-Constant names may not collide with a constructor parameter or a function, and no parameter, binding, loop variable, or tapscript input may shadow one. Constants cannot be assigned to.
+Constants are immutable, and their names must be distinct from all other bindings and function names in the contract.
 
 ```solidity
 contract Vault(pubkey owner) {
@@ -373,17 +367,17 @@ int fee = amount / 100;            // declared type
 Policy p = { primary: {...}, limits: [1, 2], exitDelay: 10 };
 int[3] scale = [1, 2, 3];
 x = <expr>;                        // reassignment keeps the declared type
-scale[1] = 10;                     // literal index only on master, see Upcoming
+scale[x + 1] = 10;                 // runtime index with bounds checking
 p.primary.weight = 5;
 if (<expr>) { ... } else { ... }
 for (i, item) in arr { ... }       // unrolled at compile time
 ```
 
-Shadowing a live name is an error. Constructor parameters cannot be reassigned.
+Each live binding has a unique name. Constructor parameters are immutable.
 
 ### Expressions
 
-Arithmetic `+ - * /` and unary `-` on `int`. Comparison `== != < <= > >=`. `+` on byte operands is concatenation; mixing an `int` into a byte concatenation is an error until you widen it with `num2bin(value, width)`, because the width is consensus-visible. `arr.length` folds to the declared size. Array indices may be any `int` expression when reading; a runtime index emits a bounds check.
+Arithmetic `+ - * /` and unary `-` on `int`. Comparison `== != < <= > >=`. `+` on byte operands is concatenation; mixing an `int` into a byte concatenation is an error until you widen it with `num2bin(value, width)`, because the width is consensus-visible. `arr.length` folds to the declared size. Array reads and writes accept `int` index expressions; runtime indices emit bounds checks.
 
 ### Built-ins
 
@@ -456,25 +450,15 @@ Keys resolve to constructor `pubkey` parameters, declared `pubkey` inputs, or th
 
 Witness `encoding` values: `compressed-33`, `schnorr-64`, `raw`, `raw-20`, `raw-32`, `scriptnum`. `updatedAt` changes on every compile; ignore it when diffing artifacts.
 
-The `source` field is a bundle object, replacing the previous single string. This is an intentional breaking format change: regenerate string-source artifacts with this compiler before loading them in updated consumers such as `arkade-bindgen`, and upgrade compiler and consumers together. It includes only files loaded for this compilation. Paths are normalized and relative, preserving import relationships; native compilation strips the common directory prefix from the loaded files. File contents are preserved verbatim. Recompile with the same compiler version using `compile_sources(source.entry, &source.files)`; `updatedAt` is the only dynamic field. Standalone compilation produces a one-file bundle with entry `main.ark`.
+The `source` bundle contains the entry file and every loaded dependency, preserving their text verbatim, including comments. Paths are normalized and relative; native compilation strips the common directory prefix. Recompile a bundle with the same compiler version using `compile_sources(&source.entry, &source.files)`. Standalone compilation produces a one-file bundle with entry `main.ark`.
 
-Previous compiler versions stripped comments from embedded source; this version retains them. Source hashes and whole-artifact comparisons across that boundary change even when contract logic is identical. Regenerate stored comparison baselines and use the same compiler version for reproducibility checks. Warnings from loaded dependencies remain visible and include paths relative to the source bundle root.
+Type-check and validation warnings identify their source file relative to the bundle root, including warnings from dependencies.
 
 ### Covenant stack ABI
 
 `constructorInputs`, `arkade.inputs`, and `witness` describe the source ABI, not the physical stack. Clients expand an array entry `oracles` of type `pubkey[3]` into `oracles.0`, `oracles.1`, `oracles.2`, and a struct entry into its scalar leaves in field order, recursively, using dotted paths such as `policy.primary.key`.
 
 Clients serialize covenant inputs in reverse `arkade.inputs` order. Every covenant `asm` opens with one `<name>` placeholder per expanded constructor input, also reversed, which instantiation replaces with data pushes before the covenant hash is computed. The VM installs the function witness first, so constructor values sit above function inputs; the body reaches everything through `OP_PICK` and friends and never emits function inputs as placeholders. After instantiation the only remaining placeholders are `<VTXO:Contract(<a>,<b>)>` tokens, which the runtime resolves to the child contract's scriptPubKey.
-
-## Upcoming
-
-The README tracks `master`. These are in review and will change what compiles:
-
-**Expression-indexed element writes ([#82](https://github.com/arkade-os/compiler/pull/82)).** `scale[writeIndex + 1] = 10;` and `state.values[i + 1] = next;` become legal with any `int` index expression, with lower and upper bound checks emitted at runtime. Reassignment of scalars and elements moves to `OP_PUT`, which shortens the emitted covenant. On `master` an element write needs a literal index.
-
-**Artifact static analysis ([#81](https://github.com/arkade-os/compiler/pull/81)).** A public `arkade_compiler::analysis::analyze_output(&ContractJson)` re-derives each leaf's closure from its ASM and re-runs the tapscript rules against the emitted artifact, so consumers can validate artifacts they did not compile themselves.
-
-**Wall-clock time.** Several draft example PRs reference `tx.offchainTime`, the TEE introspector's unix-seconds clock, as distinct from `tx.time` block height. It is not a recognized binding on `master` yet, so those examples keep it in comments.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,9 @@ Structs use their declared names; contract constants and static functions use `C
 
 Each file sees its own declarations and declarations directly imported from other files. Dependencies of imported code retain their defining scope and are loaded recursively, but are not re-exported. Struct and contract names must be unique across the loaded files; repeated imports of the same normalized path are deduplicated. Bindings cannot shadow a visible contract namespace. Missing files, unknown members, and circular imports are errors. Import chains are limited to 128 files. There are no aliases, selective imports, package search paths, remote imports, or library objects.
 
-`new Contract(args...)` requires the current contract or a directly imported contract and checks the constructor's argument count and types. It still emits a runtime VTXO placeholder; imported contracts do not add spend groups to the entry artifact. FujiSafe accepts its treasury and borrower burn-output witness programs as constructor inputs; clients construct these from the keys and asset commitment and preserve them on renewal.
+`new Contract(args...)` requires the current contract or a directly imported contract and checks the constructor's argument count and types. It still emits a runtime VTXO placeholder; imported contracts do not add spend groups to the entry artifact.
+
+**FujiSafe constructor migration:** the constructor now takes 12 arguments. Append `bytes32 treasuryBurnScript` and `bytes32 borrowerBurnScript`, in that order, after `exit`. Clients construct these burn-output witness programs from the corresponding keys and asset commitment and preserve both on renewal. Regenerate FujiSafe artifacts and bindings, and update construction and scriptPubKey verification code together. The old ten-argument layout is rejected by the compiler and cannot be used to derive outputs for the updated contract.
 
 The playground compiles against the files in its Explorer. Source paths appear above the editor; default shared SingleSig lives at `single_sig/single_sig.ark`. Imported files are editable, and shared links contain the files used by the selected contract. Sharing is limited to 1 MiB of encoded URL content and 4 MiB of decompressed UTF-8 source data.
 
@@ -449,12 +451,14 @@ Keys resolve to constructor `pubkey` parameters, declared `pubkey` inputs, or th
 | `functions[]` | Spend groups: `{ name, arkade?, leaves[] }` |
 | `arkade` | `{ inputs, asm }`; absent for groups made only of standalone leaves |
 | `leaves[]` | `{ name, witness, asm }`; `witness` lists spend-time values in source order, `injected: true` marks infrastructure signatures |
-| `warnings` | Type-check warnings, omitted when empty |
+| `warnings` | Type-check and validation warnings include their source file path; omitted when empty |
 | `source` | `{ entry, files }`: original entry source and every recursively imported file, including comments |
 
 Witness `encoding` values: `compressed-33`, `schnorr-64`, `raw`, `raw-20`, `raw-32`, `scriptnum`. `updatedAt` changes on every compile; ignore it when diffing artifacts.
 
 The `source` field is a bundle object, replacing the previous single string. This is an intentional breaking format change: regenerate string-source artifacts with this compiler before loading them in updated consumers such as `arkade-bindgen`, and upgrade compiler and consumers together. It includes only files loaded for this compilation. Paths are normalized and relative, preserving import relationships; native compilation strips the common directory prefix from the loaded files. File contents are preserved verbatim. Recompile with the same compiler version using `compile_sources(source.entry, &source.files)`; `updatedAt` is the only dynamic field. Standalone compilation produces a one-file bundle with entry `main.ark`.
+
+Previous compiler versions stripped comments from embedded source; this version retains them. Source hashes and whole-artifact comparisons across that boundary change even when contract logic is identical. Regenerate stored comparison baselines and use the same compiler version for reproducibility checks. Warnings from loaded dependencies remain visible and include paths relative to the source bundle root.
 
 ### Covenant stack ABI
 

--- a/arkade-bindgen/src/ir.rs
+++ b/arkade-bindgen/src/ir.rs
@@ -126,7 +126,7 @@ pub struct ContractIR {
     /// Spend groups in artifact order.
     pub groups: Vec<GroupIR>,
     /// Original .ark source code, if embedded.
-    pub source: Option<String>,
+    pub source: Option<arkade_compiler::models::SourceBundle>,
     /// Compiler version string.
     pub compiler_version: Option<String>,
 }

--- a/arkade-bindgen/tests/fixtures/htlc.json
+++ b/arkade-bindgen/tests/fixtures/htlc.json
@@ -138,7 +138,12 @@
       ]
     }
   ],
-  "source": "contract HTLC(\n  pubkey sender,\n  pubkey receiver,\n  bytes20 preimageHash,\n  int refundTime,\n  int exit\n) {\n  function claim() {\n    require(tx.outputs[0].value >= tx.inputs[0].value);\n  }\n  function refund() {\n    require(tx.outputs[0].value >= tx.inputs[0].value);\n  }\n\n  function claim(bytes preimage, signature serverSig, signature emulatorSig) tapscript {\n    require(hash160(preimage) == preimageHash);\n    require(checkMultisig([server, emulator], [serverSig, emulatorSig], 2));\n  }\n  function refund(signature serverSig, signature emulatorSig) tapscript {\n    require(tx.time >= refundTime);\n    require(checkMultisig([server, emulator], [serverSig, emulatorSig], 2));\n  }\n\n  function unilateral(signature senderSig) tapscript {\n    require(older(exit));\n    require(checkSig(senderSig, sender));\n  }\n}",
+  "source": {
+    "entry": "htlc.ark",
+    "files": {
+      "htlc.ark": "contract HTLC(\n  pubkey sender,\n  pubkey receiver,\n  bytes20 preimageHash,\n  int refundTime,\n  int exit\n) {\n  function claim() {\n    require(tx.outputs[0].value >= tx.inputs[0].value);\n  }\n  function refund() {\n    require(tx.outputs[0].value >= tx.inputs[0].value);\n  }\n\n  function claim(bytes preimage, signature serverSig, signature emulatorSig) tapscript {\n    require(hash160(preimage) == preimageHash);\n    require(checkMultisig([server, emulator], [serverSig, emulatorSig], 2));\n  }\n  function refund(signature serverSig, signature emulatorSig) tapscript {\n    require(tx.time >= refundTime);\n    require(checkMultisig([server, emulator], [serverSig, emulatorSig], 2));\n  }\n\n  function unilateral(signature senderSig) tapscript {\n    require(older(exit));\n    require(checkSig(senderSig, sender));\n  }\n}"
+    }
+  },
   "compiler": {
     "name": "arkade-compiler",
     "version": "0.1.0"

--- a/arkade-bindgen/tests/fixtures/single_sig.json
+++ b/arkade-bindgen/tests/fixtures/single_sig.json
@@ -75,7 +75,12 @@
       ]
     }
   ],
-  "source": "contract SingleSig(\n  pubkey user,\n  int exit\n) {\n  function spend(signature userSig) {\n    require(checkSig(userSig, user));\n  }\n\n  function unilateral(signature userSig) tapscript {\n    require(older(exit));\n    require(checkSig(userSig, user));\n  }\n}",
+  "source": {
+    "entry": "single_sig.ark",
+    "files": {
+      "single_sig.ark": "contract SingleSig(\n  pubkey user,\n  int exit\n) {\n  function spend(signature userSig) {\n    require(checkSig(userSig, user));\n  }\n\n  function unilateral(signature userSig) tapscript {\n    require(older(exit));\n    require(checkSig(userSig, user));\n  }\n}"
+    }
+  },
   "compiler": {
     "name": "arkade-compiler",
     "version": "0.1.0"

--- a/examples/arkade_kitties/arkade_kitties.ark
+++ b/examples/arkade_kitties/arkade_kitties.ark
@@ -12,7 +12,7 @@
 // - Each kitty is a unique asset controlled by speciesControlId
 // - Breeding creates a new kitty with isFresh=1
 
-import "single_sig.ark";
+import "../single_sig/single_sig.ark";
 
 contract ArkadeKitties(
     bytes32 speciesControlIdTxid,

--- a/examples/bonds/bond_mint.ark
+++ b/examples/bonds/bond_mint.ark
@@ -73,7 +73,7 @@
 //   borrower is the only relevant signer for unilateral collateral recovery.
 //   See docs/bonds.md §"Unilateral exits".
 
-import "single_sig.ark";
+import "../single_sig/single_sig.ark";
 
 contract BondMint(
   pubkey  borrowerPk,

--- a/examples/fuji_safe/fuji_safe.ark
+++ b/examples/fuji_safe/fuji_safe.ark
@@ -19,15 +19,14 @@ contract FujiSafe(
   // The asset pair identifier
   bytes assetPair,
   // Exit timelock in blocks
-  int exit
+  int exit,
+  // Burn-output witness programs, constructed from the keys and asset commitment by the client
+  bytes32 treasuryBurnScript,
+  bytes32 borrowerBurnScript
 ) {
   // Helper function to verify treasury Fuji token burning via Taproot output
   private function verifyTreasuryFujiBurning() {
-    // In Taproot, we verify the output is a P2TR that commits to our asset
-    bytes p2trScript = new P2TR(treasuryPk, assetCommitmentHash);
-
-    // Verify output 0 has the correct P2TR scriptPubKey and value
-    require(tx.outputs[0].scriptPubKey == p2trScript, "P2TR output mismatch");
+    require(tx.outputs[0].scriptPubKey == treasuryBurnScript, "burn output mismatch");
     require(tx.outputs[0].value == borrowAmount, "Value mismatch");
   }
 
@@ -67,8 +66,7 @@ contract FujiSafe(
   // Private Redemption: Only owner can unlock all collateral with key when burning Fuji
   function redeem(signature borrowerSig) {
     // Verify burning of Fuji token using borrower key
-    bytes p2trScript = new P2TR(borrowerPk, assetCommitmentHash);
-    require(tx.outputs[0].scriptPubKey == p2trScript, "P2TR output mismatch");
+    require(tx.outputs[0].scriptPubKey == borrowerBurnScript, "burn output mismatch");
     require(tx.outputs[0].value == borrowAmount, "Value mismatch");
 
     // Require borrower signature
@@ -83,7 +81,8 @@ contract FujiSafe(
     require(
       tx.outputs[0].scriptPubKey == new FujiSafe(
         assetCommitmentHash, borrowAmount, borrowerPk, treasuryPk,
-        expirationTimeout, priceLevel, setupTimestamp, oraclePk, assetPair, exit
+        expirationTimeout, priceLevel, setupTimestamp, oraclePk, assetPair, exit,
+        treasuryBurnScript, borrowerBurnScript
       ),
       "contract mismatch"
     );

--- a/examples/layerzero/endpoint.ark
+++ b/examples/layerzero/endpoint.ark
@@ -82,6 +82,8 @@
 //     117..149 remoteRecipient
 //     149..181 messageHash
 
+import "receive_marker.ark";
+
 contract Endpoint(
   bytes32 endpointCtrlAssetIdTxid,
   int     endpointCtrlAssetIdGidx,

--- a/examples/layerzero/oapp.ark
+++ b/examples/layerzero/oapp.ark
@@ -31,6 +31,8 @@
 //     111..143  remoteRecipient
 //     143..175  messageHash
 
+import "send_marker.ark";
+
 contract OApp(
   bytes32 oappCtrlAssetIdTxid,
   int     oappCtrlAssetIdGidx,

--- a/examples/non_interactive_swap/non_interactive_swap.ark
+++ b/examples/non_interactive_swap/non_interactive_swap.ark
@@ -6,7 +6,7 @@
 // - cancel cooperative: makerSig + serverSig + after(expiration)
 // - unilateral: makerSig + CSV (maker recovers if no taker)
 
-import "single_sig.ark";
+import "../single_sig/single_sig.ark";
 
 contract NonInteractiveSwap(
   // Maker's public key (creator of the swap offer)

--- a/examples/options/cash_secured_put.ark
+++ b/examples/options/cash_secured_put.ark
@@ -33,7 +33,7 @@
 // Transfer functions are retained below but disabled until dynamic taproot
 // reconstruction is supported.
 
-import "single_sig.ark";
+import "../single_sig/single_sig.ark";
 
 contract CashSecuredPut(
   pubkey  sellerPk,         // option writer; locks the stable

--- a/examples/options/covered_call.ark
+++ b/examples/options/covered_call.ark
@@ -36,7 +36,7 @@
 // Transfer functions are retained below but disabled until dynamic taproot
 // reconstruction is supported.
 
-import "single_sig.ark";
+import "../single_sig/single_sig.ark";
 
 contract CoveredCall(
   pubkey  sellerPk,         // option writer; locks the BTC

--- a/examples/stability/stability_vault.ark
+++ b/examples/stability/stability_vault.ark
@@ -27,7 +27,7 @@
 //   At settlement the caller supplies (oraclePrice, oracleTime, oracleSig).
 //   Freshness: tx.offchainTime - oracleTime <= 600 seconds.
 
-import "single_sig.ark";
+import "../single_sig/single_sig.ark";
 
 contract StabilityVault(
   pubkey  seekerPk,           // current holder of the USD claim

--- a/playground/arkade-language.js
+++ b/playground/arkade-language.js
@@ -6,7 +6,7 @@ const arkadeMonarch = {
 
     keywords: [
         'contract', 'struct', 'function', 'tapscript', 'require', 'if', 'else',
-        'for', 'in', 'let', 'private', 'public', 'static', 'const', 'return', 'new'
+        'for', 'in', 'let', 'private', 'public', 'static', 'const', 'return', 'new', 'import'
     ],
 
     typeKeywords: [
@@ -36,7 +36,7 @@ const arkadeMonarch = {
             [/\s+/, 'white'],
 
             // Keywords
-            [/\b(contract|struct|function|tapscript|require|if|else|for|in|let|private|public|static|const|return|new)\b/, 'keyword'],
+            [/\b(contract|struct|function|tapscript|require|if|else|for|in|let|private|public|static|const|return|new|import)\b/, 'keyword'],
 
             // Types
             [/\b(pubkey|signature|bytes32|bytes20|bytes|asset|int|bool)\b/, 'type'],
@@ -46,9 +46,6 @@ const arkadeMonarch = {
 
             // Transaction/this keywords
             [/\b(tx|this)\b/, 'variable.predefined'],
-
-            // P2TR constructor
-            [/\bP2TR\b/, 'type'],
 
             // Numbers
             [/\b\d+\b/, 'number'],
@@ -168,8 +165,7 @@ const arkadeCompletions = [
     { label: 'tx.outputs', kind: 'Property', insertText: 'tx.outputs[${1:o}]', insertTextRules: 4, detail: 'Transaction outputs' },
     { label: 'tx.input.current', kind: 'Property', insertText: 'tx.input.current', detail: 'Current input' },
 
-    // P2TR
-    { label: 'P2TR', kind: 'Constructor', insertText: 'new P2TR(${1:internalKey})', insertTextRules: 4, detail: 'Create P2TR scriptPubKey' },
+    { label: 'import', kind: 'Keyword', insertText: 'import "${1:./contract.ark}";', insertTextRules: 4, detail: 'Import structs and a contract from a relative file' },
 ];
 
 // Export all parts

--- a/playground/imports.test.mjs
+++ b/playground/imports.test.mjs
@@ -1,0 +1,68 @@
+// Run after ./playground/build.sh with node playground/imports.test.mjs.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import * as contracts from './contracts.js';
+import { initSync, compile_sources } from './pkg/arkade_compiler.js';
+
+initSync({ module: fs.readFileSync(new URL('./pkg/arkade_compiler_bg.wasm', import.meta.url)) });
+const context = vm.createContext({
+    contracts, compile_sources,
+    document: { addEventListener() {} },
+    localStorage: { setItem() {} },
+    location: { hash: '' },
+    CompressionStream, DecompressionStream, TextEncoder, TextDecoder, btoa, atob,
+    console: { warn() {} },
+});
+const source = fs.readFileSync(new URL('./main.js', import.meta.url), 'utf8');
+vm.runInContext(source.replace(/^import .*;$/gm, ''), context);
+
+const selections = vm.runInContext(`[
+    ...Object.entries(projects).flatMap(([id, project]) => Object.keys(project.files).map(file => [id, file])),
+    ...Object.keys(examples).map(id => [null, id]),
+]`, context);
+for (const [project, file] of selections) {
+    context.selection = [project, file];
+    const input = vm.runInContext(`
+        [currentProject, currentFile] = selection;
+        editor = { getValue: () => currentProject ? projects[currentProject].files[currentFile] : examples[currentFile].code };
+        compilationSources();
+    `, context);
+    const output = JSON.parse(compile_sources(input.entry, JSON.stringify(input.files)));
+    const bundle = output.source;
+    const rebuilt = JSON.parse(compile_sources(bundle.entry, JSON.stringify(bundle.files)));
+    rebuilt.updatedAt = output.updatedAt;
+    assert.deepEqual(rebuilt, output);
+}
+
+context.bundle = {
+    entry: 'vault/main.ark',
+    files: {
+        'vault/main.ark': 'import "../shared/fees.ark"; contract Vault() { function spend() { require(Fees.VALUE == 7); } }',
+        'shared/fees.ark': 'contract Fees() { const int VALUE = 7; }',
+    },
+};
+await vm.runInContext(`
+    compressCode(JSON.stringify(bundle)).then(encoded => { location.hash = '#project=' + encoded; });
+`, context);
+const shared = await vm.runInContext('loadFromUrl()', context);
+assert.deepEqual(JSON.parse(JSON.stringify(shared)), context.bundle);
+context.shared = shared;
+const sharedInput = vm.runInContext(`
+    projects.shared = { name: 'Shared', files: shared.files };
+    currentProject = 'shared';
+    currentFile = shared.entry;
+    editor = { getValue: () => projects.shared.files[currentFile] };
+    compilationSources();
+`, context);
+assert.equal(JSON.parse(compile_sources(sharedInput.entry, JSON.stringify(sharedInput.files))).contractName, 'Vault');
+
+// Compilation reads edits in dependencies, including files that are not selected.
+vm.runInContext(`projects.shared.files['shared/fees.ark'] = 'contract Fees() { const int VALUE = 8; }';`, context);
+const edited = vm.runInContext('compilationSources()', context);
+assert.match(JSON.parse(compile_sources(edited.entry, JSON.stringify(edited.files))).source.files['shared/shared/fees.ark'], /VALUE = 8/);
+
+context.bundle = { entry: '<img>.ark', files: { '<img>.ark': 'contract Invalid() {}' } };
+await vm.runInContext(`compressCode(JSON.stringify(bundle)).then(encoded => { location.hash = '#project=' + encoded; });`, context);
+assert.equal(await vm.runInContext('loadFromUrl()', context), null);
+console.log(`Verified ${selections.length} playground entries, source round trips, shared projects, and dependency edits.`);

--- a/playground/imports.test.mjs
+++ b/playground/imports.test.mjs
@@ -2,6 +2,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import vm from 'node:vm';
+import { deflateRawSync } from 'node:zlib';
 import * as contracts from './contracts.js';
 import { initSync, compile_sources } from './pkg/arkade_compiler.js';
 
@@ -11,7 +12,7 @@ const context = vm.createContext({
     document: { addEventListener() {} },
     localStorage: { setItem() {} },
     location: { hash: '' },
-    CompressionStream, DecompressionStream, TextEncoder, TextDecoder, btoa, atob,
+    Blob, CompressionStream, DecompressionStream, TextEncoder, TextDecoder, btoa, atob,
     console: { warn() {} },
 });
 const source = fs.readFileSync(new URL('./main.js', import.meta.url), 'utf8');
@@ -65,4 +66,21 @@ assert.match(JSON.parse(compile_sources(edited.entry, JSON.stringify(edited.file
 context.bundle = { entry: '<img>.ark', files: { '<img>.ark': 'contract Invalid() {}' } };
 await vm.runInContext(`compressCode(JSON.stringify(bundle)).then(encoded => { location.hash = '#project=' + encoded; });`, context);
 assert.equal(await vm.runInContext('loadFromUrl()', context), null);
+const encodedLimit = vm.runInContext('MAX_SHARED_ENCODED_CHARS', context);
+const decodedLimit = vm.runInContext('MAX_SHARED_DECODED_BYTES', context);
+context.encoded = 'A'.repeat(encodedLimit + 1);
+await assert.rejects(vm.runInContext('decompressCode(encoded)', context), /Encoded share link exceeds/);
+for (const size of [decodedLimit, decodedLimit + 1]) {
+    context.encoded = deflateRawSync(Buffer.alloc(size, 'a')).toString('base64url');
+    const decoded = vm.runInContext('decompressCode(encoded)', context);
+    if (size === decodedLimit) assert.equal((await decoded).length, size);
+    else await assert.rejects(decoded, /Shared source exceeds/);
+}
+context.encoded = 'AA';
+await assert.rejects(vm.runInContext('decompressCode(encoded)', context));
+for (const prefix of ['#code=', '#project=']) {
+    context.location.hash = prefix + deflateRawSync(Buffer.alloc(decodedLimit + 1, 'a')).toString('base64url');
+    assert.equal(await vm.runInContext('loadFromUrl()', context), null);
+}
+await assert.rejects(vm.runInContext("compressCode('a'.repeat(MAX_SHARED_DECODED_BYTES + 1))", context), /Shared source exceeds/);
 console.log(`Verified ${selections.length} playground entries, source round trips, shared projects, and dependency edits.`);

--- a/playground/main.js
+++ b/playground/main.js
@@ -1,6 +1,6 @@
 // Arkade Playground - Main Application
 // Import default export for WASM initialization, plus the exported functions
-import initWasm, { compile, version, validate, init as initPanicHook } from './pkg/arkade_compiler.js';
+import initWasm, { compile_sources, version, init as initPanicHook } from './pkg/arkade_compiler.js';
 import * as contracts from './contracts.js';
 import { generateBindings, AVAILABLE_TARGETS } from './codegen.js';
 
@@ -49,6 +49,14 @@ const examples = {
     fuji_safe: { name: 'FujiSafe', code: contracts.fuji_safe },
     struct_vault: { name: 'StructVault', code: contracts.struct_vault },
     swap: { name: 'NonInteractiveSwap', code: contracts.non_interactive_swap },
+};
+
+const examplePaths = {
+    single_sig: 'single_sig/single_sig.ark',
+    htlc: 'htlc/htlc.ark',
+    fuji_safe: 'fuji_safe/fuji_safe.ark',
+    struct_vault: 'struct_vault/struct_vault.ark',
+    swap: 'non_interactive_swap/non_interactive_swap.ark',
 };
 
 // Global state
@@ -138,8 +146,16 @@ async function decompressCode(b64url) {
 
 async function shareContract() {
     if (!editor) return;
-    const encoded = await compressCode(editor.getValue());
-    const url = `${location.origin}${location.pathname}#code=${encoded}`;
+    let bundle;
+    try {
+        const { entry, files } = compilationSources();
+        bundle = JSON.parse(compile_sources(entry, JSON.stringify(files))).source;
+    } catch (error) {
+        showError(error.toString());
+        return;
+    }
+    const encoded = await compressCode(JSON.stringify(bundle));
+    const url = `${location.origin}${location.pathname}#project=${encoded}`;
     await navigator.clipboard.writeText(url);
     const btn = document.getElementById('share-btn');
     const orig = btn.innerHTML;
@@ -148,9 +164,20 @@ async function shareContract() {
 }
 
 async function loadFromUrl() {
-    if (!location.hash.startsWith('#code=')) return null;
+    const isProject = location.hash.startsWith('#project=');
+    if (!isProject && !location.hash.startsWith('#code=')) return null;
     try {
-        return await decompressCode(location.hash.slice(6));
+        const source = await decompressCode(location.hash.slice(isProject ? 9 : 6));
+        if (!isProject) return { entry: 'main.ark', files: { 'main.ark': source } };
+        const bundle = JSON.parse(source);
+        if (typeof bundle.entry !== 'string' || !bundle.files || Array.isArray(bundle.files)
+            || typeof bundle.files !== 'object' || !Object.hasOwn(bundle.files, bundle.entry)
+            || Object.entries(bundle.files).some(([path, text]) => typeof text !== 'string'
+                || !path.endsWith('.ark') || /[<>"'&\\:\u0000-\u001f]/.test(path)
+                || path.split('/').some(part => !part || part === '.' || part === '..'))) {
+            throw new Error('Invalid shared source bundle');
+        }
+        return bundle;
     } catch (e) {
         console.warn('Failed to decode shared contract from URL:', e);
         return null;
@@ -1014,7 +1041,8 @@ function closeTab(tabId) {
 
 // Update current file name display
 function updateCurrentFileName(name) {
-    document.getElementById('current-file').textContent = name;
+    document.getElementById('current-file').textContent = currentProject
+        ? `${currentProject}/${name}` : examplePaths[currentFile] || `_examples/${currentFile}.ark`;
 }
 
 // Initialize Monaco Editor
@@ -1089,12 +1117,12 @@ function initMonaco() {
         });
 
         // Load shared contract from URL hash if present
-        window._urlCodePromise.then(urlCode => {
-            if (urlCode) {
-                const id = uniqueId('shared', examples);
-                examples[id] = { name: 'Shared', code: urlCode };
+        window._urlCodePromise.then(bundle => {
+            if (bundle) {
+                const id = uniqueId('shared', projects);
+                projects[id] = { name: 'Shared', description: '', files: bundle.files };
                 saveToStorage();
-                selectExample(id);
+                selectProjectFile(id, bundle.entry);
                 history.replaceState(null, '', location.pathname + location.search);
             }
         });
@@ -1124,6 +1152,25 @@ function markCompiled() {
     btn.classList.add('compiled');
 }
 
+function compilationSources() {
+    saveCurrentFile();
+    const files = {};
+    for (const [id, project] of Object.entries(projects)) {
+        for (const [name, source] of Object.entries(project.files)) {
+            files[`${id}/${name}`] = source;
+        }
+    }
+    for (const [id, example] of Object.entries(examples)) {
+        const path = examplePaths[id] || `_examples/${id}.ark`;
+        if (Object.hasOwn(files, path)) throw new Error(`Duplicate source path: ${path}`);
+        files[path] = example.code;
+    }
+    const entry = currentProject ? `${currentProject}/${currentFile}`
+        : examplePaths[currentFile] || `_examples/${currentFile || 'main'}.ark`;
+    files[entry] = editor.getValue();
+    return { entry, files };
+}
+
 // Compile the source code
 function doCompile() {
     if (!wasmReady || !editor) return;
@@ -1132,7 +1179,8 @@ function doCompile() {
     clearErrors();
 
     try {
-        const result = compile(source);
+        const { entry, files } = compilationSources();
+        const result = compile_sources(entry, JSON.stringify(files));
         lastCompiledSource = source;
         displayJson(result);
         displayAsm(result);

--- a/playground/main.js
+++ b/playground/main.js
@@ -109,28 +109,13 @@ function loadFromStorage() {
 
 // ── URL sharing ───────────────────────────────────────────────────
 
-async function compressCode(text) {
-    const stream = new CompressionStream('deflate-raw');
-    const writer = stream.writable.getWriter();
-    writer.write(new TextEncoder().encode(text));
-    writer.close();
-    const chunks = [];
-    const reader = stream.readable.getReader();
-    let result;
-    while (!(result = await reader.read()).done) chunks.push(result.value);
-    const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
-    let i = 0;
-    for (const c of chunks) { out.set(c, i); i += c.length; }
-    let bin = '';
-    for (let j = 0; j < out.length; j++) bin += String.fromCharCode(out[j]);
-    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
+const MAX_SHARED_ENCODED_CHARS = 1024 * 1024;
+const MAX_SHARED_DECODED_BYTES = 4 * 1024 * 1024;
 
-async function decompressCode(b64url) {
-    const bin = atob(b64url.replace(/-/g, '+').replace(/_/g, '/'));
-    const data = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) data[i] = bin.charCodeAt(i);
-    const stream = new DecompressionStream('deflate-raw');
+async function compressCode(text) {
+    const data = new TextEncoder().encode(text);
+    if (data.length > MAX_SHARED_DECODED_BYTES) throw new Error('Shared source exceeds 4 MiB');
+    const stream = new CompressionStream('deflate-raw');
     const writer = stream.writable.getWriter();
     writer.write(data);
     writer.close();
@@ -141,20 +126,51 @@ async function decompressCode(b64url) {
     const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
     let i = 0;
     for (const c of chunks) { out.set(c, i); i += c.length; }
+    let bin = '';
+    for (let j = 0; j < out.length; j++) bin += String.fromCharCode(out[j]);
+    const encoded = btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    if (encoded.length > MAX_SHARED_ENCODED_CHARS) throw new Error('Encoded share link exceeds 1 MiB');
+    return encoded;
+}
+
+async function decompressCode(b64url) {
+    if (b64url.length > MAX_SHARED_ENCODED_CHARS) throw new Error('Encoded share link exceeds 1 MiB');
+    const bin = atob(b64url.replace(/-/g, '+').replace(/_/g, '/'));
+    const data = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) data[i] = bin.charCodeAt(i);
+    const reader = new Blob([data]).stream().pipeThrough(new DecompressionStream('deflate-raw')).getReader();
+    const chunks = [];
+    let size = 0;
+    try {
+        let result;
+        while (!(result = await reader.read()).done) {
+            size += result.value.length;
+            if (size > MAX_SHARED_DECODED_BYTES) {
+                await reader.cancel();
+                throw new Error('Shared source exceeds 4 MiB');
+            }
+            chunks.push(result.value);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+    const out = new Uint8Array(size);
+    let i = 0;
+    for (const c of chunks) { out.set(c, i); i += c.length; }
     return new TextDecoder().decode(out);
 }
 
 async function shareContract() {
     if (!editor) return;
-    let bundle;
+    let encoded;
     try {
         const { entry, files } = compilationSources();
-        bundle = JSON.parse(compile_sources(entry, JSON.stringify(files))).source;
+        const bundle = JSON.parse(compile_sources(entry, JSON.stringify(files))).source;
+        encoded = await compressCode(JSON.stringify(bundle));
     } catch (error) {
         showError(error.toString());
         return;
     }
-    const encoded = await compressCode(JSON.stringify(bundle));
     const url = `${location.origin}${location.pathname}#project=${encoded}`;
     await navigator.clipboard.writeText(url);
     const btn = document.getElementById('share-btn');

--- a/src/compiler/concat.rs
+++ b/src/compiler/concat.rs
@@ -35,7 +35,7 @@ pub(crate) fn rewrite_concat_ops(contract: &mut crate::models::Contract) -> Resu
     };
     let constructor_scope =
         crate::typechecker::build_scope_with_structs(&contract.parameters, &contract.structs);
-    for function in &mut contract.functions {
+    for function in contract.functions.iter_mut().filter(|f| !f.is_imported()) {
         let mut scope = constructor_scope.clone();
         scope.extend(crate::typechecker::build_scope_with_structs(
             &function.parameters,

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -10,7 +10,7 @@ pub(crate) fn fold(contract: &mut Contract) -> Result<(), String> {
     if values.is_empty() {
         return Ok(());
     }
-    for function in &mut contract.functions {
+    for function in contract.functions.iter_mut().filter(|f| !f.is_imported()) {
         fold_statements(&mut function.statements, &values);
     }
     for tapscript in &mut contract.tapscripts {
@@ -84,6 +84,12 @@ fn collect(contract: &Contract) -> Result<HashMap<String, String>, String> {
             ));
         }
         values.insert(name.clone(), text.clone());
+    }
+    for constant in contract.constants.iter().filter(|c| !c.name.contains('.')) {
+        values.insert(
+            format!("{}.{}", contract.name, constant.name),
+            values[&constant.name].clone(),
+        );
     }
     Ok(values)
 }
@@ -161,11 +167,9 @@ fn fold_requirement(requirement: &mut Requirement, values: &HashMap<String, Stri
 
 fn fold_expression(expression: &mut Expression, values: &HashMap<String, String>) {
     match expression {
-        Expression::Variable(name) => {
-            if let Some(text) = values.get(name.as_str()) {
-                *expression = Expression::Literal(text.clone());
-                return;
-            }
+        Expression::Variable(name) | Expression::Property(name) if values.contains_key(name) => {
+            *expression = Expression::Literal(values[name].clone());
+            return;
         }
         Expression::Property(name) => fold_named_index(name, values),
         Expression::CheckSigExpr { signature, pubkey } => {

--- a/src/compiler/functions.rs
+++ b/src/compiler/functions.rs
@@ -152,15 +152,17 @@ impl Generator {
                 self.value_leaves(&parameter.name, &parameter.param_type)?,
             ));
         }
-        // Only constructor bindings cross the call boundary; caller temporaries are hidden too.
+        // Static calls hide all caller bindings; instance helpers retain constructor state.
         for (index, item) in self.stack[..baseline].iter_mut().enumerate() {
-            if !matches!(
-                item,
-                StackItem::Binding {
-                    kind: BindingKind::Constructor,
-                    ..
-                }
-            ) {
+            if function.is_static
+                || !matches!(
+                    item,
+                    StackItem::Binding {
+                        kind: BindingKind::Constructor,
+                        ..
+                    }
+                )
+            {
                 *item = StackItem::Binding {
                     name: format!("$caller:{index}"),
                     kind: BindingKind::Local,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,5 +1,5 @@
 use crate::models::{
-    ArkadeCovenant, AssignmentTarget, CompilerInfo, ContractJson, Expression, Function,
+    ArkadeCovenant, AssignmentTarget, CompilerInfo, Contract, ContractJson, Expression, Function,
     FunctionInput, Parameter, Requirement, Statement,
 };
 use crate::opcodes::{
@@ -20,7 +20,6 @@ use crate::opcodes::{
     OP_SIGHASH, OP_SIZE, OP_SUB, OP_SUBSTR, OP_SWAP, OP_TWEAKVERIFY, OP_TXID, OP_TXWEIGHT,
     OP_VERIFY,
 };
-use crate::parser;
 use crate::typechecker::{self};
 use crate::validator::{self, Severity};
 use chrono::Utc;
@@ -33,6 +32,7 @@ mod asset;
 mod comparison;
 mod concat;
 mod constants;
+pub(crate) use constants::fold as fold_constants;
 mod expr;
 mod functions;
 mod introspection;
@@ -627,24 +627,6 @@ impl Generator {
     }
 }
 
-fn strip_comments(source: &str) -> String {
-    source
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.starts_with("//") {
-                None
-            } else if let Some(idx) = line.find("//") {
-                let without_comment = line[..idx].trim_end();
-                Some(without_comment.to_string())
-            } else {
-                Some(line.to_string())
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 /// Compiles an Arkade Script contract into a JSON-serializable structure.
 ///
 /// Takes source code, parses it into an AST, and transforms it into a ContractJson
@@ -660,19 +642,22 @@ fn strip_comments(source: &str) -> String {
 ///
 /// A Result containing a ContractJson or an error message
 pub fn compile(source_code: &str) -> Result<ContractJson, String> {
-    let mut contract = match parser::parse(source_code) {
-        Ok(contract) => contract,
-        Err(e) => return Err(format!("Parse error: {}", e)),
-    };
+    crate::imports::compile_sources(
+        "main.ark",
+        &std::collections::BTreeMap::from([("main.ark".to_string(), source_code.to_string())]),
+    )
+}
 
-    constants::fold(&mut contract)?;
-
-    typechecker::resolve_group_properties(&mut contract);
+pub(crate) fn prepare(
+    contract: &mut Contract,
+    require_entrypoint: bool,
+) -> Result<Vec<String>, String> {
+    typechecker::resolve_group_properties(contract);
 
     // ── Semantic validation ────────────────────────────────────────────────
     // Catch errors the PEG grammar cannot express (duplicate names, missing
     // timelocks, etc.) before we attempt code generation.
-    let ast_issues = validator::validate_ast(&contract);
+    let ast_issues = validator::validate_ast(contract, require_entrypoint);
     if validator::has_errors(&ast_issues) {
         let errors: Vec<String> = ast_issues
             .iter()
@@ -683,12 +668,12 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
     }
 
     // ── Rewrite pass: route `+` to OP_CAT when operands are bytes-like ─────
-    rewrite_concat_ops(&mut contract)?;
+    rewrite_concat_ops(contract)?;
 
     // ── Type checking ──────────────────────────────────────────────────────
     // Run the type checker. Errors are non-fatal and returned as warnings on
     // ContractJson so callers (CLI, WASM, tests) can surface them as they see fit.
-    let type_errors = typechecker::check_contract(&contract);
+    let type_errors = typechecker::check_contract(contract);
     let mut warnings: Vec<String> = type_errors
         .iter()
         .map(|e| format!("warning[type]: {}", e.message))
@@ -701,6 +686,14 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
         }
     }
 
+    Ok(warnings)
+}
+
+pub(crate) fn emit(
+    contract: &Contract,
+    source: crate::models::SourceBundle,
+    warnings: Vec<String>,
+) -> Result<ContractJson, String> {
     let parameters = contract.parameters.clone();
 
     let mut json = ContractJson {
@@ -708,7 +701,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
         structs: contract.structs.clone(),
         parameters,
         functions: Vec::new(),
-        source: Some(strip_comments(source_code)),
+        source: Some(source),
         compiler: Some(CompilerInfo {
             name: "arkade-compiler".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -732,7 +725,7 @@ pub fn compile(source_code: &str) -> Result<ContractJson, String> {
         );
     }
 
-    json.functions = tapscript::build_function_groups(&contract, covenants)?;
+    json.functions = tapscript::build_function_groups(contract, covenants)?;
 
     // ── Output invariant check ─────────────────────────────────────────────
     // Self-check the emitted JSON for structural invariants.

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -112,16 +112,13 @@ fn compile_with_loader(
         &mut HashMap::new(),
     )?;
     let root = &modules[entry];
-    let warnings = modules
-        .values()
-        .flat_map(|module| module.warnings.clone())
-        .collect();
     let mut bundle = SourceBundle {
         entry: entry.to_string(),
         files,
     };
+    let mut base = PathBuf::new();
     if filesystem {
-        let mut base = Path::new(entry)
+        base = Path::new(entry)
             .parent()
             .expect("absolute entry")
             .to_path_buf();
@@ -150,6 +147,20 @@ fn compile_with_loader(
             })
             .collect();
     }
+    let warnings = modules
+        .iter()
+        .flat_map(|(path, module)| {
+            let path = Path::new(path)
+                .strip_prefix(&base)
+                .expect("common root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            module
+                .warnings
+                .iter()
+                .map(move |warning| format!("{warning} ({path})"))
+        })
+        .collect();
     compiler::emit(&root.contract, bundle, warnings)
 }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,0 +1,531 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
+
+use crate::models::{self, Contract, ContractJson, Expression, SourceBundle, Statement};
+use crate::{compiler, parser, typechecker};
+
+// Dependency definitions are copied per module; use a shared symbol table if quadratic copying becomes costly.
+struct Module {
+    contract: Contract,
+    structs: HashSet<String>,
+    warnings: Vec<String>,
+}
+
+pub(crate) fn compile_sources(
+    entry: &str,
+    files: &BTreeMap<String, String>,
+) -> Result<ContractJson, String> {
+    let entry = relative_path(entry)?;
+    let mut normalized = BTreeMap::new();
+    for (path, source) in files {
+        let path = relative_path(path)?;
+        if normalized.insert(path.clone(), source.clone()).is_some() {
+            return Err(format!("duplicate source path '{path}'"));
+        }
+    }
+    compile_with_loader(
+        &entry,
+        |path| {
+            normalized.get(path).cloned().ok_or_else(|| format!(
+                "source file '{path}' not found; imports require source files supplied through compile_sources or compile_file"
+            ))
+        },
+        false,
+    )
+}
+
+pub(crate) fn compile_file(path: &Path) -> Result<ContractJson, String> {
+    let absolute = std::path::absolute(path).map_err(|e| e.to_string())?;
+    let entry = normalize(&absolute)?;
+    compile_with_loader(
+        &entry,
+        |path| std::fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}")),
+        true,
+    )
+}
+
+fn relative_path(path: &str) -> Result<String, String> {
+    if Path::new(path).is_absolute() || path.contains('\\') || path.contains(':') {
+        return Err(format!(
+            "source path '{path}' must be a relative .ark path using '/'"
+        ));
+    }
+    normalize(Path::new(path))
+}
+
+fn normalize(path: &Path) -> Result<String, String> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(format!("path '{}' escapes the source root", path.display()));
+                }
+            }
+            _ => normalized.push(component),
+        }
+    }
+    if normalized
+        .extension()
+        .is_none_or(|extension| extension != "ark")
+    {
+        return Err(format!(
+            "source path '{}' must have .ark extension",
+            path.display()
+        ));
+    }
+    normalized
+        .into_os_string()
+        .into_string()
+        .map_err(|_| "source paths must be UTF-8".to_string())
+}
+
+fn import_path(importer: &str, import: &str) -> Result<String, String> {
+    if Path::new(import).is_absolute() || import.contains('\\') || import.contains(':') {
+        return Err(format!(
+            "import '{import}' must be a relative .ark path using '/'"
+        ));
+    }
+    normalize(
+        &Path::new(importer)
+            .parent()
+            .unwrap_or(Path::new(""))
+            .join(import),
+    )
+}
+
+fn compile_with_loader(
+    entry: &str,
+    mut read: impl FnMut(&str) -> Result<String, String>,
+    filesystem: bool,
+) -> Result<ContractJson, String> {
+    let mut modules = BTreeMap::new();
+    let mut files = BTreeMap::new();
+    load(
+        entry,
+        entry,
+        &mut read,
+        &mut modules,
+        &mut files,
+        &mut Vec::new(),
+        &mut HashMap::new(),
+    )?;
+    let root = &modules[entry];
+    let warnings = modules
+        .values()
+        .flat_map(|module| module.warnings.clone())
+        .collect();
+    let mut bundle = SourceBundle {
+        entry: entry.to_string(),
+        files,
+    };
+    if filesystem {
+        let mut base = Path::new(entry)
+            .parent()
+            .expect("absolute entry")
+            .to_path_buf();
+        for path in bundle.files.keys() {
+            while !Path::new(path).starts_with(&base) {
+                base.pop();
+            }
+        }
+        bundle.entry = Path::new(entry)
+            .strip_prefix(&base)
+            .expect("common root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        bundle.files = bundle
+            .files
+            .into_iter()
+            .map(|(path, source)| {
+                (
+                    Path::new(&path)
+                        .strip_prefix(&base)
+                        .expect("common root")
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                    source,
+                )
+            })
+            .collect();
+    }
+    compiler::emit(&root.contract, bundle, warnings)
+}
+
+fn load(
+    path: &str,
+    entry: &str,
+    read: &mut impl FnMut(&str) -> Result<String, String>,
+    modules: &mut BTreeMap<String, Module>,
+    files: &mut BTreeMap<String, String>,
+    active: &mut Vec<String>,
+    declarations: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    if modules.contains_key(path) {
+        return Ok(());
+    }
+    if active.iter().any(|p| p == path) {
+        return Err(format!(
+            "circular import: {} -> {path}",
+            active.join(" -> ")
+        ));
+    }
+    // Recursive loading is bounded; use an iterative traversal for deeper projects.
+    if active.len() >= 128 {
+        return Err("import depth exceeds 128 files".to_string());
+    }
+    active.push(path.to_string());
+    let result = (|| {
+        let source = read(path)?;
+        let imports = parser::imports(&source)?;
+        let mut dependencies = Vec::new();
+        for import in imports {
+            let dependency = import_path(path, &import)?;
+            load(
+                &dependency,
+                entry,
+                read,
+                modules,
+                files,
+                active,
+                declarations,
+            )?;
+            if !dependencies.contains(&dependency) {
+                dependencies.push(dependency);
+            }
+        }
+        let mut constants = Vec::new();
+        for dependency in &dependencies {
+            let contract = &modules[dependency].contract;
+            for constant in contract.constants.iter().filter(|c| !c.name.contains('.')) {
+                let mut constant = constant.clone();
+                constant.name = format!("{}.{}", contract.name, constant.name);
+                constants.push(constant);
+            }
+        }
+        let mut contract = parser::parse_with_constants(&source, &constants)?;
+        let own_structs: HashSet<_> = contract.structs.iter().map(|s| s.name.clone()).collect();
+        if models::is_builtin_type(&contract.name)
+            || models::is_builtin_struct(&contract.name)
+            || matches!(contract.name.as_str(), "tx" | "this")
+        {
+            return Err(format!("contract name '{}' is reserved", contract.name));
+        }
+        for name in contract
+            .structs
+            .iter()
+            .map(|s| &s.name)
+            .chain((!contract.name.is_empty()).then_some(&contract.name))
+        {
+            if let Some(previous) = declarations.insert(name.clone(), path.to_string()) {
+                return Err(format!(
+                    "duplicate declaration '{name}' in '{previous}' and '{path}'"
+                ));
+            }
+        }
+        let mut visible_structs = own_structs.clone();
+        let mut visible_contracts = HashMap::new();
+        for dependency in &dependencies {
+            let module = &modules[dependency];
+            visible_structs.extend(module.structs.clone());
+            if !module.contract.name.is_empty() {
+                visible_contracts.insert(module.contract.name.clone(), &module.contract);
+            }
+        }
+        for function in &mut contract.functions {
+            visit_statements(&mut function.statements, &mut |expression| {
+                if let Expression::GroupControlIs {
+                    group,
+                    asset_txid,
+                    asset_gidx,
+                } = expression
+                {
+                    if group == &contract.name || visible_contracts.contains_key(group) {
+                        *expression = Expression::Call {
+                            name: format!("{group}.controlIs"),
+                            args: vec![*asset_txid.clone(), *asset_gidx.clone()],
+                            return_type: None,
+                        };
+                    }
+                }
+                Ok(())
+            })?;
+        }
+        compiler::fold_constants(&mut contract)?;
+        visible_contracts.insert(contract.name.clone(), &contract);
+        validate_scope(&contract, &visible_structs, &visible_contracts)?;
+        let mut structs: BTreeMap<_, _> = contract
+            .structs
+            .iter()
+            .map(|s| (s.name.clone(), s.clone()))
+            .collect();
+        let mut helpers = BTreeMap::new();
+        for dependency in &dependencies {
+            let imported = &modules[dependency].contract;
+            structs.extend(imported.structs.iter().map(|s| (s.name.clone(), s.clone())));
+            for function in imported.functions.iter().filter(|f| f.is_static) {
+                let mut function = function.clone();
+                if !function.is_imported() {
+                    function.name = format!("{}.{}", imported.name, function.name);
+                    visit_statements(&mut function.statements, &mut |expression| {
+                        if let Expression::Call { name, .. } = expression {
+                            if !name.contains('.') {
+                                *name = format!("{}.{}", imported.name, name);
+                            }
+                        }
+                        Ok(())
+                    })?;
+                }
+                helpers.insert(function.name.clone(), function);
+            }
+        }
+        // Keep standalone declaration order; append dependency types deterministically.
+        let own_names: HashSet<_> = contract.structs.iter().map(|s| s.name.clone()).collect();
+        contract.structs.extend(
+            structs
+                .into_values()
+                .filter(|s| !own_names.contains(&s.name)),
+        );
+        let owner = contract.name.clone();
+        for function in &mut contract.functions {
+            visit_statements(&mut function.statements, &mut |expression| {
+                if let Expression::Call { name, .. } = expression {
+                    if let Some(local) = name.strip_prefix(&format!("{owner}.")) {
+                        *name = local.to_string();
+                    }
+                }
+                Ok(())
+            })?;
+        }
+        contract.functions.extend(helpers.into_values());
+        let warnings = compiler::prepare(&mut contract, path == entry)?;
+        files.insert(path.to_string(), source);
+        modules.insert(
+            path.to_string(),
+            Module {
+                contract,
+                structs: own_structs,
+                warnings,
+            },
+        );
+        Ok(())
+    })();
+    active.pop();
+    result.map_err(|error: String| format!("{path}: {error}"))
+}
+
+fn validate_scope(
+    contract: &Contract,
+    structs: &HashSet<String>,
+    contracts: &HashMap<String, &Contract>,
+) -> Result<(), String> {
+    let check_binding = |name: &str| {
+        if contracts.contains_key(name) {
+            Err(format!("binding '{name}' shadows a contract namespace"))
+        } else {
+            Ok(())
+        }
+    };
+    for constant in &contract.constants {
+        check_binding(&constant.name)?;
+    }
+    let check_type = |ty: &str| {
+        let base = models::array_type_parts(ty)
+            .map(|(base, _)| base)
+            .unwrap_or(ty);
+        if models::is_builtin_type(base)
+            || models::is_builtin_struct(base)
+            || structs.contains(base)
+        {
+            Ok(())
+        } else {
+            Err(format!("unknown type '{base}'; import its defining file"))
+        }
+    };
+    for parameter in contract
+        .parameters
+        .iter()
+        .chain(contract.structs.iter().flat_map(|s| &s.fields))
+        .chain(contract.functions.iter().flat_map(|f| &f.parameters))
+        .chain(contract.tapscripts.iter().flat_map(|t| &t.inputs))
+    {
+        check_type(&parameter.param_type)?;
+    }
+    for parameter in contract
+        .parameters
+        .iter()
+        .chain(contract.functions.iter().flat_map(|f| &f.parameters))
+        .chain(contract.tapscripts.iter().flat_map(|t| &t.inputs))
+    {
+        check_binding(&parameter.name)?;
+    }
+    for function in &contract.functions {
+        if let Some(ty) = &function.return_type {
+            check_type(ty)?;
+        }
+        let mut scope =
+            typechecker::build_scope_with_structs(&contract.parameters, &contract.structs);
+        scope.extend(typechecker::build_scope_with_structs(
+            &function.parameters,
+            &contract.structs,
+        ));
+        let mut body = function.statements.clone();
+        validate_local_types(&body, &check_type, &check_binding)?;
+        visit_statements(&mut body, &mut |expression| {
+            match expression {
+                Expression::Call { name, .. } if name.contains('.') => {
+                    let (owner, member) = name.split_once('.').expect("qualified name");
+                    let target = contracts.get(owner).ok_or_else(|| {
+                        format!("unknown contract '{owner}'; import its defining file")
+                    })?;
+                    if !target
+                        .functions
+                        .iter()
+                        .any(|f| f.name == member && f.is_static)
+                    {
+                        return Err(format!("'{name}' is not a static function"));
+                    }
+                }
+                Expression::Property(name) => {
+                    if let Some((owner, _)) = name.split_once('.') {
+                        if contracts.contains_key(owner) {
+                            return Err(format!("unknown constant '{name}'"));
+                        }
+                    }
+                }
+                Expression::ContractInstance {
+                    contract_name,
+                    args,
+                } => {
+                    let target = contracts.get(contract_name).ok_or_else(|| {
+                        format!("unknown contract '{contract_name}'; import its defining file")
+                    })?;
+                    if args.len() != target.parameters.len() {
+                        return Err(format!(
+                            "constructor '{contract_name}' expects {} arguments, got {}",
+                            target.parameters.len(),
+                            args.len()
+                        ));
+                    }
+                    for (arg, param) in args.iter().zip(&target.parameters) {
+                        let actual = typechecker::infer_type(arg, &scope);
+                        if actual != typechecker::ArkType::Unknown
+                            && !crate::validator::binding_types_compatible(
+                                &typechecker::ArkType::parse(&param.param_type),
+                                &actual,
+                            )
+                        {
+                            return Err(format!(
+                                "constructor '{contract_name}' argument '{}' expects {}, got {}",
+                                param.name,
+                                param.param_type,
+                                actual.as_str()
+                            ));
+                        }
+                    }
+                }
+                _ => {}
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_local_types(
+    statements: &[Statement],
+    check: &impl Fn(&str) -> Result<(), String>,
+    binding: &impl Fn(&str) -> Result<(), String>,
+) -> Result<(), String> {
+    for statement in statements {
+        match statement {
+            Statement::LetBinding {
+                name,
+                declared_type,
+                ..
+            } => {
+                binding(name)?;
+                if let Some(ty) = declared_type {
+                    check(ty)?;
+                }
+            }
+            Statement::IfElse {
+                then_body,
+                else_body,
+                ..
+            } => {
+                validate_local_types(then_body, check, binding)?;
+                if let Some(body) = else_body {
+                    validate_local_types(body, check, binding)?;
+                }
+            }
+            Statement::ForIn {
+                index_var,
+                value_var,
+                body,
+                ..
+            } => {
+                binding(index_var)?;
+                binding(value_var)?;
+                validate_local_types(body, check, binding)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn visit_statements(
+    statements: &mut [Statement],
+    visit: &mut impl FnMut(&mut Expression) -> Result<(), String>,
+) -> Result<(), String> {
+    for statement in statements {
+        match statement {
+            Statement::Call(expr)
+            | Statement::Return(Some(expr))
+            | Statement::LetBinding { value: expr, .. } => visit_expression(expr, visit)?,
+            Statement::Require(requirement) => match requirement {
+                models::Requirement::Expression(expr) => visit_expression(expr, visit)?,
+                models::Requirement::Comparison { left, right, .. } => {
+                    visit_expression(left, visit)?;
+                    visit_expression(right, visit)?;
+                }
+                _ => {}
+            },
+            Statement::VarAssign { target, value } => {
+                if let models::AssignmentTarget::ArrayIndex { index, .. } = target {
+                    visit_expression(index, visit)?;
+                }
+                visit_expression(value, visit)?;
+            }
+            Statement::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                visit_expression(condition, visit)?;
+                visit_statements(then_body, visit)?;
+                if let Some(body) = else_body {
+                    visit_statements(body, visit)?;
+                }
+            }
+            Statement::ForIn { iterable, body, .. } => {
+                visit_expression(iterable, visit)?;
+                visit_statements(body, visit)?;
+            }
+            Statement::Return(None) => {}
+        }
+    }
+    Ok(())
+}
+
+fn visit_expression(
+    expr: &mut Expression,
+    visit: &mut impl FnMut(&mut Expression) -> Result<(), String>,
+) -> Result<(), String> {
+    for child in models::child_exprs_mut(expr) {
+        visit_expression(child, visit)?;
+    }
+    visit(expr)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-// Public API surface: `compile` plus the data model (`models`) and opcode
-// constants consumers need. The pipeline stages are crate-internal.
+// Compilation entry points, data models, and opcode constants are public.
+// Pipeline stages are crate-internal.
 mod compiler;
+mod imports;
 pub mod models;
 pub mod opcodes;
 mod parser;
@@ -63,4 +64,19 @@ pub fn compile(source_code: &str) -> Result<ContractJson, Box<dyn std::error::Er
         Ok(output) => Ok(output),
         Err(err) => Err(err.into()),
     }
+}
+
+/// Compile an entry file and its relative imports from the filesystem.
+pub fn compile_file(
+    path: impl AsRef<std::path::Path>,
+) -> Result<ContractJson, Box<dyn std::error::Error>> {
+    imports::compile_file(path.as_ref()).map_err(Into::into)
+}
+
+/// Compile an entry file from an in-memory map of relative paths to source text.
+pub fn compile_sources(
+    entry: &str,
+    files: &std::collections::BTreeMap<String, String>,
+) -> Result<ContractJson, Box<dyn std::error::Error>> {
+    imports::compile_sources(entry, files).map_err(Into::into)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser as ClapParser;
 use std::fs;
 use std::path::Path;
 
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 
 /// Arkade Compiler CLI
 ///
@@ -48,11 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err("Input file must have .ark extension".into());
     }
 
-    // Read source code
-    let source_code = fs::read_to_string(&args.file)?;
-
     // Compile source code to JSON
-    let output = match compile(&source_code) {
+    let output = match compile_file(file_path) {
         Ok(json) => json,
         Err(err) => {
             eprintln!("Compilation error: {}", err);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -233,13 +233,20 @@ pub struct ContractJson {
     pub parameters: Vec<Parameter>,
     pub functions: Vec<AbiFunctionGroup>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
+    pub source: Option<SourceBundle>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compiler: Option<CompilerInfo>,
     #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub warnings: Vec<String>,
+}
+
+/// Original files needed to reproduce a compilation without filesystem access.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SourceBundle {
+    pub entry: String,
+    pub files: std::collections::BTreeMap<String, String>,
 }
 
 /// Compiler information
@@ -255,9 +262,9 @@ pub struct CompilerInfo {
 /// Contract AST
 #[derive(Debug, Clone)]
 pub struct Contract {
-    /// Contract name
+    /// Contract name; empty for a source file containing only structs.
     pub name: String,
-    /// Struct types declared before this contract.
+    /// Struct types available to this contract.
     pub structs: Vec<StructDefinition>,
     /// Contract parameters
     pub parameters: Vec<Parameter>,
@@ -294,6 +301,13 @@ pub struct Function {
     pub is_static: bool,
     /// Explicit result type; None means the function returns no value.
     pub return_type: Option<String>,
+}
+
+impl Function {
+    // Qualified helpers have already been checked in their defining file's scope.
+    pub(crate) fn is_imported(&self) -> bool {
+        self.name.contains('.')
+    }
 }
 
 /// Statement AST - represents any executable statement in a function body

--- a/src/parser/asset.rs
+++ b/src/parser/asset.rs
@@ -91,11 +91,7 @@ pub(crate) fn parse_asset_lookup_operands(
         .into_inner()
         .next()
         .ok_or("Missing index value")?;
-    let index = match index_pair.as_rule() {
-        Rule::number_literal => Expression::Literal(index_pair.as_str().to_string()),
-        Rule::identifier => Expression::Variable(index_pair.as_str().to_string()),
-        _ => Expression::Literal(index_pair.as_str().to_string()),
-    };
+    let index = parse_general_expression(index_pair)?;
 
     // Parse the canonical Asset ID operands: txid (bytes32) then gidx (int).
     let asset_txid = parse_asset_id_txid(inner.next().ok_or("Missing asset txid")?)?;
@@ -150,11 +146,7 @@ pub(crate) fn parse_asset_count_to_expression(pair: Pair<Rule>) -> Result<Expres
         .into_inner()
         .next()
         .ok_or("Missing index value")?;
-    let index = match index_pair.as_rule() {
-        Rule::number_literal => Expression::Literal(index_pair.as_str().to_string()),
-        Rule::identifier => Expression::Variable(index_pair.as_str().to_string()),
-        _ => Expression::Literal(index_pair.as_str().to_string()),
-    };
+    let index = parse_general_expression(index_pair)?;
 
     Ok(Expression::AssetCount {
         source,
@@ -181,11 +173,7 @@ pub(crate) fn parse_asset_at_to_expression(pair: Pair<Rule>) -> Result<Expressio
         .into_inner()
         .next()
         .ok_or("Missing io index value")?;
-    let io_index = match io_index_pair.as_rule() {
-        Rule::number_literal => Expression::Literal(io_index_pair.as_str().to_string()),
-        Rule::identifier => Expression::Variable(io_index_pair.as_str().to_string()),
-        _ => Expression::Literal(io_index_pair.as_str().to_string()),
-    };
+    let io_index = parse_general_expression(io_index_pair)?;
 
     // Parse second array access (asset_index)
     let asset_array_access = inner.next().ok_or("Missing asset array index")?;
@@ -193,11 +181,7 @@ pub(crate) fn parse_asset_at_to_expression(pair: Pair<Rule>) -> Result<Expressio
         .into_inner()
         .next()
         .ok_or("Missing asset index value")?;
-    let asset_index = match asset_index_pair.as_rule() {
-        Rule::number_literal => Expression::Literal(asset_index_pair.as_str().to_string()),
-        Rule::identifier => Expression::Variable(asset_index_pair.as_str().to_string()),
-        _ => Expression::Literal(asset_index_pair.as_str().to_string()),
-    };
+    let asset_index = parse_general_expression(asset_index_pair)?;
 
     // Parse property: "assetId" or "amount"
     let property = inner

--- a/src/parser/checksig.rs
+++ b/src/parser/checksig.rs
@@ -82,7 +82,7 @@ pub(crate) fn parse_multisig_threshold(
     constants: &[Constant],
 ) -> Result<u16, String> {
     let name = pair.as_str();
-    let text = if pair.as_rule() == Rule::identifier {
+    let text = if pair.as_rule() != Rule::number_literal {
         let constant = constants
             .iter()
             .find(|constant| constant.name == name)

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -33,7 +33,9 @@ pub(crate) fn parse_general_expression(pair: Pair<Rule>) -> Result<Expression, S
         Rule::additive_expr => parse_additive_expr(pair),
         Rule::multiplicative_expr => parse_multiplicative_expr(pair),
         Rule::unary_expr | Rule::primary_expr => parse_primary_expr(pair),
-        Rule::identifier => Ok(Expression::Variable(pair.as_str().to_string())),
+        Rule::identifier | Rule::qualified_name => {
+            Ok(Expression::Variable(pair.as_str().to_string()))
+        }
         Rule::bool_literal => Ok(Expression::Literal(pair.as_str().to_string())),
         Rule::number_literal => Ok(Expression::Literal(pair.as_str().to_string())),
         Rule::tx_property_access => parse_tx_property_to_expr(pair),
@@ -195,7 +197,9 @@ pub(crate) fn parse_primary_expr(pair: Pair<Rule>) -> Result<Expression, String>
             // Parenthesized expression
             parse_general_expression(pair)
         }
-        Rule::identifier => Ok(Expression::Variable(pair.as_str().to_string())),
+        Rule::identifier | Rule::qualified_name => {
+            Ok(Expression::Variable(pair.as_str().to_string()))
+        }
         Rule::bool_literal => Ok(Expression::Literal(pair.as_str().to_string())),
         Rule::number_literal => Ok(Expression::Literal(pair.as_str().to_string())),
         Rule::array_index_access => {
@@ -462,25 +466,7 @@ pub(crate) fn parse_constructor_to_expression(pair: Pair<Rule>) -> Result<Expres
 /// alternatives matched by the silent `complex_expression` rule — so we
 /// see the raw inner rules (identifier, number_literal, etc.) directly.
 pub(crate) fn parse_constructor_args(pair: Pair<Rule>) -> Result<Vec<Expression>, String> {
-    let mut args = Vec::new();
-
-    for inner in pair.into_inner() {
-        let expr = match inner.as_rule() {
-            Rule::identifier => Expression::Variable(inner.as_str().to_string()),
-            Rule::number_literal => Expression::Literal(inner.as_str().to_string()),
-            Rule::constructor => parse_constructor_to_expression(inner)?,
-            Rule::input_introspection => parse_input_introspection_to_expression(inner)?,
-            Rule::output_introspection => parse_output_introspection_to_expression(inner)?,
-            Rule::tx_introspection => parse_tx_introspection_to_expression(inner)?,
-            _ => {
-                // Fall back to treating as a variable/property reference
-                Expression::Variable(inner.as_str().to_string())
-            }
-        };
-        args.push(expr);
-    }
-
-    Ok(args)
+    pair.into_inner().map(parse_general_expression).collect()
 }
 
 // ─── Helper Functions ──────────────────────────────────────────────────────────

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -1,12 +1,12 @@
 // Whitespace and comments are silently consumed
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
-COMMENT = _{ "//" ~ (!"\n" ~ ANY)* ~ "\n" }
+COMMENT = _{ "//" ~ (!"\n" ~ ANY)* ~ ("\n" | EOI) }
 
 // Import statement: import "path/to/contract.ark";
 import_stmt = { "import" ~ string_literal ~ ";" }
 
 // Main entry point - must consume the entire input
-main = { SOI ~ import_stmt* ~ struct_definition* ~ contract ~ EOI }
+main = { SOI ~ import_stmt* ~ struct_definition* ~ contract? ~ EOI }
 
 struct_definition = {
     "struct" ~ identifier ~ "{" ~ struct_field+ ~ "}"
@@ -139,7 +139,7 @@ multiplicative_expr = {
 unary_expr = { (sub_op | not_op)* ~ primary_expr }
 
 // Built-in operands accept prefixes on literals, bindings, and grouped expressions.
-unary_atom = { (sub_op | not_op)* ~ ("(" ~ general_expression ~ ")" | bool_literal | identifier | number_literal) }
+unary_atom = { (sub_op | not_op)* ~ ("(" ~ general_expression ~ ")" | bool_literal | qualified_name | number_literal) }
 
 // Primary expressions (atoms)
 primary_expr = {
@@ -178,9 +178,9 @@ primary_expr = {
     array_length_access |
     tx_property_access |
     this_property_access |
+    function_call |
     identifier_property_access |
     constructor |
-    function_call |
     array_index_access |
     struct_literal |
     array_literal |
@@ -442,7 +442,7 @@ tx_special_property = {
 
 // Array access with index - simplified to avoid parsing ambiguity
 array_access = {
-    "[" ~ (number_literal | identifier) ~ "]"
+    "[" ~ (number_literal | qualified_name) ~ "]"
 }
 
 // Method call with optional arguments
@@ -472,8 +472,10 @@ struct_literal = {
 struct_literal_field = { identifier ~ ":" ~ general_expression }
 
 // Function call
+qualified_name = @{ identifier ~ ("." ~ identifier)? }
+
 function_call = {
-    identifier ~ "(" ~ (general_expression ~ ("," ~ general_expression)*)? ~ ")"
+    qualified_name ~ "(" ~ (general_expression ~ ("," ~ general_expression)*)? ~ ")"
 }
 
 // ─── Cryptographic Primitives ──────────────────────────────────────────────────
@@ -508,7 +510,7 @@ check_multisig = { check_threshold_multisig }
 // checkMultisig([keys], [sigs], threshold?) — keys may be tweak()s; the second
 // array carries the aligned signature inputs and the final threshold is optional.
 check_threshold_multisig = {
-    "checkMultisig" ~ "(" ~ key_array ~ "," ~ array ~ ("," ~ (number_literal | identifier))? ~ ")"
+    "checkMultisig" ~ "(" ~ key_array ~ "," ~ array ~ ("," ~ (number_literal | qualified_name))? ~ ")"
 }
 
 // Array of identifiers
@@ -520,8 +522,8 @@ array = {
 // to a single binding because these AST nodes store operand names directly.
 named_binding = @{
     identifier ~ (
-        ("." ~ identifier)+ ~ ("[" ~ (identifier | number_literal) ~ "]")? |
-        "[" ~ (identifier | number_literal) ~ "]"
+        ("." ~ identifier)+ ~ ("[" ~ (qualified_name | number_literal) ~ "]")? |
+        "[" ~ (qualified_name | number_literal) ~ "]"
     )?
 }
 

--- a/src/parser/introspection.rs
+++ b/src/parser/introspection.rs
@@ -35,11 +35,7 @@ pub(crate) fn parse_input_introspection_to_expression(
         .into_inner()
         .next()
         .ok_or("Missing index value")?;
-    let index = match index_pair.as_rule() {
-        Rule::number_literal => Expression::Literal(index_pair.as_str().to_string()),
-        Rule::identifier => Expression::Variable(index_pair.as_str().to_string()),
-        _ => Expression::Literal(index_pair.as_str().to_string()),
-    };
+    let index = parse_general_expression(index_pair)?;
 
     // Parse the property
     let property = inner
@@ -67,11 +63,7 @@ pub(crate) fn parse_output_introspection_to_expression(
         .into_inner()
         .next()
         .ok_or("Missing index value")?;
-    let index = match index_pair.as_rule() {
-        Rule::number_literal => Expression::Literal(index_pair.as_str().to_string()),
-        Rule::identifier => Expression::Variable(index_pair.as_str().to_string()),
-        _ => Expression::Literal(index_pair.as_str().to_string()),
-    };
+    let index = parse_general_expression(index_pair)?;
 
     // Parse the property
     let property = inner

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -28,18 +28,40 @@ pub(crate) use expr::*;
 pub(crate) use introspection::*;
 pub(crate) use tapscript::*;
 
-/// Parse Arkade Script source code into a Contract AST.
-///
-/// This is the main entry point for the parser. It tokenizes the source code
-/// using the Pest grammar and builds a typed AST.
-pub fn parse(source_code: &str) -> Result<Contract, Box<dyn std::error::Error>> {
-    let pairs = ArkadeParser::parse(Rule::main, source_code)?;
-    let ast = build_ast(pairs)?;
-    Ok(ast)
+#[cfg(test)]
+pub fn parse(source: &str) -> Result<Contract, String> {
+    parse_with_constants(source, &[])
+}
+
+pub(crate) fn imports(source: &str) -> Result<Vec<String>, String> {
+    let mut pairs =
+        ArkadeParser::parse(Rule::main, source).map_err(|e| format!("Parse error: {e}"))?;
+    Ok(pairs
+        .next()
+        .expect("main")
+        .into_inner()
+        .filter(|p| p.as_rule() == Rule::import_stmt)
+        .map(|p| {
+            p.into_inner()
+                .next()
+                .expect("import path")
+                .as_str()
+                .trim_matches('"')
+                .to_string()
+        })
+        .collect())
+}
+
+pub(crate) fn parse_with_constants(
+    source: &str,
+    constants: &[Constant],
+) -> Result<Contract, String> {
+    let pairs = ArkadeParser::parse(Rule::main, source).map_err(|e| format!("Parse error: {e}"))?;
+    build_ast(pairs, constants)
 }
 
 /// Build a Contract AST from parsed Pest pairs
-fn build_ast(pairs: Pairs<Rule>) -> Result<Contract, String> {
+fn build_ast(pairs: Pairs<Rule>, constants: &[Constant]) -> Result<Contract, String> {
     let mut contract = Contract {
         name: String::new(),
         structs: Vec::new(),
@@ -47,7 +69,7 @@ fn build_ast(pairs: Pairs<Rule>) -> Result<Contract, String> {
         functions: Vec::new(),
         tapscripts: Vec::new(),
         imports: Vec::new(),
-        constants: Vec::new(),
+        constants: constants.to_vec(),
     };
 
     for pair in pairs {
@@ -125,11 +147,24 @@ fn parse_contract(contract: &mut Contract, pair: Pair<Rule>) -> Result<(), Strin
         contract.parameters = parse_parameters(param_list)?;
     }
 
-    contract.constants = inner_pairs
+    let constants = inner_pairs
         .clone()
         .filter(|pair| pair.as_rule() == Rule::const_decl)
         .map(parse_const_decl)
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
+    contract.constants.extend(constants);
+    let mut parsing_constants = contract.constants.clone();
+    parsing_constants.extend(
+        contract
+            .constants
+            .iter()
+            .filter(|c| !c.name.contains('.'))
+            .cloned()
+            .map(|mut constant| {
+                constant.name = format!("{}.{}", contract.name, constant.name);
+                constant
+            }),
+    );
 
     // Functions (covenant) and tapscript declarations share the `function` rule;
     // a tapscript carries a `tapscript_block` body.
@@ -138,10 +173,10 @@ fn parse_contract(contract: &mut Contract, pair: Pair<Rule>) -> Result<(), Strin
             continue;
         }
         if function_pair_is_tapscript(&func_pair) {
-            let ts = parse_named_tapscript(func_pair, &contract.constants)?;
+            let ts = parse_named_tapscript(func_pair, &parsing_constants)?;
             contract.tapscripts.push(ts);
         } else {
-            let func = parse_function(func_pair, &contract.constants)?;
+            let func = parse_function(func_pair, &parsing_constants)?;
             contract.functions.push(func);
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -496,6 +496,21 @@ mod tests {
     use crate::models::{AssignmentTarget, Expression, Requirement, Statement};
 
     #[test]
+    fn distinguishes_property_access_from_qualified_calls() {
+        let contract = parse(
+            "contract C() { function spend() { let field = x.field; let call = Helper.value(); } }",
+        )
+        .unwrap();
+        let statements = &contract.functions[0].statements;
+        assert!(
+            matches!(&statements[0], Statement::LetBinding { value: Expression::Property(name), .. } if name == "x.field")
+        );
+        assert!(
+            matches!(&statements[1], Statement::LetBinding { value: Expression::Call { name, args, .. }, .. } if name == "Helper.value" && args.is_empty())
+        );
+    }
+
+    #[test]
     fn parses_private_visibility_return_types_and_call_arguments() {
         use crate::models::Expression;
         let contract = parse(

--- a/src/parser/tapscript.rs
+++ b/src/parser/tapscript.rs
@@ -179,7 +179,7 @@ pub(crate) fn parse_tap_multisig(
                     sigs.push(s.as_str().to_string());
                 }
             }
-            Rule::number_literal | Rule::identifier => {
+            Rule::number_literal | Rule::qualified_name => {
                 threshold = Some(parse_multisig_threshold(child, constants)?);
             }
             _ => {}

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -226,7 +226,7 @@ pub(crate) fn resolve_group_properties(contract: &mut Contract) {
         .iter()
         .map(|f| (f.name.clone(), f.return_type.clone()))
         .collect();
-    for function in &mut contract.functions {
+    for function in contract.functions.iter_mut().filter(|f| !f.is_imported()) {
         let mut scope = constructor_scope.clone();
         scope.extend(build_scope_with_structs(
             &function.parameters,
@@ -367,6 +367,7 @@ pub fn check_contract(contract: &Contract) -> Vec<TypeError> {
     contract
         .functions
         .iter()
+        .filter(|f| !f.is_imported())
         .flat_map(|f| check_function(f, &constructor_scope, &contract.structs))
         .collect()
 }

--- a/src/validator/functions.rs
+++ b/src/validator/functions.rs
@@ -7,7 +7,7 @@ pub(super) fn validate_functions(contract: &Contract, issues: &mut Vec<Validatio
         .iter()
         .map(|s| (s.name.as_str(), s))
         .collect();
-    for function in &contract.functions {
+    for function in contract.functions.iter().filter(|f| !f.is_imported()) {
         if let Some(result) = &function.return_type {
             if !function.is_private {
                 issues.push(ValidationIssue::error(format!(
@@ -37,13 +37,13 @@ pub(super) fn validate_functions(contract: &Contract, issues: &mut Vec<Validatio
     }
 
     let mut guarantees = HashMap::new();
-    for function in &contract.functions {
+    for function in contract.functions.iter().filter(|f| !f.is_imported()) {
         if let Err(error) = analyze_function(function, contract, &mut Vec::new(), &mut guarantees) {
             issues.push(ValidationIssue::error(error));
             return;
         }
     }
-    for function in &contract.functions {
+    for function in contract.functions.iter().filter(|f| !f.is_imported()) {
         let flow = flow_block(&function.statements, 1, &guarantees);
         if function.is_private && function.return_type.is_some() && flow.fallthrough != 0 {
             issues.push(ValidationIssue::error(format!(

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -82,19 +82,19 @@ pub fn has_errors(issues: &[ValidationIssue]) -> bool {
 /// - Each function's parameter names are unique within that function.
 /// - Tapscript inputs do not collide with reserved key roles.
 /// - Asset ID operands have the expected txid/gidx types.
-pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
+pub fn validate_ast(contract: &Contract, require_entrypoint: bool) -> Vec<ValidationIssue> {
     let mut issues = Vec::new();
 
     check_struct_definitions(contract, &mut issues);
 
     // ── Contract name ──────────────────────────────────────────────────────
-    if contract.name.is_empty() {
+    if require_entrypoint && contract.name.is_empty() {
         issues.push(ValidationIssue::error("contract name must not be empty"));
     }
 
     // ── At least one public function or tapscript ──────────────────
     let public_count = contract.functions.iter().filter(|f| !f.is_private).count();
-    if public_count == 0 && contract.tapscripts.is_empty() {
+    if require_entrypoint && public_count == 0 && contract.tapscripts.is_empty() {
         issues.push(ValidationIssue::error(
             "contract must declare at least one public function",
         ));
@@ -103,7 +103,7 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
     // ── Unique function names ──────────────────────────────────────────────
     {
         let mut seen: HashSet<&str> = HashSet::new();
-        for func in &contract.functions {
+        for func in contract.functions.iter().filter(|f| !f.is_imported()) {
             if !seen.insert(func.name.as_str()) {
                 issues.push(ValidationIssue::error(format!(
                     "duplicate function name '{}'; each function must have a unique name",
@@ -128,7 +128,7 @@ pub fn validate_ast(contract: &Contract) -> Vec<ValidationIssue> {
     }
 
     // ── Unique parameter names within each function ────────────────────────
-    for func in &contract.functions {
+    for func in contract.functions.iter().filter(|f| !f.is_imported()) {
         let mut seen: HashSet<&str> = HashSet::new();
         for param in &func.parameters {
             validate_source_identifier(
@@ -283,7 +283,7 @@ fn check_struct_definitions(contract: &Contract, issues: &mut Vec<ValidationIssu
     {
         validate_declared_type(&parameter.param_type, "parameter", &definitions, issues);
     }
-    for function in &contract.functions {
+    for function in contract.functions.iter().filter(|f| !f.is_imported()) {
         validate_local_types(&function.statements, &function.name, &definitions, issues);
     }
 }
@@ -422,7 +422,7 @@ fn validate_source_identifier(name: &str, context: &str, issues: &mut Vec<Valida
 /// not accepted as an Asset ID component.
 fn check_asset_id_operands(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
     let ctor_scope = build_scope_with_structs(&contract.parameters, &contract.structs);
-    for func in &contract.functions {
+    for func in contract.functions.iter().filter(|f| !f.is_imported()) {
         let mut scope = ctor_scope.clone();
         scope.extend(build_scope_with_structs(
             &func.parameters,
@@ -763,7 +763,7 @@ fn resolved_expression_type(expression: &Expression, scopes: &BindingScopes) -> 
     }
 }
 
-fn binding_types_compatible(expected: &ArkType, actual: &ArkType) -> bool {
+pub(crate) fn binding_types_compatible(expected: &ArkType, actual: &ArkType) -> bool {
     expected == actual
         || matches!(
             (expected, actual),
@@ -777,7 +777,7 @@ fn binding_types_compatible(expected: &ArkType, actual: &ArkType) -> bool {
 }
 
 fn check_binding_semantics(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
-    for function in &contract.functions {
+    for function in contract.functions.iter().filter(|f| !f.is_imported()) {
         let mut root = HashMap::new();
         insert_parameters(
             &mut root,
@@ -1722,7 +1722,7 @@ fn check_shadowing(contract: &Contract, issues: &mut Vec<ValidationIssue>) {
         }
     }
 
-    for func in &contract.functions {
+    for func in contract.functions.iter().filter(|f| !f.is_imported()) {
         // Seed frame: constructor params + this function's params.
         let mut seed: HashSet<String> = ctor_names
             .iter()
@@ -2038,7 +2038,10 @@ mod tests {
     }
 
     fn parse_and_validate(source: &str) -> Vec<ValidationIssue> {
-        validate_ast(&crate::parser::parse(source).expect("contract should parse"))
+        validate_ast(
+            &crate::parser::parse(source).expect("contract should parse"),
+            true,
+        )
     }
 
     #[test]
@@ -2169,7 +2172,7 @@ contract Demo() {
     #[test]
     fn valid_contract_has_no_issues() {
         let contract = make_contract("Simple");
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(!has_errors(&issues));
     }
 
@@ -2186,7 +2189,7 @@ contract Demo() {
             })],
             else_body: None,
         }];
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(has_errors(&issues));
         assert!(issues
             .iter()
@@ -2207,13 +2210,13 @@ contract Demo() {
             then_body: vec![req()],
             else_body: Some(vec![req()]),
         }];
-        assert!(!has_errors(&validate_ast(&contract)));
+        assert!(!has_errors(&validate_ast(&contract, true)));
     }
 
     #[test]
     fn empty_contract_name_is_error() {
         let contract = make_contract("");
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(has_errors(&issues));
         assert!(issues.iter().any(|i| i.message.contains("name")));
     }
@@ -2222,7 +2225,7 @@ contract Demo() {
     fn no_functions_is_error() {
         let mut contract = make_contract("Empty");
         contract.functions.clear();
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(has_errors(&issues));
         assert!(issues.iter().any(|i| i.message.contains("public function")));
     }
@@ -2231,7 +2234,7 @@ contract Demo() {
     fn only_private_functions_is_error() {
         let mut contract = make_contract("AllInternal");
         contract.functions[0].is_private = true;
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(has_errors(&issues));
     }
 
@@ -2239,7 +2242,7 @@ contract Demo() {
     fn duplicate_function_name_is_error() {
         let mut contract = make_contract("Dup");
         contract.functions.push(contract.functions[0].clone());
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(has_errors(&issues));
         assert!(issues.iter().any(|i| i.message.contains("spend")));
     }
@@ -2248,7 +2251,7 @@ contract Demo() {
     fn duplicate_constructor_param_is_error() {
         let mut contract = make_contract("Dup");
         contract.parameters.push(contract.parameters[0].clone());
-        let issues = validate_ast(&contract);
+        let issues = validate_ast(&contract, true);
         assert!(has_errors(&issues));
     }
 

--- a/src/validator/references.rs
+++ b/src/validator/references.rs
@@ -29,7 +29,10 @@ fn collect_expression<'a>(
 ) {
     match expression {
         Expression::Call { name, .. } if visited.insert(name) => {
-            if let Some(function) = functions.iter().find(|f| f.is_private && f.name == *name) {
+            if let Some(function) = functions
+                .iter()
+                .find(|f| f.is_private && !f.is_static && f.name == *name)
+            {
                 collect_statements(&function.statements, names, functions, visited);
             }
         }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -48,3 +48,11 @@ pub fn validate(source: &str) -> Result<bool, String> {
         Err(e) => Err(e.to_string()),
     }
 }
+
+/// Compile a virtual project. `files` is a JSON object mapping relative .ark paths to source text.
+#[wasm_bindgen]
+pub fn compile_sources(entry: &str, files: &str) -> Result<String, String> {
+    let files = serde_json::from_str(files).map_err(|e| format!("Invalid source files: {e}"))?;
+    let output = crate::imports::compile_sources(entry, &files)?;
+    serde_json::to_string_pretty(&output).map_err(|e| format!("Serialization error: {e}"))
+}

--- a/tests/examples/arkade_kitties.rs
+++ b/tests/examples/arkade_kitties.rs
@@ -1,15 +1,18 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use arkade_compiler::opcodes::{
     OP_CHECKSIG, OP_INSPECTASSETGROUPASSETID, OP_INSPECTASSETGROUPCTRL,
     OP_INSPECTASSETGROUPMETADATAHASH, OP_INSPECTASSETGROUPSUM, OP_INSPECTOUTASSETLOOKUP,
     OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_SUB, OP_TXID,
 };
 
-const ARKADE_KITTIES_CODE: &str = include_str!("../../examples/arkade_kitties/arkade_kitties.ark");
+const ARKADE_KITTIES_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/arkade_kitties/arkade_kitties.ark"
+);
 
 #[test]
 fn test_arkade_kitties_compiles() {
-    let result = compile(ARKADE_KITTIES_CODE);
+    let result = compile_file(ARKADE_KITTIES_PATH);
     assert!(
         result.is_ok(),
         "ArkadeKitties compilation failed: {:?}",
@@ -19,7 +22,7 @@ fn test_arkade_kitties_compiles() {
 
 #[test]
 fn test_arkade_kitties_structure() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     assert_eq!(output.name, "ArkadeKitties");
 
@@ -43,7 +46,7 @@ fn test_arkade_kitties_structure() {
 
 #[test]
 fn test_breed_function_has_is_fresh() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "breed");
 
@@ -62,7 +65,7 @@ fn test_breed_function_has_is_fresh() {
 
 #[test]
 fn test_breed_function_has_metadata_hash() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "breed");
 
@@ -75,7 +78,7 @@ fn test_breed_function_has_metadata_hash() {
 
 #[test]
 fn test_breed_function_has_control_check() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "breed");
 
@@ -88,7 +91,7 @@ fn test_breed_function_has_control_check() {
 
 #[test]
 fn test_breed_function_has_delta_checks() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "breed");
 
@@ -107,7 +110,7 @@ fn test_breed_function_has_delta_checks() {
 
 #[test]
 fn test_transfer_verifies_not_fresh() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "transfer");
 
@@ -126,7 +129,7 @@ fn test_transfer_verifies_not_fresh() {
 
 #[test]
 fn test_transfer_has_control_check() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "transfer");
 
@@ -139,7 +142,7 @@ fn test_transfer_has_control_check() {
 
 #[test]
 fn test_transfer_uses_owner_authorized_destination_script() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
     let transfer = crate::common::group(&output, "transfer")
         .arkade
         .as_ref()
@@ -164,7 +167,7 @@ fn test_transfer_uses_owner_authorized_destination_script() {
 
 #[test]
 fn test_breed_has_asset_lookups() {
-    let output = compile(ARKADE_KITTIES_CODE).unwrap();
+    let output = compile_file(ARKADE_KITTIES_PATH).unwrap();
 
     let asm_str = crate::common::arkade_asm(&output, "breed");
 

--- a/tests/examples/asm_structural.rs
+++ b/tests/examples/asm_structural.rs
@@ -14,7 +14,7 @@
 //! coverage, and over targeted synthetic contracts to verify each check fires
 //! correctly when the invariant is violated.
 
-use arkade_compiler::compile;
+use arkade_compiler::{compile, compile_file};
 use std::fs;
 use std::path::PathBuf;
 
@@ -136,8 +136,7 @@ fn all_examples_have_balanced_if_else_endif() {
     for entry in entries {
         let path = entry.path();
         let filename = path.file_name().unwrap().to_string_lossy().into_owned();
-        let source = fs::read_to_string(&path).unwrap();
-        let output = compile(&source).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
+        let output = compile_file(&path).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
 
         for group in &output.functions {
             if let Some(arkade) = &group.arkade {
@@ -173,8 +172,7 @@ fn all_examples_have_no_empty_asm_instructions() {
     for entry in entries {
         let path = entry.path();
         let filename = path.file_name().unwrap().to_string_lossy().into_owned();
-        let source = fs::read_to_string(&path).unwrap();
-        let output = compile(&source).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
+        let output = compile_file(&path).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
 
         for group in &output.functions {
             if let Some(arkade) = &group.arkade {
@@ -221,8 +219,7 @@ fn all_examples_have_well_formed_placeholders() {
     for entry in entries {
         let path = entry.path();
         let filename = path.file_name().unwrap().to_string_lossy().into_owned();
-        let source = fs::read_to_string(&path).unwrap();
-        let output = compile(&source).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
+        let output = compile_file(&path).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
 
         for group in &output.functions {
             if let Some(arkade) = &group.arkade {
@@ -266,9 +263,7 @@ fn simple_contracts_have_fully_resolvable_placeholders() {
     let simple = ["single_sig/single_sig.ark", "htlc/htlc.ark"];
     for filename in &simple {
         let path = examples_dir().join(filename);
-        let source = fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("{} must exist in examples/: {}", filename, e));
-        let output = compile(&source).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
+        let output = compile_file(&path).unwrap_or_else(|e| panic!("compile {}: {}", filename, e));
 
         let ctor_names: Vec<&str> = output.parameters.iter().map(|p| p.name.as_str()).collect();
 
@@ -318,8 +313,7 @@ fn local_variable_placeholders_are_resolved() {
     if !path.exists() {
         return;
     }
-    let source = fs::read_to_string(&path).unwrap();
-    let output = compile(&source).expect("arkade_kitties.ark must compile");
+    let output = compile_file(&path).expect("arkade_kitties.ark must compile");
 
     // Find the breed function group
     let breed_group = output.functions.iter().find(|g| g.name == "breed");

--- a/tests/examples/bond_mint.rs
+++ b/tests/examples/bond_mint.rs
@@ -1,4 +1,4 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use arkade_compiler::opcodes::{
     OP_CHECKSEQUENCEVERIFY, OP_CHECKSIG, OP_INSPECTASSETGROUPSUM, OP_INSPECTINASSETLOOKUP,
     OP_INSPECTOUTPUTSCRIPTPUBKEY, OP_INSPECTOUTPUTVALUE, OP_LESSTHAN,
@@ -6,11 +6,11 @@ use arkade_compiler::opcodes::{
 
 use crate::common::{arkade_asm, arkade_inputs, user_signatures};
 
-const CODE: &str = include_str!("../../examples/bonds/bond_mint.ark");
+const PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/bonds/bond_mint.ark");
 
 #[test]
 fn test_bond_mint_compiles() {
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     assert_eq!(output.name, "BondMint");
     // 4 covenant functions (repay, liquidate, auction, roll) + 1 tapscript (unilateral) = 5 groups
     assert_eq!(output.functions.len(), 5, "expected 5 function groups");
@@ -32,7 +32,7 @@ fn test_bond_mint_compiles() {
 
 #[test]
 fn test_repay_is_atomic_with_pool() {
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "repay");
     assert!(
         asm.contains(OP_INSPECTINASSETLOOKUP),
@@ -60,7 +60,7 @@ fn test_liquidate_is_permissionless_prematurity() {
     // pre-maturity gated (tx.time < maturity), pool co-spent, debit-burned,
     // caller-selected collateral output. The oracle + threshold + payout
     // math lives on the pool side.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "liquidate");
     assert!(
         asm.contains(OP_INSPECTINASSETLOOKUP),
@@ -108,7 +108,7 @@ fn test_auction_is_permissionless_and_phased() {
     //   - debit burn
     //   - caller-selected collateral output
     // The destination is a witness scriptPubKey; no user signature.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "auction");
     assert!(
         asm.contains(OP_INSPECTINASSETLOOKUP),
@@ -154,7 +154,7 @@ fn test_roll_is_borrower_authorized_prematurity_pool_cospent() {
     // pre-maturity. It does NOT pin any output — outputs are claimed by
     // the paired rollOut/rollIn/swap covenants at their witness-supplied
     // indices.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "roll");
     assert!(
         asm.contains(OP_INSPECTINASSETLOOKUP),
@@ -200,7 +200,7 @@ fn test_unilateral_exit_is_csv_timelocked() {
     // The shared unilateral exit leaf must be CSV-timelocked, avoid covenant
     // introspection, and require only the borrower's signature.
     use arkade_compiler::opcodes::OP_DROP;
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = crate::common::leaf_asm(&output, "unilateral", "unilateral");
     assert!(
         asm.contains(OP_CHECKSEQUENCEVERIFY),
@@ -235,8 +235,7 @@ fn test_bond_mint_cli() {
     use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
-    let input = dir.path().join("bond_mint.ark");
-    fs::write(&input, CODE).unwrap();
+    let input = std::path::Path::new(PATH);
     let out = dir.path().join("bond_mint.json");
 
     let result = std::process::Command::new(env!("CARGO_BIN_EXE_arkadec"))

--- a/tests/examples/cash_secured_put.rs
+++ b/tests/examples/cash_secured_put.rs
@@ -1,4 +1,4 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use arkade_compiler::opcodes::{
     OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTLOCKTIME,
     OP_INSPECTOUTASSETLOOKUP,
@@ -6,20 +6,23 @@ use arkade_compiler::opcodes::{
 
 use crate::common::{arkade_asm, arkade_inputs, group};
 
-const PUT_CODE: &str = include_str!("../../examples/options/cash_secured_put.ark");
+const PUT_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/options/cash_secured_put.ark"
+);
 
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_compiles_with_5_groups() {
     // 4 covenant functions + 1 standalone unilateral tapscript = 5 groups
-    let out = compile(PUT_CODE).expect("compile");
+    let out = compile_file(PUT_PATH).expect("compile");
     assert_eq!(out.name, "CashSecuredPut");
     assert_eq!(out.functions.len(), 5);
 }
 
 #[test]
 fn test_exercise_takes_only_buyer_signature() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     let names = arkade_inputs(&out, "exercise");
     assert!(
         names.contains(&"buyerSig".to_string()),
@@ -42,7 +45,7 @@ fn test_exercise_takes_only_buyer_signature() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_no_oracle_anywhere() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     for fn_name in ["exercise", "reclaim", "transferSeller", "transferBuyer"] {
         let asm = arkade_asm(&out, fn_name);
         assert!(
@@ -54,7 +57,7 @@ fn test_no_oracle_anywhere() {
 
 #[test]
 fn test_exercise_verifies_btc_delivery_and_stable_payout() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     let asm = arkade_asm(&out, "exercise");
     assert!(
         asm.contains(OP_INSPECTOUTASSETLOOKUP),
@@ -72,7 +75,7 @@ fn test_exercise_verifies_btc_delivery_and_stable_payout() {
 
 #[test]
 fn test_reclaim_is_seller_only_with_timelock() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     let names = arkade_inputs(&out, "reclaim");
     assert!(
         names.contains(&"sellerSig".to_string()),
@@ -95,7 +98,7 @@ fn test_reclaim_is_seller_only_with_timelock() {
 
 #[test]
 fn test_asset_id_is_two_explicit_params() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     let txid = out
         .parameters
         .iter()
@@ -113,7 +116,7 @@ fn test_asset_id_is_two_explicit_params() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_transfers_guarded_by_expiry() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     for name in ["transferSeller", "transferBuyer"] {
         let asm = arkade_asm(&out, name);
         assert!(
@@ -126,7 +129,7 @@ fn test_transfers_guarded_by_expiry() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_transfers_preserve_stablecoin_collateral() {
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     for name in ["transferSeller", "transferBuyer"] {
         let asm = arkade_asm(&out, name);
         assert!(
@@ -144,7 +147,7 @@ fn test_transfers_preserve_stablecoin_collateral() {
 fn test_unilateral_leaf_has_no_introspection() {
     // The unilateral tapscript (CSV exit) is a standalone leaf: older(exit) +
     // checkSig. It must carry no introspection opcodes.
-    let out = compile(PUT_CODE).unwrap();
+    let out = compile_file(PUT_PATH).unwrap();
     let g = group(&out, "unilateral");
     assert_eq!(g.leaves.len(), 1);
     let leaf_asm = g.leaves[0].asm.join(" ");

--- a/tests/examples/compilation_roundtrip.rs
+++ b/tests/examples/compilation_roundtrip.rs
@@ -12,7 +12,7 @@
 //! These tests catch regressions where the compiler silently emits structurally
 //! broken output without failing.
 
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use std::fs;
 use std::path::PathBuf;
 
@@ -24,9 +24,7 @@ fn examples_dir() -> PathBuf {
 
 fn compile_example(filename: &str) -> arkade_compiler::models::ContractJson {
     let path = examples_dir().join(filename);
-    let source = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
-    compile(&source).unwrap_or_else(|e| panic!("failed to compile {}: {}", filename, e))
+    compile_file(path).unwrap_or_else(|e| panic!("failed to compile {}: {}", filename, e))
 }
 
 /// Assert every structural invariant on a compiled `ContractJson`.
@@ -262,10 +260,8 @@ fn all_examples_compile_and_satisfy_invariants() {
     for path in &paths {
         let rel = path.strip_prefix(&dir).unwrap_or(path);
         let label = rel.display().to_string();
-        let source = fs::read_to_string(path)
-            .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
         let output =
-            compile(&source).unwrap_or_else(|e| panic!("failed to compile {}: {}", label, e));
+            compile_file(path).unwrap_or_else(|e| panic!("failed to compile {}: {}", label, e));
         assert_output_invariants(&output, &label);
     }
 

--- a/tests/examples/covered_call.rs
+++ b/tests/examples/covered_call.rs
@@ -1,4 +1,4 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use arkade_compiler::opcodes::{
     OP_CHECKLOCKTIMEVERIFY, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_INSPECTLOCKTIME,
     OP_INSPECTOUTASSETLOOKUP,
@@ -6,13 +6,16 @@ use arkade_compiler::opcodes::{
 
 use crate::common::{arkade_asm, arkade_inputs, group};
 
-const CALL_CODE: &str = include_str!("../../examples/options/covered_call.ark");
+const CALL_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/options/covered_call.ark"
+);
 
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_compiles_with_5_groups() {
     // 4 covenant functions + 1 standalone unilateral tapscript = 5 groups
-    let out = compile(CALL_CODE).expect("compile");
+    let out = compile_file(CALL_PATH).expect("compile");
     assert_eq!(out.name, "CoveredCall");
     assert_eq!(out.functions.len(), 5);
 }
@@ -20,7 +23,7 @@ fn test_compiles_with_5_groups() {
 #[test]
 fn test_exercise_takes_only_buyer_signature() {
     // Single-locked design: exercise is buyer-gated. No oracle, no seller.
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     let names = arkade_inputs(&out, "exercise");
     assert!(
         names.contains(&"buyerSig".to_string()),
@@ -44,7 +47,7 @@ fn test_exercise_takes_only_buyer_signature() {
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_exercise_has_no_oracle() {
     // No checkSigFromStack — there is no oracle dependency in this design.
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     for fn_name in ["exercise", "reclaim", "transferSeller", "transferBuyer"] {
         let asm = arkade_asm(&out, fn_name);
         assert!(
@@ -56,7 +59,7 @@ fn test_exercise_has_no_oracle() {
 
 #[test]
 fn test_exercise_verifies_strike_payment() {
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     let asm = arkade_asm(&out, "exercise");
     assert!(
         asm.contains(OP_INSPECTOUTASSETLOOKUP),
@@ -75,7 +78,7 @@ fn test_exercise_verifies_strike_payment() {
 
 #[test]
 fn test_reclaim_is_seller_only_with_timelock() {
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     let names = arkade_inputs(&out, "reclaim");
     assert!(
         names.contains(&"sellerSig".to_string()),
@@ -98,7 +101,7 @@ fn test_reclaim_is_seller_only_with_timelock() {
 
 #[test]
 fn test_asset_id_is_two_explicit_params() {
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     let txid = out
         .parameters
         .iter()
@@ -117,7 +120,7 @@ fn test_asset_id_is_two_explicit_params() {
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_transfers_guarded_by_expiry() {
     // Cooperative covenant carries the `tx.time < expiryHeight` guard.
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     for name in ["transferSeller", "transferBuyer"] {
         let asm = arkade_asm(&out, name);
         assert!(
@@ -132,7 +135,7 @@ fn test_transfers_guarded_by_expiry() {
 fn test_transfers_preserve_btc_collateral() {
     // CoveredCall vault holds BTC only — transfers must check the
     // continuation's BTC value, not asset balance.
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     for name in ["transferSeller", "transferBuyer"] {
         let asm = arkade_asm(&out, name);
         assert!(
@@ -153,7 +156,7 @@ fn test_transfers_preserve_btc_collateral() {
 #[test]
 fn test_unilateral_leaf_has_no_introspection() {
     // The unilateral tapscript (CSV exit) must carry no introspection opcodes.
-    let out = compile(CALL_CODE).unwrap();
+    let out = compile_file(CALL_PATH).unwrap();
     let g = group(&out, "unilateral");
     assert_eq!(g.leaves.len(), 1);
     let leaf_asm = g.leaves[0].asm.join(" ");

--- a/tests/examples/fuji_safe.rs
+++ b/tests/examples/fuji_safe.rs
@@ -18,7 +18,9 @@ fn test_fuji_safe_contract() {
     // Verify parameters
     assert_eq!(output.parameters.len(), 12);
     assert_eq!(output.parameters[10].name, "treasuryBurnScript");
+    assert_eq!(output.parameters[10].param_type, "bytes32");
     assert_eq!(output.parameters[11].name, "borrowerBurnScript");
+    assert_eq!(output.parameters[11].param_type, "bytes32");
     assert_eq!(output.parameters[0].name, "assetCommitmentHash");
     assert_eq!(output.parameters[0].param_type, "bytes");
     assert_eq!(output.parameters[1].name, "borrowAmount");
@@ -49,27 +51,93 @@ fn test_fuji_safe_contract() {
         "missing unilateral group"
     );
 
-    for function in ["claim", "liquidate"] {
-        for opcode in ["OP_INSPECTOUTPUTSCRIPTPUBKEY", "OP_INSPECTOUTPUTVALUE"] {
-            assert_eq!(
-                crate::common::opcode_count_in_arkade(&output, function, opcode),
-                1,
-                "{function} must enforce the private treasury burning helper"
+    for (function, script, script_read, value_read, inputs) in [
+        (
+            "claim",
+            "<treasuryBurnScript>",
+            "OP_5 OP_PICK",
+            "OP_2 OP_PICK",
+            &[("treasurySig", "signature")][..],
+        ),
+        (
+            "liquidate",
+            "<treasuryBurnScript>",
+            "OP_9 OP_PICK",
+            "OP_3 OP_PICK",
+            &[
+                ("currentPrice", "int"),
+                ("oracleSig", "signature"),
+                ("treasurySig", "signature"),
+            ][..],
+        ),
+        (
+            "redeem",
+            "<borrowerBurnScript>",
+            "OP_3 OP_PICK",
+            "OP_1 OP_PICK",
+            &[("borrowerSig", "signature")][..],
+        ),
+        (
+            "renew",
+            "<borrowerBurnScript>",
+            concat!(
+                "<VTXO:FujiSafe(<assetCommitmentHash>,<borrowAmount>,<borrowerPk>,<treasuryPk>,",
+                "<expirationTimeout>,<priceLevel>,<setupTimestamp>,<oraclePk>,<assetPair>,<exit>,",
+                "<treasuryBurnScript>,<borrowerBurnScript>)>"
+            ),
+            "OP_1 OP_PICK",
+            &[("treasurySig", "signature")][..],
+        ),
+    ] {
+        let group = crate::common::group(&output, function);
+        let covenant = group.arkade.as_ref().expect("covenant");
+        assert_eq!(
+            covenant
+                .inputs
+                .iter()
+                .map(|input| (input.name.as_str(), input.param_type.as_str()))
+                .collect::<Vec<_>>(),
+            inputs
+        );
+        let asm = crate::common::arkade_asm_tokens(&output, function);
+        assert_eq!(asm.first().map(String::as_str), Some(script));
+        for (opcode, operand) in [
+            ("OP_INSPECTOUTPUTSCRIPTPUBKEY OP_DROP", script_read),
+            ("OP_INSPECTOUTPUTVALUE", value_read),
+        ] {
+            let comparison = format!("0 {opcode} {operand} OP_EQUAL OP_VERIFY");
+            let expected = comparison.split_whitespace().collect::<Vec<_>>();
+            assert!(
+                asm.windows(expected.len()).any(|window| window
+                    .iter()
+                    .map(String::as_str)
+                    .eq(expected.iter().copied())),
+                "{function} must enforce {comparison}"
             );
         }
-    }
-
-    for (function, script) in [
-        ("claim", "treasuryBurnScript"),
-        ("liquidate", "treasuryBurnScript"),
-        ("redeem", "borrowerBurnScript"),
-    ] {
-        assert!(
-            crate::common::arkade_asm_tokens(&output, function).contains(&format!("<{script}>"))
+        assert_eq!(group.leaves.len(), 1);
+        assert_eq!(group.leaves[0].name, function);
+        assert_eq!(
+            crate::common::leaf_asm(&output, function, function),
+            format!("<SERVER_KEY> {OP_CHECKSIGVERIFY} <EMULATOR_KEY:{function}> {OP_CHECKSIG}")
+        );
+        assert_eq!(
+            group.leaves[0]
+                .witness
+                .iter()
+                .map(|input| (
+                    input.name.as_str(),
+                    input.elem_type.as_str(),
+                    input.encoding.as_str(),
+                    input.injected
+                ))
+                .collect::<Vec<_>>(),
+            [
+                ("serverSig", "signature", "schnorr-64", true),
+                ("emulatorSig", "signature", "schnorr-64", true),
+            ]
         );
     }
-    let renewal = crate::common::arkade_asm(&output, "renew");
-    assert!(renewal.contains("<treasuryBurnScript>,<borrowerBurnScript>)>"));
 
     // The claim covenant checks expiration through locktime inspection.
     let claim_asm = crate::common::arkade_asm(&output, "claim");
@@ -82,19 +150,6 @@ fn test_fuji_safe_contract() {
         claim_asm.contains(OP_CHECKSIG),
         "claim covenant should verify treasury sig: {}",
         claim_asm
-    );
-
-    // claim leaf carries server + emulator cosig
-    let claim_leaf = crate::common::leaf_asm(&output, "claim", "claim");
-    assert!(
-        claim_leaf.contains("<SERVER_KEY>"),
-        "claim leaf should have SERVER_KEY: {}",
-        claim_leaf
-    );
-    assert!(
-        claim_leaf.contains(OP_CHECKSIGVERIFY),
-        "claim leaf should have CHECKSIGVERIFY: {}",
-        claim_leaf
     );
 
     // Verify liquidate function: price comparison + oracle sig + CLTV
@@ -115,14 +170,6 @@ fn test_fuji_safe_contract() {
         liquidate_asm
     );
 
-    // liquidate leaf carries server + emulator cosig
-    let liquidate_leaf = crate::common::leaf_asm(&output, "liquidate", "liquidate");
-    assert!(
-        liquidate_leaf.contains("<SERVER_KEY>"),
-        "liquidate leaf should have SERVER_KEY: {}",
-        liquidate_leaf
-    );
-
     // Verify redeem function: borrower signature
     let redeem_asm = crate::common::arkade_asm(&output, "redeem");
     assert!(
@@ -131,28 +178,12 @@ fn test_fuji_safe_contract() {
         redeem_asm
     );
 
-    // redeem leaf carries server + emulator cosig
-    let redeem_leaf = crate::common::leaf_asm(&output, "redeem", "redeem");
-    assert!(
-        redeem_leaf.contains("<SERVER_KEY>"),
-        "redeem leaf should have SERVER_KEY: {}",
-        redeem_leaf
-    );
-
     // Verify renew function: treasury signature
     let renew_asm = crate::common::arkade_asm(&output, "renew");
     assert!(
         renew_asm.contains(OP_CHECKSIG),
         "renew covenant should verify treasury sig: {}",
         renew_asm
-    );
-
-    // renew leaf carries server + emulator cosig
-    let renew_leaf = crate::common::leaf_asm(&output, "renew", "renew");
-    assert!(
-        renew_leaf.contains("<SERVER_KEY>"),
-        "renew leaf should have SERVER_KEY: {}",
-        renew_leaf
     );
 
     // Unilateral exit: CSV-based, borrower only (no server involvement)

--- a/tests/examples/fuji_safe.rs
+++ b/tests/examples/fuji_safe.rs
@@ -16,7 +16,9 @@ fn test_fuji_safe_contract() {
     assert_eq!(output.name, "FujiSafe");
 
     // Verify parameters
-    assert_eq!(output.parameters.len(), 10);
+    assert_eq!(output.parameters.len(), 12);
+    assert_eq!(output.parameters[10].name, "treasuryBurnScript");
+    assert_eq!(output.parameters[11].name, "borrowerBurnScript");
     assert_eq!(output.parameters[0].name, "assetCommitmentHash");
     assert_eq!(output.parameters[0].param_type, "bytes");
     assert_eq!(output.parameters[1].name, "borrowAmount");
@@ -56,6 +58,18 @@ fn test_fuji_safe_contract() {
             );
         }
     }
+
+    for (function, script) in [
+        ("claim", "treasuryBurnScript"),
+        ("liquidate", "treasuryBurnScript"),
+        ("redeem", "borrowerBurnScript"),
+    ] {
+        assert!(
+            crate::common::arkade_asm_tokens(&output, function).contains(&format!("<{script}>"))
+        );
+    }
+    let renewal = crate::common::arkade_asm(&output, "renew");
+    assert!(renewal.contains("<treasuryBurnScript>,<borrowerBurnScript>)>"));
 
     // The claim covenant checks expiration through locktime inspection.
     let claim_asm = crate::common::arkade_asm(&output, "claim");

--- a/tests/examples/fuji_safe.rs
+++ b/tests/examples/fuji_safe.rs
@@ -4,6 +4,17 @@ use arkade_compiler::opcodes::{
 };
 
 #[test]
+fn fuji_safe_rejects_the_old_constructor_layout() {
+    let source = include_str!("../../examples/fuji_safe/fuji_safe.ark")
+        .replace(",\n        treasuryBurnScript, borrowerBurnScript\n", "\n");
+    let error = compile(&source).unwrap_err().to_string();
+    assert!(
+        error.contains("constructor 'FujiSafe' expects 12 arguments, got 10"),
+        "{error}"
+    );
+}
+
+#[test]
 fn test_fuji_safe_contract() {
     let fuji_code = include_str!("../../examples/fuji_safe/fuji_safe.ark");
 

--- a/tests/examples/htlc.rs
+++ b/tests/examples/htlc.rs
@@ -176,7 +176,7 @@ fn test_htlc_cli() {
     fs::write(&input_path, HTLC_CODE).unwrap();
 
     // Compile via library
-    let result = compile(HTLC_CODE);
+    let result = arkade_compiler::compile_file(&input_path);
     assert!(result.is_ok());
 
     // Run the CLI command

--- a/tests/examples/layerzero.rs
+++ b/tests/examples/layerzero.rs
@@ -1,4 +1,4 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_sources;
 use arkade_compiler::models::ContractJson;
 use arkade_compiler::opcodes::{
     OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DROP, OP_FINDASSETGROUPBYASSETID,
@@ -53,6 +53,23 @@ fn has_self_continuation(asm: &[String]) -> bool {
 //   - Both marker contracts pin themselves to the consuming contract's
 //     control-asset singleton.
 // ---------------------------------------------------------------------------
+
+fn compile(source: &str) -> Result<arkade_compiler::ContractJson, Box<dyn std::error::Error>> {
+    let files = [
+        ("main.ark".to_string(), source.to_string()),
+        (
+            "receive_marker.ark".to_string(),
+            include_str!("../../examples/layerzero/receive_marker.ark").to_string(),
+        ),
+        (
+            "send_marker.ark".to_string(),
+            include_str!("../../examples/layerzero/send_marker.ark").to_string(),
+        ),
+    ]
+    .into_iter()
+    .collect();
+    compile_sources("main.ark", &files)
+}
 
 fn load_example(name: &str) -> String {
     let path = format!("examples/layerzero/{}.ark", name);

--- a/tests/examples/repayment_pool.rs
+++ b/tests/examples/repayment_pool.rs
@@ -1,4 +1,4 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use arkade_compiler::opcodes::{
     OP_CAT, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_DIV, OP_FINDASSETGROUPBYASSETID,
     OP_INSPECTASSETGROUPCTRL, OP_INSPECTASSETGROUPSUM, OP_INSPECTINPUTSCRIPTPUBKEY,
@@ -10,12 +10,15 @@ use crate::common::{
     arkade_asm, arkade_asm_tokens, arkade_inputs, opcode_count_in_arkade, user_signatures,
 };
 
-const CODE: &str = include_str!("../../examples/bonds/repayment_pool.ark");
+const PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/bonds/repayment_pool.ark"
+);
 
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_repayment_pool_compiles() {
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     assert_eq!(output.name, "RepaymentPool");
     // 7 covenant functions (issue, acceptRepayment, rollOut, rollIn, liquidate,
     // acceptAuction, redeem) produce 7 function groups.
@@ -145,7 +148,7 @@ fn test_pool_retains_debit_ctrl_in_every_function() {
     // at least three: usdtAssetId balance + creditCtrlId retention +
     // debitCtrlId retention. (issue, rollIn additionally check credit/debit
     // delivery to the borrower output, so they emit more.)
-    let output = compile(CODE).expect("pool compilation failed");
+    let output = compile_file(PATH).expect("pool compilation failed");
     let pool_recreating_fns = [
         "issue",
         "acceptRepayment",
@@ -175,7 +178,7 @@ fn test_no_interest_rate_anywhere() {
     // match, case-insensitive) rather than a hard-coded pair of names — so
     // a future regression that re-adds interest accrual under any plausible
     // name is caught.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let names: Vec<String> = output
         .parameters
         .iter()
@@ -206,7 +209,7 @@ fn test_no_interest_rate_anywhere() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_issue_is_oracle_priced_and_dual_mints() {
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "issue");
     assert!(
         asm.contains(OP_CHECKSIGFROMSTACK),
@@ -262,7 +265,7 @@ fn test_issue_enforces_deployment_invariants() {
     // the EXACT count means removing any single invariant fails the test —
     // a `>= 5` lower bound would let one be silently deleted.
     // (OP_GREATERTHANOREQUAL / *_64 are distinct opcodes, not counted here.)
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let gt = opcode_count_in_arkade(&output, "issue", "OP_GREATERTHAN");
     assert_eq!(
         gt, 6,
@@ -347,7 +350,7 @@ fn test_issue_uses_ceiling_division_on_required_collateral() {
     // on the presence of `9999` as a token in both issue + rollIn locks in
     // the fix at the ASM level — a regression to floor division (or to
     // a different bias like + 5000) trips this test.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     for fn_name in ["issue", "rollIn"] {
         let tokens = arkade_asm_tokens(&output, fn_name);
         assert!(
@@ -362,7 +365,7 @@ fn test_issue_uses_ceiling_division_on_required_collateral() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_accept_repayment_validates_vault_and_burns_debit() {
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "acceptRepayment");
     assert!(
         asm.contains(OP_INSPECTINPUTSCRIPTPUBKEY),
@@ -391,7 +394,7 @@ fn test_accept_repayment_validates_vault_and_burns_debit() {
 fn test_accept_auction_is_permissionless_oracle_priced_phased() {
     // Oracle witness only. Auctioneer identity = witness pubkey.
     // Phased gate: tx.time >= maturity AND tx.time < maturity + auctionWindow.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "acceptAuction");
     assert!(
         asm.contains(OP_CHECKSIGFROMSTACK),
@@ -450,7 +453,7 @@ fn test_liquidate_is_oracle_priced_health_gated_permissionless() {
     // collateral when collateralValue < liqThresholdBps × mintedAmount / 10000.
     // Same two-branch payout as acceptAuction, same auctioneer-discount
     // incentive — but pre-maturity and triggered by the health threshold.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "liquidate");
     assert!(
         asm.contains(OP_CHECKSIGFROMSTACK),
@@ -518,7 +521,7 @@ fn test_liquidate_and_accept_auction_are_phase_disjoint() {
     // (discount bound + pre-maturity gate + health gate); acceptAuction carries
     // an OP_LESSTHAN for its window upper bound but its lower bound is a
     // >= comparison — so the two paths can never both be valid at one height.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     assert_eq!(
         opcode_count_in_arkade(&output, "liquidate", "OP_LESSTHAN"),
         3,
@@ -535,7 +538,7 @@ fn test_liquidate_and_accept_auction_are_phase_disjoint() {
 fn test_redeem_is_pro_rata_post_window() {
     // redeem only opens AFTER the auction window closes, so the rate
     // (usdtBalance / totalCreditOutstanding) is locked and fair for all orderings.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "redeem");
     assert!(
         asm.contains(OP_MUL) && asm.contains(OP_DIV),
@@ -599,7 +602,7 @@ fn test_roll_out_extinguishes_old_obligation_at_witness_index() {
     // and force-liquidate a healthy vault at par price, bypassing
     // pool.liquidate's oracle + healthFloor gate entirely. The pool-side sig
     // is the gate that blocks that pairing.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "rollOut");
     assert!(
         asm.contains(OP_INSPECTINPUTSCRIPTPUBKEY),
@@ -664,7 +667,7 @@ fn test_roll_in_oracle_priced_dual_mints_at_witness_indices() {
     // over-collateralisation; mints credit + debit; pins the new BondMint
     // vault + the credit destination + the pool recreation, all at witness
     // output indices.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let asm = arkade_asm(&output, "rollIn");
     assert!(
         asm.contains(OP_CHECKSIGFROMSTACK),
@@ -725,7 +728,7 @@ fn test_roll_pair_enforces_all_deployment_invariants() {
     // liqThresholdBps > 0, auctionWindow > 0, auctionDiscountBps in
     // [0, 10000)). Without these re-checks a misconfigured pool that
     // somehow escaped issue could still mint fresh vaults via rollIn.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     let gt = opcode_count_in_arkade(&output, "rollIn", "OP_GREATERTHAN");
     // 3 `> 0` value guards (newMintedAmount, newCollateral, oraclePrice) +
     // 3 deployment invariants (initRatioBps > liqThresholdBps,
@@ -772,7 +775,7 @@ fn test_default_leaves_carry_no_introspection() {
     // All covenant introspection lives in the arkade block; the leaves are
     // pure cosig. This test verifies no introspection opcode leaked into any
     // default leaf.
-    let output = compile(CODE).expect("compilation failed");
+    let output = compile_file(PATH).expect("compilation failed");
     for fn_name in [
         "issue",
         "acceptRepayment",
@@ -802,13 +805,7 @@ fn test_repayment_pool_cli() {
     use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
-    fs::write(
-        dir.path().join("bond_mint.ark"),
-        include_str!("../../examples/bonds/bond_mint.ark"),
-    )
-    .unwrap();
-    let input = dir.path().join("repayment_pool.ark");
-    fs::write(&input, CODE).unwrap();
+    let input = std::path::Path::new(PATH);
     let out = dir.path().join("repayment_pool.json");
 
     let result = std::process::Command::new(env!("CARGO_BIN_EXE_arkadec"))

--- a/tests/examples/stability_vault.rs
+++ b/tests/examples/stability_vault.rs
@@ -1,16 +1,22 @@
-use arkade_compiler::compile;
+use arkade_compiler::compile_file;
 use arkade_compiler::opcodes::{OP_CAT, OP_CHECKSIG, OP_CHECKSIGFROMSTACK, OP_SHA256};
 
 use crate::common::arkade_asm;
 
-const VAULT_CODE: &str = include_str!("../../examples/stability/stability_vault.ark");
-const OFFER_CODE: &str = include_str!("../../examples/stability/stability_offer.ark");
+const VAULT_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/stability/stability_vault.ark"
+);
+const OFFER_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/stability/stability_offer.ark"
+);
 
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_vault_compiles_with_9_groups() {
     // 8 covenant functions + 1 unilateral tapscript = 9 groups
-    let out = compile(VAULT_CODE).expect("vault compile");
+    let out = compile_file(VAULT_PATH).expect("vault compile");
     assert_eq!(out.name, "StabilityVault");
     assert_eq!(out.functions.len(), 9);
 }
@@ -19,7 +25,7 @@ fn test_vault_compiles_with_9_groups() {
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_merge_emits_active_input_index_opcode() {
     use arkade_compiler::opcodes::OP_PUSHCURRENTINPUTINDEX;
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     let asm = arkade_asm(&out, "merge");
     assert!(
         asm.contains(OP_PUSHCURRENTINPUTINDEX),
@@ -37,7 +43,7 @@ fn test_vault_settlement_verifies_full_oracle_message() {
     // seekerExit and providerExit must reconstruct sha256(ticker || price || time)
     // via OP_CAT + OP_SHA256 and verify the oracle sig against it.
     // Oracle logic lives in the covenant (arkade) ASM.
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     for name in &["seekerExit", "providerExit"] {
         let asm_tokens: Vec<String> = crate::common::arkade_asm_tokens(&out, name);
         let asm = asm_tokens.join(" ");
@@ -58,7 +64,7 @@ fn test_vault_settlement_verifies_full_oracle_message() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_vault_transfer_is_pure_keyswap() {
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     let asm = arkade_asm(&out, "transfer");
     assert!(
         !asm.contains(OP_CHECKSIGFROMSTACK),
@@ -72,7 +78,7 @@ fn test_vault_transfer_is_pure_keyswap() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_vault_split_is_pure_keyswap() {
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     let asm = arkade_asm(&out, "split");
     assert!(
         !asm.contains(OP_CHECKSIGFROMSTACK),
@@ -87,7 +93,7 @@ fn test_vault_split_is_pure_keyswap() {
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_settle_and_update_funding_does_no_oracle_call() {
     // Funding update is purely time-driven; no oracle witness involved.
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     let asm = arkade_asm(&out, "settleAndUpdateFunding");
     assert!(
         !asm.contains(OP_CHECKSIGFROMSTACK),
@@ -102,7 +108,7 @@ fn test_settle_and_update_funding_does_no_oracle_call() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_add_capital_does_no_oracle_call() {
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     let asm = arkade_asm(&out, "addCapital");
     assert!(
         !asm.contains(OP_CHECKSIGFROMSTACK),
@@ -113,7 +119,7 @@ fn test_add_capital_does_no_oracle_call() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_remove_capital_verifies_oracle() {
-    let out = compile(VAULT_CODE).unwrap();
+    let out = compile_file(VAULT_PATH).unwrap();
     let asm = arkade_asm(&out, "removeCapital");
     assert!(
         asm.contains(OP_CHECKSIGFROMSTACK),
@@ -129,7 +135,7 @@ fn test_remove_capital_verifies_oracle() {
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_offer_compiles_with_3_groups() {
     // 2 covenant functions + 1 unilateral tapscript = 3 groups
-    let out = compile(OFFER_CODE).expect("offer compile");
+    let out = compile_file(OFFER_PATH).expect("offer compile");
     assert_eq!(out.name, "StabilityOffer");
     assert_eq!(out.functions.len(), 3);
 }
@@ -137,7 +143,7 @@ fn test_offer_compiles_with_3_groups() {
 #[test]
 #[ignore = "dynamic contract reconstruction is temporarily disabled"]
 fn test_offer_take_verifies_full_oracle_message() {
-    let out = compile(OFFER_CODE).unwrap();
+    let out = compile_file(OFFER_PATH).unwrap();
     let asm_tokens = crate::common::arkade_asm_tokens(&out, "take");
     let asm = asm_tokens.join(" ");
     let cat_count = asm_tokens.iter().filter(|s| s.as_str() == OP_CAT).count();

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -54,3 +54,6 @@ mod tx_introspection;
 mod type_system;
 #[path = "features/validation_error.rs"]
 mod validation_error;
+
+#[path = "features/imports.rs"]
+mod imports;

--- a/tests/features/contract_import_instantiation.rs
+++ b/tests/features/contract_import_instantiation.rs
@@ -1,4 +1,13 @@
-use arkade_compiler::compile;
+fn compile(source: &str) -> Result<arkade_compiler::ContractJson, Box<dyn std::error::Error>> {
+    arkade_compiler::compile_sources("main.ark", &[
+        ("main.ark", source),
+        ("single_sig.ark", "contract SingleSig(pubkey owner, int exit) {}"),
+        ("htlc.ark", "contract HTLC(pubkey sender, pubkey receiver, bytes hash, int refundTime, int exit) {}"),
+        ("random_num.ark", "contract RandomNum() {}"),
+        ("time_locked.ark", "contract TimeLocked(pubkey owner, int exit) {}"),
+        ("threshold_oracle.ark", "contract ThresholdOracle(pubkey[3] owners) {}"),
+    ].into_iter().map(|(path, code)| (path.to_string(), code.to_string())).collect())
+}
 
 use crate::common::{arkade_asm, arkade_asm_tokens, leaf_asm, leaf_asm_tokens};
 
@@ -7,7 +16,7 @@ use crate::common::{arkade_asm, arkade_asm_tokens, leaf_asm, leaf_asm_tokens};
 #[test]
 fn test_import_statement_is_parsed() {
     // A contract file that declares an import before the contract keyword.
-    // The import path is captured in the AST (not resolved at compile time).
+    // The imported file is loaded even when no declaration is referenced.
     let code = r#"
 import "single_sig.ark";
 
@@ -684,7 +693,6 @@ fn test_self_referential_contract() {
     // common recursion pattern for VTXOs). SelfRef has 1 param (ownerPk only)
     // as the inline contract defines it; renew passes ownerPk back to itself.
     let code = r#"
-import "self.ark";
 
 contract SelfRef(pubkey ownerPk) {
   function renew() {

--- a/tests/features/general_comparisons.rs
+++ b/tests/features/general_comparisons.rs
@@ -270,8 +270,7 @@ fn comparison_results_can_be_compared_as_boolean_operands() {
 
 #[test]
 fn constructor_and_introspection_results_use_general_comparisons() {
-    let asm = compile_asm(
-        r#"
+    let source = r#"
 import "single_sig.ark";
 
 contract Compare(pubkey owner, bytes expectedScript, bytes32 expectedTxid) {
@@ -280,8 +279,21 @@ contract Compare(pubkey owner, bytes expectedScript, bytes32 expectedTxid) {
         require(expectedTxid == tx.id);
     }
 }
-"#,
-    );
+"#;
+    let output = arkade_compiler::compile_sources(
+        "main.ark",
+        &[
+            ("main.ark".into(), source.into()),
+            (
+                "single_sig.ark".into(),
+                "contract SingleSig(pubkey owner) {}".into(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    )
+    .unwrap();
+    let asm = crate::common::arkade_asm_tokens(&output, "compare");
 
     assert!(
         asm.windows(4).any(|window| {

--- a/tests/features/imports.rs
+++ b/tests/features/imports.rs
@@ -268,11 +268,21 @@ fn constructors_require_visible_contracts_and_matching_signatures() {
 fn native_and_virtual_compilation_match_and_bundle_is_portable() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir(dir.path().join("contracts")).unwrap();
-    let source = r#"import "../helper.ark"; contract Main() { function spend() { require(Helper.VALUE == 1); } }"#;
-    let helper = "contract Helper() { const int VALUE = 1; }";
+    let source = r#"import "../helper.ark"; contract Main() { function spend() { require(Helper.VALUE == 1); require(1); } }"#;
+    let helper = "contract Helper() { const int VALUE = 1; function spend() { require(2); } }";
     std::fs::write(dir.path().join("contracts/main.ark"), source).unwrap();
     std::fs::write(dir.path().join("helper.ark"), helper).unwrap();
     let output = compile_file(dir.path().join("contracts/main.ark")).unwrap();
+    assert_eq!(output.warnings.len(), 2);
+    for path in ["contracts/main.ark", "helper.ark"] {
+        assert!(
+            output.warnings.iter().any(|warning| {
+                warning.starts_with("warning[type]:") && warning.ends_with(&format!(" ({path})"))
+            }),
+            "{:?}",
+            output.warnings
+        );
+    }
     let mut virtual_output = project(
         "contracts/main.ark",
         &[("contracts/main.ark", source), ("helper.ark", helper)],

--- a/tests/features/imports.rs
+++ b/tests/features/imports.rs
@@ -209,6 +209,36 @@ fn imports_validate_paths_cycles_and_name_collisions() {
 }
 
 #[test]
+fn import_depth_limit_includes_the_entry_file() {
+    for count in [128, 129] {
+        let files = (0..count)
+            .map(|index| {
+                let import = if index + 1 < count {
+                    format!("import \"{}.ark\";", index + 1)
+                } else {
+                    String::new()
+                };
+                (
+                    format!("{index}.ark"),
+                    format!(
+                        "{import} contract C{index}() {{ function spend() {{ require(true); }} }}"
+                    ),
+                )
+            })
+            .collect();
+        let result = compile_sources("0.ark", &files);
+        if count == 128 {
+            assert_eq!(result.unwrap().source.unwrap().files.len(), count);
+        } else {
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("import depth exceeds 128 files"));
+        }
+    }
+}
+
+#[test]
 fn constructors_require_visible_contracts_and_matching_signatures() {
     for (call, succeeds) in [
         ("Other(owner)", true),

--- a/tests/features/imports.rs
+++ b/tests/features/imports.rs
@@ -1,0 +1,373 @@
+use std::collections::BTreeMap;
+
+use crate::common::{arkade_asm_tokens, leaf_asm_tokens};
+use arkade_compiler::{compile, compile_file, compile_sources, ContractJson};
+
+fn project(
+    entry: &str,
+    sources: &[(&str, &str)],
+) -> Result<ContractJson, Box<dyn std::error::Error>> {
+    compile_sources(
+        entry,
+        &sources
+            .iter()
+            .map(|(path, source)| (path.to_string(), source.to_string()))
+            .collect(),
+    )
+}
+
+#[test]
+fn imports_inline_helpers_fold_constants_and_preserve_sources() {
+    let source = r#"// Original source and comments are embedded.
+import "../shared/types.ark";
+import "../shared/fees.ark";
+contract Vault(Policy policy, int amount, pubkey owner) {
+    function spend(int value) {
+        require(Fees.calculate(value) <= policy.maximum);
+        require(value >= Fees.MINIMUM);
+        require(value != amount);
+    }
+    function exit(signature sig) tapscript { require(older(Fees.DELAY)); require(checkSig(sig, owner)); }
+}"#;
+    let types = "struct Policy { int maximum; } // end of file comment";
+    let fees = r#"contract Fees() {
+        const int MINIMUM = 10;
+        const int DELAY = 144;
+        static function twice(int amount) int { return amount * 2; }
+        static function calculate(int amount) int { return twice(amount) + MINIMUM; }
+    }"#;
+    let output = project(
+        "contracts/vault.ark",
+        &[
+            ("contracts/vault.ark", source),
+            ("shared/types.ark", types),
+            ("shared/fees.ark", fees),
+            ("unused.ark", "invalid unused source"),
+        ],
+    )
+    .expect("imports compile");
+    let flat = compile(
+        r#"struct Policy { int maximum; }
+contract Vault(Policy policy, int amount, pubkey owner) {
+    function spend(int value) {
+        require(calculate(value) <= policy.maximum);
+        require(value >= 10);
+        require(value != amount);
+    }
+    static function twice(int n) int { return n * 2; }
+    static function calculate(int n) int { return twice(n) + 10; }
+    function exit(signature sig) tapscript { require(older(144)); require(checkSig(sig, owner)); }
+}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        arkade_asm_tokens(&output, "spend"),
+        arkade_asm_tokens(&flat, "spend")
+    );
+    assert_eq!(
+        leaf_asm_tokens(&output, "exit", "exit"),
+        leaf_asm_tokens(&flat, "exit", "exit")
+    );
+    assert_eq!(output.functions.len(), 2);
+    assert_eq!(output.structs.len(), 1);
+    assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    let bundle = output.source.as_ref().unwrap();
+    assert_eq!(bundle.entry, "contracts/vault.ark");
+    assert_eq!(bundle.files.len(), 3);
+    assert_eq!(bundle.files["contracts/vault.ark"], source);
+    assert_eq!(bundle.files["shared/types.ark"], types);
+    let restored: ContractJson =
+        serde_json::from_str(&serde_json::to_string(&output).unwrap()).unwrap();
+    let bundle = restored.source.unwrap();
+    let mut rebuilt = compile_sources(&bundle.entry, &bundle.files).unwrap();
+    rebuilt.updated_at = output.updated_at.clone();
+    assert_eq!(
+        serde_json::to_value(rebuilt).unwrap(),
+        serde_json::to_value(output).unwrap()
+    );
+}
+
+#[test]
+fn transitive_imports_keep_defining_scope_and_deduplicate_diamonds() {
+    let output = project("main.ark", &[
+        ("main.ark", r#"import "a.ark"; import "b.ark";
+contract Main() { const int VALUE = 999; function spend() { require(A.value() == B.VALUE); } }"#),
+        ("a.ark", r#"import "./b.ark"; contract A() { static function value() int { return B.VALUE; } }"#),
+        ("b.ark", "contract B() { const int VALUE = 7; }"),
+    ]).unwrap();
+    assert_eq!(output.source.unwrap().files.len(), 3);
+    let error = project("main.ark", &[
+        ("main.ark", r#"import "a.ark"; contract Main() { function spend() { require(B.value() == 7); } }"#),
+        ("a.ark", r#"import "b.ark"; contract A() {}"#),
+        ("b.ark", "contract B() { static function value() int { return 7; } }"),
+    ]).unwrap_err().to_string();
+    assert!(error.contains("unknown contract 'B'"), "{error}");
+}
+
+#[test]
+fn imported_struct_dependencies_are_available_for_layout_but_not_declaration() {
+    for (ty, succeeds) in [("Policy", true), ("Hidden", false)] {
+        let source = format!(
+            r#"import "policy.ark"; contract Main({ty} policy) {{ function spend() {{ require(true); }} }}"#
+        );
+        let result = project(
+            "main.ark",
+            &[
+                ("main.ark", &source),
+                (
+                    "policy.ark",
+                    r#"import "hidden.ark"; struct Policy { Hidden value; }"#,
+                ),
+                ("hidden.ark", "struct Hidden { int number; }"),
+            ],
+        );
+        assert_eq!(result.is_ok(), succeeds, "{result:?}");
+    }
+}
+
+#[test]
+fn imported_helpers_cannot_capture_callers_state_or_call_private_functions() {
+    for (body, expected) in [
+        (
+            "static function value() int { return amount; }",
+            "binding 'amount' is undefined",
+        ),
+        (
+            "private function value() int { return 1; }",
+            "not a static function",
+        ),
+        (
+            "function value() { require(true); }",
+            "not a static function",
+        ),
+    ] {
+        let dependency = format!("contract Helper() {{ {body} }}");
+        let error = project("main.ark", &[
+            ("main.ark", r#"import "helper.ark"; contract Main(int amount) { function spend() { require(Helper.value() == amount); } }"#),
+            ("helper.ark", &dependency),
+        ]).unwrap_err().to_string();
+        assert!(error.contains(expected), "{error}");
+    }
+}
+
+#[test]
+fn imports_validate_paths_cycles_and_name_collisions() {
+    for (files, expected) in [
+        (
+            vec![("main.ark", r#"import "missing.ark"; contract Main() {}"#)],
+            "missing.ark",
+        ),
+        (
+            vec![("main.ark", r#"import "main.ark"; contract Main() {}"#)],
+            "circular import",
+        ),
+        (
+            vec![
+                ("main.ark", r#"import "a.ark"; contract Main() {}"#),
+                ("a.ark", r#"import "main.ark"; contract A() {}"#),
+            ],
+            "circular import",
+        ),
+        (
+            vec![("main.ark", r#"import "../a.ark"; contract Main() {}"#)],
+            "escapes the source root",
+        ),
+        (
+            vec![("main.ark", r#"import "/a.ark"; contract Main() {}"#)],
+            "relative .ark path",
+        ),
+        (
+            vec![("main.ark", r#"import "a.txt"; contract Main() {}"#)],
+            ".ark extension",
+        ),
+        (
+            vec![
+                ("main.ark", r#"import "a.ark"; contract Main() {}"#),
+                ("a.ark", "contract Main() {}"),
+            ],
+            "duplicate declaration 'Main'",
+        ),
+        (
+            vec![
+                (
+                    "main.ark",
+                    r#"import "a.ark"; struct Policy { int a; } contract Main() {}"#,
+                ),
+                ("a.ark", "struct Policy { int b; }"),
+            ],
+            "duplicate declaration 'Policy'",
+        ),
+    ] {
+        let error = project("main.ark", &files).unwrap_err().to_string();
+        assert!(error.contains(expected), "{error}");
+        assert!(error.contains("main.ark"), "{error}");
+    }
+    let error = compile(r#"import "a.ark"; contract Main() {}"#)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("imports require source files"), "{error}");
+}
+
+#[test]
+fn constructors_require_visible_contracts_and_matching_signatures() {
+    for (call, succeeds) in [
+        ("Other(owner)", true),
+        ("Other()", false),
+        ("Other(1)", false),
+        ("Missing(owner)", false),
+        ("Main(owner)", true),
+    ] {
+        let source = format!(
+            r#"import "other.ark"; contract Main(pubkey owner) {{ function spend() {{ require(tx.outputs[0].scriptPubKey == new {call}); }} }}"#
+        );
+        let result = project(
+            "main.ark",
+            &[
+                ("main.ark", &source),
+                (
+                    "other.ark",
+                    "contract Other(pubkey owner) { function spend() { require(true); } }",
+                ),
+            ],
+        );
+        assert_eq!(result.is_ok(), succeeds, "{call}: {result:?}");
+    }
+}
+
+#[test]
+fn native_and_virtual_compilation_match_and_bundle_is_portable() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("contracts")).unwrap();
+    let source = r#"import "../helper.ark"; contract Main() { function spend() { require(Helper.VALUE == 1); } }"#;
+    let helper = "contract Helper() { const int VALUE = 1; }";
+    std::fs::write(dir.path().join("contracts/main.ark"), source).unwrap();
+    std::fs::write(dir.path().join("helper.ark"), helper).unwrap();
+    let output = compile_file(dir.path().join("contracts/main.ark")).unwrap();
+    let mut virtual_output = project(
+        "contracts/main.ark",
+        &[("contracts/main.ark", source), ("helper.ark", helper)],
+    )
+    .unwrap();
+    virtual_output.updated_at = output.updated_at.clone();
+    assert_eq!(
+        serde_json::to_value(output).unwrap(),
+        serde_json::to_value(virtual_output).unwrap()
+    );
+    let files = BTreeMap::from([
+        ("./main.ark".to_string(), source.to_string()),
+        ("main.ark".to_string(), source.to_string()),
+    ]);
+    assert!(compile_sources("main.ark", &files)
+        .unwrap_err()
+        .to_string()
+        .contains("duplicate source path"));
+}
+
+#[test]
+fn imported_constants_work_in_named_indices_and_multisig_thresholds() {
+    let output = project("main.ark", &[
+        ("main.ark", r#"import "limits.ark";
+contract Main(pubkey[2] keys, pubkey owner) {
+    function spend(signature sig) {
+        require(checkMultisig([keys[Limits.INDEX]], [sig], Limits.THRESHOLD));
+    }
+    function exit(signature sig) tapscript {
+        require(older(Limits.DELAY));
+        require(checkMultisig([owner], [sig], Limits.THRESHOLD));
+    }
+}"#),
+        ("limits.ark", "contract Limits() { const int INDEX = 1; const int THRESHOLD = 1; const int DELAY = 144; }"),
+    ]).unwrap();
+    assert!(arkade_asm_tokens(&output, "spend").contains(&"<keys.1>".to_string()));
+    assert!(
+        leaf_asm_tokens(&output, "exit", "exit").contains(&"OP_CHECKSEQUENCEVERIFY".to_string())
+    );
+}
+
+#[test]
+fn imported_helpers_do_not_retain_unreferenced_caller_parameters() {
+    let output = project("main.ark", &[
+        ("main.ark", r#"import "helper.ark"; contract Main(int value) { function spend(int input) { require(Helper.double(input) > 0); } }"#),
+        ("helper.ark", "contract Helper() { static function double(int value) int { return value * 2; } }"),
+    ]).unwrap();
+    assert!(!arkade_asm_tokens(&output, "spend").contains(&"<value>".to_string()));
+}
+
+#[test]
+fn imported_helpers_check_returns_recursion_and_namespace_shadowing() {
+    for (entry, helper, expected) in [
+        (
+            "contract Main() { function spend() { require(Helper.value(1) == 1); } }",
+            "contract Helper() { static function value(int x) int { if (x > 0) { return x; } } }",
+            "must return a value on every path",
+        ),
+        (
+            "contract Main() { function spend() { require(Helper.value() == 1); } }",
+            "contract Helper() { static function value() int { return value(); } }",
+            "recursive",
+        ),
+        (
+            "contract Main(int Helper) { function spend() { require(Helper.VALUE > 0); } }",
+            "contract Helper() { const int VALUE = 1; }",
+            "shadows a contract namespace",
+        ),
+        (
+            "contract Main() { function spend() { int Helper = 1; require(Helper.VALUE > 0); } }",
+            "contract Helper() { const int VALUE = 1; }",
+            "shadows a contract namespace",
+        ),
+        (
+            "contract Main() { function spend() { require(Helper.MISSING > 0); } }",
+            "contract Helper() { const int VALUE = 1; }",
+            "unknown constant",
+        ),
+    ] {
+        let source = format!("import \"helper.ark\"; {entry}");
+        let error = project("main.ark", &[("main.ark", &source), ("helper.ark", helper)])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(expected), "{error}");
+    }
+}
+
+#[test]
+fn qualified_static_calls_are_distinct_from_group_methods() {
+    project("main.ark", &[
+        ("main.ark", r#"import "helper.ark"; contract Main(bytes32 txid) { function spend(int index) { require(Helper.controlIs(txid, index)); } }"#),
+        ("helper.ark", "contract Helper() { static function controlIs(bytes32 txid, int index) bool { return index == 0; } }"),
+    ]).unwrap();
+}
+
+#[test]
+fn qualified_constants_in_builtin_operands_and_transaction_indices_match_literals() {
+    let body = r#"contract Main(bytes32 txid) {
+        function spend() {
+            require(size(num2bin(Limits.VALUE, Limits.WIDTH)) == Limits.WIDTH);
+            require(size(tx.inputs[Limits.INDEX].packet(Limits.PACKET)) >= 0);
+            require(size(tx.packet(Limits.PACKET)) >= 0);
+            require(tx.inputs[Limits.INDEX].value >= Limits.VALUE);
+            require(tx.outputs[Limits.INDEX].value >= Limits.VALUE);
+            require(tx.outputs[Limits.INDEX].assets.length >= Limits.INDEX);
+            require(tx.outputs[Limits.INDEX].assets[Limits.INDEX].amount >= Limits.VALUE);
+            require(tx.inputs[Limits.INDEX].assets.lookup(txid, Limits.INDEX) >= Limits.VALUE);
+            require(tx.outputs[Limits.INDEX].scriptPubKey == new Limits(Limits.VALUE));
+        }
+    }"#;
+    let helper = "contract Limits(int value) { const int INDEX = 0; const int VALUE = 7; const int WIDTH = 8; const int PACKET = 16; }";
+    let source = format!("import \"limits.ark\"; {body}");
+    let output = project("main.ark", &[("main.ark", &source), ("limits.ark", helper)]).unwrap();
+    let literal_source = source
+        .replace("Limits.INDEX", "0")
+        .replace("Limits.VALUE", "7")
+        .replace("Limits.WIDTH", "8")
+        .replace("Limits.PACKET", "16");
+    let literal = project(
+        "main.ark",
+        &[("main.ark", &literal_source), ("limits.ark", helper)],
+    )
+    .unwrap();
+    assert_eq!(
+        arkade_asm_tokens(&output, "spend"),
+        arkade_asm_tokens(&literal, "spend")
+    );
+}

--- a/tests/features/symbolic_stack.rs
+++ b/tests/features/symbolic_stack.rs
@@ -404,6 +404,26 @@ contract Paths(int unused, int left, int right, pubkey exitKey, int delay) {
 
 #[test]
 fn constructor_references_cover_nested_bodies_and_named_operands() {
+    let covenant = |source: &str, name: &str| {
+        let output = arkade_compiler::compile_sources(
+            "main.ark",
+            &[
+                ("main.ark".into(), source.into()),
+                (
+                    "policy.ark".into(),
+                    "struct Policy { pubkey key; int[2] limits; }".into(),
+                ),
+                (
+                    "child.ark".into(),
+                    "import \"policy.ark\"; contract Child(Policy policy) {}".into(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )
+        .unwrap();
+        crate::common::group(&output, name).arkade.clone().unwrap()
+    };
     for (parameters, inputs, body, expected) in [
         ("int limit, int alternate, bool choose", "int value",
          "let total = 0; if (choose) { total = limit; } else { total = alternate; } require(total > value);",
@@ -434,7 +454,7 @@ fn constructor_references_cover_nested_bodies_and_named_operands() {
          vec!["<policy.limits.1>", "<policy.limits.0>", "<policy.key>"]),
     ] {
         let source = format!(
-            "struct Policy {{ pubkey key; int[2] limits; }} contract C(int unused, Policy unusedPolicy, {parameters}, int unusedTail) {{ function spend({inputs}) {{ {body} }} }}"
+            "import \"policy.ark\"; import \"child.ark\"; contract C(int unused, Policy unusedPolicy, {parameters}, int unusedTail) {{ function spend({inputs}) {{ {body} }} }}"
         );
         let actual = covenant(&source, "spend");
         let prologue = actual.asm.iter().take_while(|token| token.starts_with('<')).map(String::as_str).collect::<Vec<_>>();

--- a/tests/features/threshold_multisig.rs
+++ b/tests/features/threshold_multisig.rs
@@ -369,7 +369,7 @@ fn test_threshold_multisig_cli() {
     fs::write(&input_path, THRESHOLD_MULTISIG_CODE).unwrap();
 
     // Compile the contract using the library
-    let result = compile(THRESHOLD_MULTISIG_CODE);
+    let result = arkade_compiler::compile_file(&input_path);
     assert!(result.is_ok());
 
     // Run the CLI command


### PR DESCRIPTION
Imports currently record filenames without loading them, leaving shared structs and contract members unavailable and allowing undefined constructor targets. This PR resolves relative `.ark` imports, exposes declared structs and `Contract.constant` / `Contract.staticFunction(...)`, and validates constructor targets and signatures. Imported helpers are checked in their defining scope and reuse the existing constant folding and inlining passes; only the entry contract emits spend groups.

Files may contain structs and an optional contract, including contracts containing only static helpers and constants when imported. Dependencies load recursively, repeated paths are deduplicated, and missing files, cycles, conflicting declarations, and inaccessible members are errors. Imports are direct-only, names are unique across loaded files, and import depth is bounded at 128. No aliases, package resolution, remote imports, or library objects are added.

`compile_file(path)` serves the CLI and native callers; `compile_sources(entry, files)` serves in-memory and WASM projects. The playground compiles its Explorer files, displays source paths, and shares the selected contract's source bundle.

**Artifact migration:** `source` changes from a string to `{ entry, files }`. This is an intentional breaking schema change: regenerate old artifacts and upgrade compiler and consumers, including bindgen, together. Sources now retain comments that previous versions stripped, so source hashes and whole-artifact comparisons change even for identical logic. Regenerate comparison baselines and use the same compiler version for reproducibility checks. Loaded dependency warnings include paths relative to the bundle root.

**FujiSafe constructor migration:** the constructor expands from ten to twelve arguments. Append `bytes32 treasuryBurnScript` and `bytes32 borrowerBurnScript`, in that order, after `exit`. These replace undefined `P2TR(...)` placeholders with client-supplied burn-output witness programs constructed from the corresponding keys and asset commitment; renewal preserves both. Regenerate FujiSafe artifacts and bindings, and update construction and scriptPubKey verification code together. Old-layout `new FujiSafe(...)` calls are rejected at compile time; the old ABI cannot derive outputs for the updated contract.

Existing example imports now point to real files.

Validation:

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `./playground/build.sh`
- `node playground/imports.test.mjs` (15 Explorer entries, source round trips, shared projects, dependency edits)
- `./scripts/e2e.sh -v`

Focused regressions cover scope isolation, static-call stack isolation, dependency diamonds, visibility, constructor checks, constants in covenant/tapscript/built-in operands, and recompilation entirely from the artifact source bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-file contract compilation with relative imports, imported structs, constants, helpers, and contract functions.
  - Added file-based and in-memory compilation APIs, including WASM support.
  - Playground sharing now supports complete multi-file source bundles, project restoration, and size validation.
  - Artifacts preserve entry files and source bundles for reproducible recompilation.
  - Added import-aware language highlighting and completion support.

- **Bug Fixes**
  - Improved expression parsing, constant handling, validation, and static helper behavior.
  - Updated examples for corrected relative import paths and FujiSafe burn-script parameters.
  - Expanded coverage for imports, recursive loading, validation, and compilation round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->